### PR TITLE
[Wait for #3951][CausalLM] add quick.ai single-DLL ABI

### DIFF
--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -212,6 +212,24 @@ thinking mode by default and strips reasoning tags from the returned OpenAI
 `content` or `text` field. Pass `--enable-thinking` to keep the model's
 thinking template enabled.
 
+#### Single-DLL C ABI
+
+For in-process hosts that cannot run the REST server, build
+`nntrainer_causallm.dll` with the static-library and static CRT options:
+
+```powershell
+PS> meson setup build-causallm-abi -Dplatform=windows -Denable-transformer=true -Denable-test=false -Ddefault_library=static -Db_vscrt=mt
+PS> ninja -C build-causallm-abi nntrainer_causallm nntrainer_causallm_sample
+```
+
+The package contract is one `nntrainer_causallm.dll`, the public
+`Applications\CausalLM\capi\nntrainer_causallm.h` header, and a `model/`
+directory. The ABI uses `nntr_ctx_create`, `nntr_generate` streaming callbacks,
+`nntr_cancel`, and `nntr_ctx_free`; it does not require an executable, HTTP
+port, `PATH` edits, or runtime plugin DLL discovery. See
+`Applications\CausalLM\capi\README.md` and `MODEL_PACKAGE.md` for the ABI,
+threading contract, and model layout.
+
 ### 4. Android Build & Test
 
 The Android build process is modularized to support building the core library, API library, and test applications independently.

--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -81,21 +81,23 @@ To use chat templates, ensure `tokenizer_config.json` is in your model directory
 
 ### Multi-turn Conversations (API)
 
-The C API supports multi-turn conversations through `ChatMessage`:
+The chat template helper supports multi-turn conversations through JSON input:
 
 ```cpp
 #include "chat_template.h"
 
-causallm::ChatTemplate tmpl = causallm::ChatTemplate::fromFile("tokenizer_config.json");
+causallm::ChatTemplate tmpl = causallm::ChatTemplate::Load("/path/to/model");
 
-std::vector<causallm::ChatMessage> messages = {
-  {"system", "You are a helpful assistant."},
-  {"user", "Hello!"},
-  {"assistant", "Hi there!"},
-  {"user", "How are you?"}
+nlohmann::json input = {
+  {"messages",
+   {{{"role", "system"}, {"content", "You are a helpful assistant."}},
+    {{"role", "user"}, {"content", "Hello!"}},
+    {{"role", "assistant"}, {"content", "Hi there!"}},
+    {{"role", "user"}, {"content", "How are you?"}}}},
+  {"add_generation_prompt", true},
 };
 
-std::string formatted = tmpl.apply(messages);
+std::string formatted = tmpl.apply(input);
 ```
 
 ## How to run
@@ -184,6 +186,31 @@ PS> $env:PATH = (($dllDirs + @($build, "$build\Applications\CausalLM")) -join ";
 PS> $env:NNTR_NUM_THREADS = "4"
 PS> .\build-causallm-win\Applications\CausalLM\nntr_causallm.exe C:\path\to\model "Hello from Windows"
 ```
+
+#### OpenAI-compatible REST server
+
+CausalLM can also be built as a local OpenAI-compatible REST server:
+
+```powershell
+PS> ninja -C build-causallm-win nntr_causallm_openai_server
+PS> $build = Resolve-Path build-causallm-win
+PS> $dllDirs = Get-ChildItem $build -Filter *.dll -Recurse | ForEach-Object { Split-Path -Parent $_.FullName } | Sort-Object -Unique
+PS> $env:PATH = (($dllDirs + @($build, "$build\Applications\CausalLM")) -join ";") + ";" + $env:PATH
+PS> .\build-causallm-win\Applications\CausalLM\nntr_causallm_openai_server.exe C:\path\to\model --port 8000 --model qwen3-0.6b
+```
+
+Supported endpoints:
+
+- `GET /health`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `POST /v1/completions`
+
+Chat completions support OpenAI-style SSE streaming with `stream=true`.
+Streaming text completions are rejected for now. The server disables Qwen
+thinking mode by default and strips reasoning tags from the returned OpenAI
+`content` or `text` field. Pass `--enable-thinking` to keep the model's
+thinking template enabled.
 
 ### 4. Android Build & Test
 

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -13,7 +13,11 @@
 #define __CAUSAL_LM_API_H__
 
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/build_tokenizer_windows.ps1
+++ b/Applications/CausalLM/build_tokenizer_windows.ps1
@@ -7,7 +7,8 @@
 
 param (
     [string]$BuildDir = "build",
-    [string]$RustTarget = ""
+    [string]$RustTarget = "",
+    [switch]$StaticCrt
 )
 
 $ErrorActionPreference = "Stop"
@@ -61,25 +62,32 @@ Write-Output "  target: $TargetDir"
 $PreviousRustFlags = $env:RUSTFLAGS
 $PreviousCFlags = $env:CFLAGS
 $PreviousCxxFlags = $env:CXXFLAGS
-$DynamicCrtFlag = "-C target-feature=-crt-static"
+if ($StaticCrt) {
+    $CrtRustFlag = "-C target-feature=+crt-static"
+    $CrtCFlag = "/MT"
+} else {
+    $CrtRustFlag = "-C target-feature=-crt-static"
+    $CrtCFlag = "/MD"
+}
+$TokenizerCFlag = "$CrtCFlag /DONIG_STATIC"
 
 try {
     if ([string]::IsNullOrWhiteSpace($PreviousRustFlags)) {
-        $env:RUSTFLAGS = $DynamicCrtFlag
+        $env:RUSTFLAGS = $CrtRustFlag
     } else {
-        $env:RUSTFLAGS = "$PreviousRustFlags $DynamicCrtFlag"
+        $env:RUSTFLAGS = "$PreviousRustFlags $CrtRustFlag"
     }
 
     if ([string]::IsNullOrWhiteSpace($PreviousCFlags)) {
-        $env:CFLAGS = "/MD"
+        $env:CFLAGS = $TokenizerCFlag
     } else {
-        $env:CFLAGS = "$PreviousCFlags /MD"
+        $env:CFLAGS = "$PreviousCFlags $TokenizerCFlag"
     }
 
     if ([string]::IsNullOrWhiteSpace($PreviousCxxFlags)) {
-        $env:CXXFLAGS = "/MD"
+        $env:CXXFLAGS = $TokenizerCFlag
     } else {
-        $env:CXXFLAGS = "$PreviousCxxFlags /MD"
+        $env:CXXFLAGS = "$PreviousCxxFlags $TokenizerCFlag"
     }
 
     & cargo @CargoArgs

--- a/Applications/CausalLM/capi/MODEL_PACKAGE.md
+++ b/Applications/CausalLM/capi/MODEL_PACKAGE.md
@@ -1,0 +1,44 @@
+# quick.ai Model Package
+
+The single-DLL C ABI loads one model directory passed to
+`quick_ai_ctx_create(model_dir_utf8, ...)`. The runtime must not rely on the current
+working directory, `PATH`, or environment variables for model discovery.
+
+Required files:
+
+- `config.json`: HuggingFace-style model architecture metadata.
+- `generation_config.json`: generation defaults such as EOS/BOS tokens,
+  temperature, top-k/top-p, and `do_sample`.
+- `nntr_config.json`: NNTrainer runtime settings. `model_file_name` and
+  `tokenizer_file` may be relative to the model directory or absolute paths.
+- `tokenizer.json`: tokenizer data referenced by `nntr_config.json`.
+- `tokenizer_config.json`: optional chat template; when present, chat messages
+  are formatted through the template.
+- `*.bin` or `*.safetensors`: NNTrainer model weights referenced by
+  `nntr_config.json`.
+
+To replace the model, place the replacement files in a new directory, update
+`nntr_config.json` so `model_file_name` and `tokenizer_file` point to files in
+that directory, then pass the new absolute directory path to
+`quick_ai_ctx_create()`.
+
+For CausalLM packages, the static graph length is fixed by
+`nntr_config.json`. `max_seq_len` is the hard prompt-plus-generation context
+window, `init_seq_len` is the maximum prefill input shape, and
+`num_to_generate` is the package's maximum generation budget. The ABI rejects
+requests whose tokenized prompt cannot fit with the requested `max_tokens`.
+
+The tested Windows package shape is:
+
+```text
+package/
+  quick_ai.dll
+  quick_ai.h
+  model/
+    config.json
+    generation_config.json
+    nntr_config.json
+    tokenizer.json
+    tokenizer_config.json
+    nntr_qwen3_0.6b_full_q40.bin
+```

--- a/Applications/CausalLM/capi/README.md
+++ b/Applications/CausalLM/capi/README.md
@@ -1,0 +1,77 @@
+# quick.ai C ABI
+
+This directory contains the in-process C ABI for packaging CausalLM as one
+runtime DLL: `quick_ai.dll`.
+
+## ABI
+
+The public header is `quick_ai.h`. It exposes only C basic types, an
+opaque `quick_ai_ctx *`, UTF-8 `const char *`, and callback function pointers.
+All ABI functions are `noexcept` on C++ builds. Failures return a negative
+`quick_ai_status`; call `quick_ai_last_error(ctx)` for the UTF-8 diagnostic.
+
+`quick_ai_generate()` accepts one OpenAI chat-completions compatible JSON request:
+`model`, `messages`, `temperature`, `top_p`, `top_k`, `max_tokens`, `stop`, and
+`stream`. The ABI always streams through `quick_ai_token_cb`; `stream` is accepted
+for compatibility. Unsupported OpenAI fields such as `frequency_penalty`,
+`presence_penalty`, `logit_bias`, `seed`, and `logprobs` are ignored.
+
+`quick_ai_embed()` accepts one OpenAI embeddings compatible JSON request:
+`{"model":"...","input":"text"}`. `input` may also be an array containing
+exactly one string; larger batches are rejected by this bounded ABI. On success,
+`out_count` is `1`, and `out_embedding` points to `out_dim` contiguous `float`
+values allocated inside the DLL. Release that buffer with `quick_ai_free()`.
+
+`quick_ai_model_info()` returns JSON with the package id, path, architecture,
+model type/kind when inferable, and model dimensions: `max_seq_len`,
+`init_seq_len`, `num_to_generate`, `batch_size`, and `hidden_dim`.
+
+`quick_ai_get_performance_metrics()` copies the current context metrics into
+`quick_ai_performance_metrics`. These values describe the last generation run.
+Measure embedding latency around `quick_ai_embed()` on the host side.
+
+## Threading
+
+Set inference threads with `quick_ai_init_options.num_threads`. Do not use
+`NNTR_NUM_THREADS` or other environment variables for this ABI. A single
+`quick_ai_ctx` serializes `quick_ai_generate()` and `quick_ai_embed()` calls; create
+separate contexts for independent model instances. `quick_ai_cancel()` may be called
+from another thread while generation is running.
+
+## Windows Build
+
+Use a static-library build and static MSVC CRT when producing the required
+single DLL:
+
+```powershell
+meson setup build-causallm-abi `
+  -Dplatform=windows `
+  -Denable-transformer=true `
+  -Denable-causallm-single-dll-abi=true `
+  -Denable-test=false `
+  -Ddefault_library=static `
+  -Db_vscrt=mt
+ninja -C build-causallm-abi quick_ai quick_ai_sample
+```
+
+Verify that the DLL does not depend on nntrainer plugin DLLs, third-party DLLs,
+or MSVC runtime DLLs:
+
+```powershell
+dumpbin /dependents build-causallm-abi\Applications\CausalLM\quick_ai.dll
+```
+
+Only Windows system DLLs should be listed.
+
+## Smoke Test
+
+The sample dynamically loads the DLL without modifying `PATH`:
+
+```powershell
+build-causallm-abi\Applications\CausalLM\quick_ai_sample.exe `
+  build-causallm-abi\Applications\CausalLM\quick_ai.dll `
+  C:\nntr_weights\qwen3-0.6b-full-q40 `
+  "Write one short sentence about local inference."
+```
+
+See `MODEL_PACKAGE.md` for the required model directory layout.

--- a/Applications/CausalLM/capi/quick_ai.cpp
+++ b/Applications/CausalLM/capi/quick_ai.cpp
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   quick_ai.cpp
+ * @date   28 May 2026
+ * @brief  C ABI wrapper for quick.ai inference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#define QUICK_AI_BUILD
+#include "quick_ai.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "causal_lm.h"
+#include "chat_template.h"
+#include "deberta_v2.h"
+#include "embedding_gemma.h"
+#include "factory.h"
+#include "gemma3_causallm.h"
+#if !defined(_WIN32)
+#include "gptoss_cached_slim_causallm.h"
+#endif
+#include "gptoss_causallm.h"
+#include "json.hpp"
+#if !defined(_WIN32) && !defined(__ANDROID__)
+#include "multilingual_tinybert_16mb.h"
+#endif
+#include "openai_protocol.h"
+#include "qwen2_causallm.h"
+#include "qwen2_embedding.h"
+#if !defined(_WIN32)
+#include "qwen3_cached_slim_moe_causallm.h"
+#endif
+#include "qwen3_causallm.h"
+#include "qwen3_embedding.h"
+#include "qwen3_moe_causallm.h"
+#include "qwen3_slim_moe_causallm.h"
+#include "sentence_transformer.h"
+#include "thread_manager.h"
+#include "timm_vit/timm_vit_transformer.h"
+
+#if defined(USE_BLAS) && __has_include("cblas_interface.h")
+#include "cblas_interface.h"
+#define QUICK_AI_HAS_CBLAS_INTERFACE 1
+#else
+#define QUICK_AI_HAS_CBLAS_INTERFACE 0
+#endif
+
+using json = nlohmann::json;
+
+namespace {
+
+std::mutex g_log_mutex;
+quick_ai_log_cb g_log_cb = nullptr;
+void *g_log_user_data = nullptr;
+int g_log_level = 0;
+thread_local std::string g_thread_last_error;
+
+void setThreadError(const std::string &message) {
+  g_thread_last_error = message;
+}
+
+void logMessage(int level, const std::string &message) {
+  std::lock_guard<std::mutex> lock(g_log_mutex);
+  if (g_log_cb && level >= g_log_level) {
+    try {
+      g_log_cb(level, message.c_str(), g_log_user_data);
+    } catch (...) {
+    }
+  }
+}
+
+void registerModels() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    auto &factory = causallm::Factory::Instance();
+    factory.registerModel("LlamaForCausalLM",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::CausalLM>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("Qwen2ForCausalLM",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Qwen2CausalLM>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("Qwen2Embedding",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Qwen2Embedding>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("Qwen3ForCausalLM",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Qwen3CausalLM>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("Qwen3MoeForCausalLM",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Qwen3MoECausalLM>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel(
+      "Qwen3SlimMoeForCausalLM",
+      [](json cfg, json generation_cfg, json nntr_cfg) {
+        return std::make_unique<causallm::Qwen3SlimMoECausalLM>(
+          cfg, generation_cfg, nntr_cfg);
+      });
+#if !defined(_WIN32)
+    factory.registerModel(
+      "Qwen3CachedSlimMoeForCausalLM",
+      [](json cfg, json generation_cfg, json nntr_cfg) {
+        return std::make_unique<causallm::Qwen3CachedSlimMoECausalLM>(
+          cfg, generation_cfg, nntr_cfg);
+      });
+#endif
+    factory.registerModel("Qwen3Embedding",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Qwen3Embedding>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("GptOssForCausalLM", [](json cfg, json generation_cfg,
+                                                  json nntr_cfg) {
+      return std::make_unique<causallm::GptOssForCausalLM>(cfg, generation_cfg,
+                                                           nntr_cfg);
+    });
+#if !defined(_WIN32)
+    factory.registerModel(
+      "GptOssCachedSlimCausalLM",
+      [](json cfg, json generation_cfg, json nntr_cfg) {
+        return std::make_unique<causallm::GptOssCachedSlimCausalLM>(
+          cfg, generation_cfg, nntr_cfg);
+      });
+#endif
+    factory.registerModel("Gemma3ForCausalLM",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::Gemma3CausalLM>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("EmbeddingGemma",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::EmbeddingGemma>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+    factory.registerModel("DebertaV2",
+                          [](json cfg, json generation_cfg, json nntr_cfg) {
+                            return std::make_unique<causallm::DebertaV2>(
+                              cfg, generation_cfg, nntr_cfg);
+                          });
+#if !defined(_WIN32) && !defined(__ANDROID__)
+    factory.registerModel(
+      "MultilingualTinyBert", [](json cfg, json generation_cfg, json nntr_cfg) {
+        return std::make_unique<causallm::MultilingualTinyBert>(
+          cfg, generation_cfg, nntr_cfg);
+      });
+#endif
+    factory.registerModel("TimmViT", [](json cfg, json generation_cfg,
+                                        json nntr_cfg) {
+      return std::make_unique<causallm::TimmViTTransformer>(cfg, generation_cfg,
+                                                            nntr_cfg);
+    });
+  });
+}
+
+std::string resolveArchitecture(std::string model_type,
+                                const std::string &architecture) {
+  std::transform(
+    model_type.begin(), model_type.end(), model_type.begin(),
+    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+  if (model_type == "embedding") {
+    if (architecture == "Qwen3ForCausalLM")
+      return "Qwen3Embedding";
+    if (architecture == "Gemma3ForCausalLM" ||
+        architecture == "Gemma3TextModel")
+      return "EmbeddingGemma";
+    if (architecture == "Qwen2Model")
+      return "Qwen2Embedding";
+    if (architecture == "BertForMaskedLM")
+      return "MultilingualTinyBert";
+    if (architecture == "TimmViT" ||
+        architecture == "vit_base_patch16_siglip_224")
+      return "TimmViT";
+    if (architecture == "deberta-v2" || architecture == "DebertaV2Model" ||
+        architecture == "DebertaV2ForMaskedLM")
+      return "DebertaV2";
+    throw std::invalid_argument("Unsupported embedding architecture: " +
+                                architecture);
+  }
+
+  if (architecture == "TimmViT" ||
+      architecture == "vit_base_patch16_siglip_224")
+    return "TimmViT";
+
+  return architecture;
+}
+
+std::string absoluteModelFile(const std::filesystem::path &model_dir,
+                              const std::string &path) {
+  const std::filesystem::path file(path);
+  return file.is_absolute()
+           ? file.string()
+           : std::filesystem::absolute(model_dir / file).string();
+}
+
+std::string
+fallbackPrompt(const std::vector<causallm::openai::ChatMessage> &messages) {
+  std::ostringstream prompt;
+  for (const auto &message : messages)
+    prompt << message.role << ": " << message.content << '\n';
+  prompt << "assistant: ";
+  return prompt.str();
+}
+
+json withChatTemplateOptions(const json &chat_input, bool enable_thinking) {
+  json request = chat_input;
+  if (!request.contains("add_generation_prompt"))
+    request["add_generation_prompt"] = true;
+  request["enable_thinking"] = enable_thinking;
+  return request;
+}
+
+causallm::GenerationOverrides
+toGenerationOverrides(const causallm::openai::GenerationOptions &options) {
+  causallm::GenerationOverrides overrides;
+  overrides.temperature = options.temperature;
+  overrides.top_p = options.top_p;
+  overrides.top_k = options.top_k;
+  overrides.max_tokens = options.max_tokens;
+  return overrides;
+}
+
+bool requestDoSample(bool default_do_sample,
+                     const causallm::openai::GenerationOptions &options) {
+  if (options.temperature.has_value())
+    return *options.temperature > 0.0F;
+  if (options.top_p.has_value() || options.top_k.has_value())
+    return true;
+  return default_do_sample;
+}
+
+std::string modelKindFromArchitecture(const std::string &architecture) {
+  if (architecture.find("Embedding") != std::string::npos ||
+      architecture == "EmbeddingGemma" ||
+      architecture == "MultilingualTinyBert" || architecture == "DebertaV2")
+    return "embedding";
+  if (architecture.find("CausalLM") != std::string::npos ||
+      architecture.find("GptOss") != std::string::npos ||
+      architecture.find("Llama") != std::string::npos ||
+      architecture.find("Qwen") != std::string::npos)
+    return "causallm";
+  return "model";
+}
+
+std::string parseEmbeddingInput(const json &payload) {
+  if (!payload.contains("input"))
+    throw std::invalid_argument("embedding request must contain input");
+
+  const auto &input = payload["input"];
+  if (input.is_string())
+    return input.get<std::string>();
+
+  if (input.is_array()) {
+    if (input.size() != 1 || !input[0].is_string()) {
+      throw std::invalid_argument(
+        "embedding input array must contain exactly one string");
+    }
+    return input[0].get<std::string>();
+  }
+
+  throw std::invalid_argument("embedding input must be a string or one-string "
+                              "array");
+}
+
+std::string canonicalModelKind(std::string model_type,
+                               const std::string &architecture) {
+  std::transform(
+    model_type.begin(), model_type.end(), model_type.begin(),
+    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+  if (model_type == "embedding")
+    return "embedding";
+  if (model_type == "causallm" || model_type == "causal_lm")
+    return "causallm";
+  return modelKindFromArchitecture(architecture);
+}
+
+/**
+ * @brief Scope guard that clears per-run generation callbacks and overrides.
+ */
+class CausalRunGuard {
+public:
+  explicit CausalRunGuard(causallm::CausalLM *model) : model_(model) {}
+  CausalRunGuard(const CausalRunGuard &) = delete;
+  CausalRunGuard &operator=(const CausalRunGuard &) = delete;
+  ~CausalRunGuard() {
+    if (!model_)
+      return;
+    model_->clearOnToken();
+    model_->clearGenerationOverrides();
+  }
+
+private:
+  causallm::CausalLM *model_;
+};
+
+quick_ai_status copyJsonToBuffer(const json &info, char *out_buf,
+                                 int out_buf_len) {
+  if (!out_buf || out_buf_len <= 0)
+    return QUICK_AI_STATUS_INVALID_ARGUMENT;
+
+  const std::string text = info.dump();
+  if (static_cast<size_t>(out_buf_len) <= text.size()) {
+    if (out_buf_len > 0)
+      out_buf[0] = '\0';
+    return QUICK_AI_STATUS_BUFFER_TOO_SMALL;
+  }
+
+  std::memcpy(out_buf, text.c_str(), text.size() + 1);
+  return QUICK_AI_STATUS_OK;
+}
+
+} // namespace
+
+/**
+ * @brief Internal quick.ai context backing the public opaque C handle.
+ */
+struct quick_ai_ctx {
+  std::string model_id;
+  std::string model_path;
+  std::string architecture;
+  std::string model_kind;
+  unsigned int ctx_len = 0;
+  std::string system_head_prompt;
+  std::string system_tail_prompt;
+  bool do_sample = false;
+  bool enable_thinking = false;
+  double initialization_duration_ms = 0.0;
+  std::optional<causallm::ChatTemplate> chat_template;
+  std::unique_ptr<causallm::Transformer> model;
+  std::mutex mutex;
+  std::mutex error_mutex;
+  std::atomic<bool> cancel_requested{false};
+  std::string last_error;
+
+  void setError(const std::string &message) {
+    {
+      std::lock_guard<std::mutex> lock(error_mutex);
+      last_error = message;
+    }
+    setThreadError(message);
+    logMessage(1, message);
+  }
+};
+
+namespace {
+
+std::unique_ptr<quick_ai_ctx> loadContext(const std::string &model_path,
+                                          const quick_ai_init_options *opts) {
+  registerModels();
+
+  const int requested_threads =
+    opts && opts->num_threads > 0 ? opts->num_threads : 1;
+  nntrainer::ThreadManagerConfig thread_config{
+    static_cast<uint32_t>(requested_threads), true};
+  nntrainer::ThreadManager::setConfig(thread_config);
+
+#if QUICK_AI_HAS_CBLAS_INTERFACE
+  nntrainer::__openblas_set_num_threads(requested_threads);
+#else
+  if (opts && opts->num_threads > 0)
+    logMessage(2, "num_threads requested but cblas_interface.h is unavailable");
+#endif
+
+  auto ctx = std::make_unique<quick_ai_ctx>();
+  ctx->model_path = std::filesystem::absolute(model_path).string();
+  ctx->model_id = std::filesystem::path(ctx->model_path).filename().string();
+  ctx->enable_thinking = opts && opts->enable_thinking != 0;
+
+  const std::filesystem::path model_dir(ctx->model_path);
+  json cfg = causallm::LoadJsonFile((model_dir / "config.json").string());
+  json generation_cfg = json::object();
+  if (std::filesystem::exists(model_dir / "generation_config.json"))
+    generation_cfg =
+      causallm::LoadJsonFile((model_dir / "generation_config.json").string());
+  json nntr_cfg =
+    causallm::LoadJsonFile((model_dir / "nntr_config.json").string());
+  ctx->ctx_len = nntr_cfg.value("max_seq_len", 0U);
+
+  if (nntr_cfg.contains("tokenizer_file") &&
+      nntr_cfg["tokenizer_file"].is_string()) {
+    nntr_cfg["tokenizer_file"] =
+      absoluteModelFile(model_dir, nntr_cfg["tokenizer_file"]);
+  }
+  if (nntr_cfg.contains("model_file_name") &&
+      nntr_cfg["model_file_name"].is_string()) {
+    nntr_cfg["model_file_name"] =
+      absoluteModelFile(model_dir, nntr_cfg["model_file_name"]);
+  }
+  if (nntr_cfg.contains("module_config_path") &&
+      nntr_cfg["module_config_path"].is_string()) {
+    nntr_cfg["module_config_path"] =
+      absoluteModelFile(model_dir, nntr_cfg["module_config_path"]);
+  }
+
+  if (nntr_cfg.contains("system_prompt")) {
+    ctx->system_head_prompt =
+      nntr_cfg["system_prompt"].value("head_prompt", "");
+    ctx->system_tail_prompt =
+      nntr_cfg["system_prompt"].value("tail_prompt", "");
+  }
+
+  std::string architecture;
+  if (cfg.contains("architectures") && cfg["architectures"].is_array() &&
+      !cfg["architectures"].empty()) {
+    architecture = cfg["architectures"].get<std::vector<std::string>>()[0];
+  } else if (cfg.contains("architecture") && cfg["architecture"].is_string()) {
+    architecture = cfg["architecture"].get<std::string>();
+  } else if (cfg.contains("model_type") && cfg["model_type"].is_string()) {
+    architecture = cfg["model_type"].get<std::string>();
+  } else {
+    throw std::invalid_argument(
+      "config.json must contain architecture metadata");
+  }
+
+  if (nntr_cfg.contains("model_type") && nntr_cfg["model_type"].is_string())
+    architecture = resolveArchitecture(
+      nntr_cfg["model_type"].get<std::string>(), architecture);
+  ctx->architecture = architecture;
+  ctx->model_kind = canonicalModelKind(
+    nntr_cfg.value("model_type", std::string()), architecture);
+
+  if (causallm::ChatTemplate::Exists(model_dir.string()))
+    ctx->chat_template.emplace(
+      causallm::ChatTemplate::Load(model_dir.string()));
+
+  ctx->model = causallm::Factory::Instance().create(architecture, cfg,
+                                                    generation_cfg, nntr_cfg);
+  if (!ctx->model) {
+    std::ostringstream os;
+    os << "Unknown architecture: " << architecture
+       << ". Registered architectures:";
+    causallm::Factory::Instance().printRegistered(os);
+    throw std::runtime_error(os.str());
+  }
+
+  const std::string weight_file =
+    nntr_cfg.at("model_file_name").get<std::string>();
+  const auto start_initialize = std::chrono::high_resolution_clock::now();
+  ctx->model->initialize();
+  ctx->model->load_weight(weight_file);
+  const auto finish_initialize = std::chrono::high_resolution_clock::now();
+  ctx->initialization_duration_ms = std::chrono::duration<double, std::milli>(
+                                      finish_initialize - start_initialize)
+                                      .count();
+  ctx->do_sample = generation_cfg.value("do_sample", false);
+  return ctx;
+}
+
+} // namespace
+
+quick_ai_status quick_ai_ctx_create(const char *model_dir_utf8,
+                                    const quick_ai_init_options *opts,
+                                    quick_ai_ctx **out_ctx) noexcept {
+  try {
+    if (!model_dir_utf8 || !out_ctx) {
+      setThreadError("model_dir_utf8 and out_ctx must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+
+    *out_ctx = nullptr;
+    auto ctx = loadContext(model_dir_utf8, opts);
+    *out_ctx = ctx.release();
+    return QUICK_AI_STATUS_OK;
+  } catch (const std::exception &e) {
+    setThreadError(e.what());
+    logMessage(1, e.what());
+    return QUICK_AI_STATUS_MODEL_LOAD_FAILED;
+  } catch (...) {
+    setThreadError("unknown error while creating quick.ai context");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+void quick_ai_ctx_free(quick_ai_ctx *ctx) noexcept {
+  try {
+    delete ctx;
+  } catch (...) {
+  }
+}
+
+quick_ai_status quick_ai_model_info(quick_ai_ctx *ctx, char *out_buf,
+                                    int out_buf_len) noexcept {
+  try {
+    if (!ctx) {
+      setThreadError("ctx must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+
+    std::lock_guard<std::mutex> lock(ctx->mutex);
+    json info = {
+      {"id", ctx->model_id},
+      {"model_path", ctx->model_path},
+      {"architecture", ctx->architecture},
+      {"model_type", ctx->model_kind},
+      {"kind", ctx->model_kind},
+      {"max_seq_len", ctx->model ? ctx->model->getMaxSeqLen() : 0},
+      {"init_seq_len", ctx->model ? ctx->model->getInitSeqLen() : 0},
+      {"num_to_generate", ctx->model ? ctx->model->getNumToGenerate() : 0},
+      {"batch_size", ctx->model ? ctx->model->getBatchSize() : 0},
+      {"hidden_dim", ctx->model ? ctx->model->getHiddenDim() : 0},
+      {"ctx_len", ctx->ctx_len}};
+    const quick_ai_status status = copyJsonToBuffer(info, out_buf, out_buf_len);
+    if (status != QUICK_AI_STATUS_OK)
+      ctx->setError("model info output buffer is too small");
+    return status;
+  } catch (const std::exception &e) {
+    ctx->setError(e.what());
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  } catch (...) {
+    ctx->setError("unknown error while reading model info");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+quick_ai_status quick_ai_generate(quick_ai_ctx *ctx,
+                                  const char *request_json_utf8,
+                                  quick_ai_token_cb on_token, void *user_data,
+                                  quick_ai_usage *usage_out) noexcept {
+  try {
+    if (!ctx || !request_json_utf8) {
+      setThreadError("ctx and request_json_utf8 must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+    if (usage_out) {
+      usage_out->prompt_tokens = 0;
+      usage_out->completion_tokens = 0;
+    }
+
+    std::lock_guard<std::mutex> lock(ctx->mutex);
+    ctx->cancel_requested.store(false);
+
+    const json payload = json::parse(request_json_utf8);
+    const auto parsed = causallm::openai::parseChatCompletionRequest(payload);
+
+    const std::string prompt =
+      ctx->chat_template.has_value()
+        ? ctx->chat_template->apply(
+            withChatTemplateOptions(parsed.chat_input, ctx->enable_thinking))
+        : fallbackPrompt(parsed.messages);
+
+    auto *causal_model = dynamic_cast<causallm::CausalLM *>(ctx->model.get());
+    if (!causal_model) {
+      ctx->setError("loaded model does not support chat generation");
+      return QUICK_AI_STATUS_GENERATION_FAILED;
+    }
+
+    CausalRunGuard run_guard(causal_model);
+    causallm::openai::StreamingTextFilter filter(parsed.options.stop,
+                                                 ctx->enable_thinking);
+    bool callback_cancelled = false;
+    bool stop_requested = false;
+
+    causal_model->resetGenerationState();
+    causal_model->setGenerationOverrides(toGenerationOverrides(parsed.options));
+    causal_model->setOnToken([&](const std::string &piece) {
+      if (ctx->cancel_requested.load())
+        return false;
+
+      auto result = filter.push(piece);
+      if (!result.text.empty() && on_token) {
+        const int cb_status = on_token(result.text.c_str(), user_data);
+        if (cb_status != 0) {
+          callback_cancelled = true;
+          return false;
+        }
+      }
+
+      stop_requested = stop_requested || result.stop;
+      return !stop_requested && !ctx->cancel_requested.load();
+    });
+
+    ctx->model->run(prompt, requestDoSample(ctx->do_sample, parsed.options),
+                    ctx->system_head_prompt, ctx->system_tail_prompt, false);
+
+    if (!callback_cancelled && !ctx->cancel_requested.load() &&
+        !stop_requested) {
+      const std::string tail = filter.flush();
+      if (!tail.empty() && on_token && on_token(tail.c_str(), user_data) != 0)
+        callback_cancelled = true;
+    }
+
+    const auto metrics = ctx->model->getPerformanceMetrics();
+    if (usage_out) {
+      usage_out->prompt_tokens = metrics.prefill_tokens;
+      usage_out->completion_tokens = metrics.generation_tokens;
+    }
+
+    if (callback_cancelled || ctx->cancel_requested.load()) {
+      ctx->setError("generation cancelled");
+      return QUICK_AI_STATUS_CANCELLED;
+    }
+
+    return QUICK_AI_STATUS_OK;
+  } catch (const std::exception &e) {
+    if (ctx)
+      ctx->setError(e.what());
+    else
+      setThreadError(e.what());
+    return QUICK_AI_STATUS_GENERATION_FAILED;
+  } catch (...) {
+    if (ctx)
+      ctx->setError("unknown error while generating text");
+    else
+      setThreadError("unknown error while generating text");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+quick_ai_status quick_ai_embed(quick_ai_ctx *ctx, const char *request_json_utf8,
+                               float **out_embedding, int *out_count,
+                               int *out_dim) noexcept {
+  try {
+    if (!ctx || !request_json_utf8 || !out_embedding || !out_count ||
+        !out_dim) {
+      setThreadError("ctx, request_json_utf8, out_embedding, out_count, and "
+                     "out_dim must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+
+    *out_embedding = nullptr;
+    *out_count = 0;
+    *out_dim = 0;
+
+    std::lock_guard<std::mutex> lock(ctx->mutex);
+
+    auto *embedding_model =
+      dynamic_cast<causallm::SentenceTransformer *>(ctx->model.get());
+    if (!embedding_model) {
+      ctx->setError("loaded model does not support embedding");
+      return QUICK_AI_STATUS_GENERATION_FAILED;
+    }
+
+    const json payload = json::parse(request_json_utf8);
+    const std::string input = parseEmbeddingInput(payload);
+    const unsigned int count = 1;
+    const int dim = ctx->model->getHiddenDim();
+    if (dim <= 0) {
+      ctx->setError("embedding model reported invalid output dimensions");
+      return QUICK_AI_STATUS_INTERNAL_ERROR;
+    }
+
+    std::vector<float *> results = embedding_model->encode(
+      input, ctx->system_head_prompt, ctx->system_tail_prompt);
+    if (results.empty() || !results[0]) {
+      ctx->setError("embedding model returned no output");
+      return QUICK_AI_STATUS_GENERATION_FAILED;
+    }
+
+    const size_t total = static_cast<size_t>(dim);
+    float *embedding = static_cast<float *>(std::malloc(total * sizeof(float)));
+    if (!embedding) {
+      for (auto *out : results)
+        delete[] out;
+      ctx->setError("failed to allocate embedding output buffer");
+      return QUICK_AI_STATUS_INTERNAL_ERROR;
+    }
+
+    std::memcpy(embedding, results[0], total * sizeof(float));
+    for (auto *out : results)
+      delete[] out;
+
+    *out_embedding = embedding;
+    *out_count = 1;
+    *out_dim = dim;
+    return QUICK_AI_STATUS_OK;
+  } catch (const std::exception &e) {
+    if (ctx)
+      ctx->setError(e.what());
+    else
+      setThreadError(e.what());
+    return QUICK_AI_STATUS_GENERATION_FAILED;
+  } catch (...) {
+    if (ctx)
+      ctx->setError("unknown error while creating embedding");
+    else
+      setThreadError("unknown error while creating embedding");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+void quick_ai_free(void *ptr) noexcept {
+  try {
+    std::free(ptr);
+  } catch (...) {
+  }
+}
+
+quick_ai_status quick_ai_get_performance_metrics(
+  quick_ai_ctx *ctx, quick_ai_performance_metrics *metrics) noexcept {
+  try {
+    if (!ctx || !metrics) {
+      setThreadError("ctx and metrics must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+
+    std::lock_guard<std::mutex> lock(ctx->mutex);
+    const auto internal_metrics = ctx->model->getPerformanceMetrics();
+    metrics->prefill_tokens = internal_metrics.prefill_tokens;
+    metrics->prefill_duration_ms = internal_metrics.prefill_duration_ms;
+    metrics->generation_tokens = internal_metrics.generation_tokens;
+    metrics->generation_duration_ms = internal_metrics.generation_duration_ms;
+    metrics->total_duration_ms = internal_metrics.total_duration_ms;
+    metrics->initialization_duration_ms = ctx->initialization_duration_ms;
+    metrics->peak_memory_kb =
+      static_cast<unsigned long long>(internal_metrics.peak_memory_kb);
+    return QUICK_AI_STATUS_OK;
+  } catch (const std::exception &e) {
+    if (ctx)
+      ctx->setError(e.what());
+    else
+      setThreadError(e.what());
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  } catch (...) {
+    if (ctx)
+      ctx->setError("unknown error while reading performance metrics");
+    else
+      setThreadError("unknown error while reading performance metrics");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+quick_ai_status quick_ai_cancel(quick_ai_ctx *ctx) noexcept {
+  try {
+    if (!ctx) {
+      setThreadError("ctx must be non-null");
+      return QUICK_AI_STATUS_INVALID_ARGUMENT;
+    }
+    ctx->cancel_requested.store(true);
+    return QUICK_AI_STATUS_OK;
+  } catch (...) {
+    setThreadError("unknown error while cancelling generation");
+    return QUICK_AI_STATUS_INTERNAL_ERROR;
+  }
+}
+
+const char *quick_ai_version(void) noexcept {
+  return "quick.ai/" QUICK_AI_ABI_VERSION;
+}
+
+const char *quick_ai_last_error(quick_ai_ctx *ctx) noexcept {
+  if (ctx) {
+    std::lock_guard<std::mutex> lock(ctx->error_mutex);
+    g_thread_last_error = ctx->last_error;
+    return g_thread_last_error.c_str();
+  }
+  return g_thread_last_error.c_str();
+}
+
+void quick_ai_set_log_callback(quick_ai_log_cb cb, void *user_data,
+                               int level) noexcept {
+  try {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    g_log_cb = cb;
+    g_log_user_data = user_data;
+    g_log_level = level;
+  } catch (...) {
+  }
+}

--- a/Applications/CausalLM/capi/quick_ai.h
+++ b/Applications/CausalLM/capi/quick_ai.h
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   quick_ai.h
+ * @date   28 May 2026
+ * @brief  Public C ABI for quick.ai single-DLL inference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef QUICK_AI_H_
+#define QUICK_AI_H_
+
+#ifdef _WIN32
+#ifdef QUICK_AI_BUILD
+#define QUICK_AI_API __declspec(dllexport)
+#else
+#define QUICK_AI_API __declspec(dllimport)
+#endif
+#else
+#define QUICK_AI_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+#define QUICK_AI_NOEXCEPT noexcept
+#else
+#define QUICK_AI_NOEXCEPT
+#endif
+
+#define QUICK_AI_ABI_VERSION_MAJOR 0
+#define QUICK_AI_ABI_VERSION_MINOR 2
+#define QUICK_AI_ABI_VERSION_PATCH 0
+#define QUICK_AI_ABI_VERSION "0.2.0"
+
+#define QUICK_AI_STATUS_OK 0
+#define QUICK_AI_STATUS_INVALID_ARGUMENT -1
+#define QUICK_AI_STATUS_MODEL_LOAD_FAILED -2
+#define QUICK_AI_STATUS_GENERATION_FAILED -3
+#define QUICK_AI_STATUS_CANCELLED -4
+#define QUICK_AI_STATUS_BUFFER_TOO_SMALL -5
+#define QUICK_AI_STATUS_INTERNAL_ERROR -6
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque CausalLM inference context.
+ */
+typedef struct quick_ai_ctx quick_ai_ctx;
+
+/**
+ * @brief ABI status code. Zero is success; negative values are errors.
+ */
+typedef int quick_ai_status;
+
+/**
+ * @brief Context creation options.
+ */
+typedef struct {
+  int num_threads;     /**< Inference thread count; <=0 selects ABI default */
+  int enable_thinking; /**< Non-zero forwards model thinking text */
+} quick_ai_init_options;
+
+/**
+ * @brief Token usage populated after generation.
+ */
+typedef struct {
+  unsigned long long prompt_tokens;
+  unsigned long long completion_tokens;
+} quick_ai_usage;
+
+/**
+ * @brief Performance metrics populated by the last model run.
+ */
+typedef struct {
+  unsigned int prefill_tokens;
+  double prefill_duration_ms;
+  unsigned int generation_tokens;
+  double generation_duration_ms;
+  double total_duration_ms;
+  double initialization_duration_ms;
+  unsigned long long peak_memory_kb;
+} quick_ai_performance_metrics;
+
+/**
+ * @brief Streaming token callback.
+ * @return 0 to continue, non-zero to request cancellation.
+ */
+typedef int (*quick_ai_token_cb)(const char *utf8_delta, void *user_data);
+
+/**
+ * @brief Log callback.
+ */
+typedef void (*quick_ai_log_cb)(int level, const char *utf8_msg,
+                                void *user_data);
+
+/**
+ * @brief Create a context from a model directory.
+ */
+QUICK_AI_API quick_ai_status quick_ai_ctx_create(
+  const char *model_dir_utf8, const quick_ai_init_options *opts,
+  quick_ai_ctx **out_ctx) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Free a context. Passing NULL is allowed.
+ */
+QUICK_AI_API void quick_ai_ctx_free(quick_ai_ctx *ctx) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Write model info JSON into out_buf.
+ */
+QUICK_AI_API quick_ai_status quick_ai_model_info(
+  quick_ai_ctx *ctx, char *out_buf, int out_buf_len) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Generate from an OpenAI chat-completions compatible JSON request.
+ */
+QUICK_AI_API quick_ai_status quick_ai_generate(
+  quick_ai_ctx *ctx, const char *request_json_utf8, quick_ai_token_cb on_token,
+  void *user_data, quick_ai_usage *usage_out) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Encode one OpenAI-compatible embeddings request.
+ *
+ * The returned embedding buffer is allocated by the ABI and must be released
+ * with quick_ai_free().
+ */
+QUICK_AI_API quick_ai_status quick_ai_embed(quick_ai_ctx *ctx,
+                                            const char *request_json_utf8,
+                                            float **out_embedding,
+                                            int *out_count,
+                                            int *out_dim) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Free memory returned by this ABI. Passing NULL is allowed.
+ */
+QUICK_AI_API void quick_ai_free(void *ptr) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Read performance metrics from the context after a model run.
+ */
+QUICK_AI_API quick_ai_status quick_ai_get_performance_metrics(
+  quick_ai_ctx *ctx, quick_ai_performance_metrics *metrics) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Request cancellation from another thread.
+ */
+QUICK_AI_API quick_ai_status quick_ai_cancel(quick_ai_ctx *ctx)
+  QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Return library and ABI version text.
+ */
+QUICK_AI_API const char *quick_ai_version(void) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Return the last error for ctx, or thread-local create error if NULL.
+ */
+QUICK_AI_API const char *
+quick_ai_last_error(quick_ai_ctx *ctx) QUICK_AI_NOEXCEPT;
+
+/**
+ * @brief Set a process-wide log callback.
+ */
+QUICK_AI_API void quick_ai_set_log_callback(quick_ai_log_cb cb, void *user_data,
+                                            int level) QUICK_AI_NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* QUICK_AI_H_ */

--- a/Applications/CausalLM/capi/sample/quick_ai_sample.c
+++ b/Applications/CausalLM/capi/sample/quick_ai_sample.c
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   quick_ai_sample.c
+ * @date   28 May 2026
+ * @brief  Minimal host sample for the quick.ai C ABI DLL
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "quick_ai.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+typedef quick_ai_status (*quick_ai_ctx_create_fn)(const char *,
+                                                  const quick_ai_init_options *,
+                                                  quick_ai_ctx **);
+typedef void (*quick_ai_ctx_free_fn)(quick_ai_ctx *);
+typedef quick_ai_status (*quick_ai_generate_fn)(quick_ai_ctx *, const char *,
+                                                quick_ai_token_cb, void *,
+                                                quick_ai_usage *);
+typedef const char *(*quick_ai_last_error_fn)(quick_ai_ctx *);
+typedef const char *(*quick_ai_version_fn)(void);
+
+static int print_token(const char *utf8_delta, void *user_data) {
+  (void)user_data;
+  if (utf8_delta != NULL) {
+    fputs(utf8_delta, stdout);
+    fflush(stdout);
+  }
+  return 0;
+}
+
+static char *json_escape(const char *text) {
+  static const char hex[] = "0123456789abcdef";
+  size_t len;
+  size_t cap;
+  size_t i;
+  size_t j;
+  char *out;
+
+  if (text == NULL)
+    text = "";
+
+  len = strlen(text);
+  cap = len * 6 + 1;
+  out = (char *)malloc(cap);
+  if (out == NULL)
+    return NULL;
+
+  j = 0;
+  for (i = 0; i < len; ++i) {
+    unsigned char ch;
+    ch = (unsigned char)text[i];
+    switch (ch) {
+    case '\\':
+      out[j++] = '\\';
+      out[j++] = '\\';
+      break;
+    case '"':
+      out[j++] = '\\';
+      out[j++] = '"';
+      break;
+    case '\n':
+      out[j++] = '\\';
+      out[j++] = 'n';
+      break;
+    case '\r':
+      out[j++] = '\\';
+      out[j++] = 'r';
+      break;
+    case '\t':
+      out[j++] = '\\';
+      out[j++] = 't';
+      break;
+    default:
+      if (ch < 0x20) {
+        out[j++] = '\\';
+        out[j++] = 'u';
+        out[j++] = '0';
+        out[j++] = '0';
+        out[j++] = hex[ch >> 4];
+        out[j++] = hex[ch & 0x0f];
+      } else {
+        out[j++] = (char)ch;
+      }
+      break;
+    }
+  }
+  out[j] = '\0';
+  return out;
+}
+
+static char *make_request(const char *prompt) {
+  static const char prefix[] =
+    "{\"model\":\"qwen3-0.6b\",\"messages\":[{\"role\":\"user\","
+    "\"content\":\"";
+  static const char suffix[] =
+    "\"}],\"stream\":true,\"max_tokens\":32,\"temperature\":0}";
+  char *escaped;
+  char *request;
+  size_t request_len;
+
+  escaped = json_escape(prompt);
+  if (escaped == NULL)
+    return NULL;
+
+  request_len = strlen(prefix) + strlen(escaped) + strlen(suffix) + 1;
+  request = (char *)malloc(request_len);
+  if (request == NULL) {
+    free(escaped);
+    return NULL;
+  }
+
+  strcpy(request, prefix);
+  strcat(request, escaped);
+  strcat(request, suffix);
+  free(escaped);
+  return request;
+}
+
+int main(int argc, char **argv) {
+  const char *dll_path;
+  const char *model_dir;
+  const char *prompt;
+  char *request_json;
+  quick_ai_init_options opts;
+  quick_ai_usage usage;
+  quick_ai_ctx *ctx;
+  quick_ai_status status;
+  quick_ai_ctx_create_fn p_ctx_create;
+  quick_ai_ctx_free_fn p_ctx_free;
+  quick_ai_generate_fn p_generate;
+  quick_ai_last_error_fn p_last_error;
+  quick_ai_version_fn p_version;
+#ifdef _WIN32
+  HMODULE lib;
+#else
+  void *lib;
+#endif
+
+  if (argc < 3) {
+    fprintf(stderr, "usage: %s <quick_ai.dll> <model_dir> [prompt]\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  dll_path = argv[1];
+  model_dir = argv[2];
+  prompt = argc >= 4 ? argv[3] : "Write one short sentence about quick.ai.";
+
+#ifdef _WIN32
+  lib = LoadLibraryA(dll_path);
+  if (lib == NULL) {
+    fprintf(stderr, "failed to load %s (GetLastError=%lu)\n", dll_path,
+            (unsigned long)GetLastError());
+    return EXIT_FAILURE;
+  }
+#define LOAD_SYMBOL(name) (name##_fn)(void *) GetProcAddress(lib, #name)
+#else
+  lib = dlopen(dll_path, RTLD_NOW | RTLD_LOCAL);
+  if (lib == NULL) {
+    fprintf(stderr, "failed to load %s: %s\n", dll_path, dlerror());
+    return EXIT_FAILURE;
+  }
+#define LOAD_SYMBOL(name) (name##_fn) dlsym(lib, #name)
+#endif
+
+  p_ctx_create = LOAD_SYMBOL(quick_ai_ctx_create);
+  p_ctx_free = LOAD_SYMBOL(quick_ai_ctx_free);
+  p_generate = LOAD_SYMBOL(quick_ai_generate);
+  p_last_error = LOAD_SYMBOL(quick_ai_last_error);
+  p_version = LOAD_SYMBOL(quick_ai_version);
+  if (p_ctx_create == NULL || p_ctx_free == NULL || p_generate == NULL ||
+      p_last_error == NULL || p_version == NULL) {
+    fprintf(stderr, "required C ABI symbol is missing\n");
+    return EXIT_FAILURE;
+  }
+
+  request_json = make_request(prompt);
+  if (request_json == NULL) {
+    fprintf(stderr, "failed to allocate request JSON\n");
+    return EXIT_FAILURE;
+  }
+
+  opts.num_threads = 4;
+  opts.enable_thinking = 0;
+  ctx = NULL;
+  status = p_ctx_create(model_dir, &opts, &ctx);
+  if (status != 0) {
+    fprintf(stderr, "quick_ai_ctx_create failed: %d: %s\n", status,
+            p_last_error(NULL));
+    free(request_json);
+    return EXIT_FAILURE;
+  }
+
+  printf("%s\n", p_version());
+  status = p_generate(ctx, request_json, print_token, NULL, &usage);
+  printf("\n");
+  if (status != 0) {
+    fprintf(stderr, "quick_ai_generate failed: %d: %s\n", status,
+            p_last_error(ctx));
+    p_ctx_free(ctx);
+    free(request_json);
+    return EXIT_FAILURE;
+  }
+
+  printf("\nusage: prompt=%llu completion=%llu\n", usage.prompt_tokens,
+         usage.completion_tokens);
+  p_ctx_free(ctx);
+  free(request_json);
+
+#ifdef _WIN32
+  FreeLibrary(lib);
+#else
+  dlclose(lib);
+#endif
+  return EXIT_SUCCESS;
+}

--- a/Applications/CausalLM/layers/causallm_common_properties.h
+++ b/Applications/CausalLM/layers/causallm_common_properties.h
@@ -25,7 +25,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -17,7 +17,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -18,7 +18,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/embedding_normalize_layer.h
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.h
@@ -17,7 +17,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/embedding_pooling_layer.h
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.h
@@ -16,7 +16,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/lm_head.h
+++ b/Applications/CausalLM/layers/lm_head.h
@@ -17,7 +17,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -14,11 +14,12 @@ causallm_embedding_normalize_src_abs = [meson.current_source_dir() / 'embedding_
 causallm_deberta_attention_src_abs = [meson.current_source_dir() / 'deberta_attention_layer.cpp']
 causallm_shared_fully_connected_src_abs = [meson.current_source_dir() / 'shared_fully_connected_layer.cpp']
 
-causallm_rms_norm = shared_library(
+causallm_rms_norm = library(
     'rms_norm_layer', 
     causallm_rms_norm_src_abs, 
     include_directories: causallm_layer_inc, 
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -27,11 +28,12 @@ causallm_rms_norm_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_swiglu = shared_library(
+causallm_swiglu = library(
     'swiglu_layer',
     causallm_swiglu_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -40,11 +42,12 @@ causallm_swiglu_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_tie_word_embedding = shared_library(
+causallm_tie_word_embedding = library(
     'tie_word_embedding_layer',
     causallm_tie_word_embedding_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -53,11 +56,12 @@ causallm_tie_word_embedding_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_lm_head = shared_library(
+causallm_lm_head = library(
     'lm_head',
     causallm_lmhead_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -66,11 +70,12 @@ causallm_lm_head_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_mha_core = shared_library(
+causallm_mha_core = library(
     'mha_core_layer',
     causallm_mha_core_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -79,11 +84,12 @@ causallm_mha_core_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_embedding_layer = shared_library(
+causallm_embedding_layer = library(
     'embedding_layer',
     causallm_embedding_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -92,11 +98,12 @@ causallm_embedding_layer_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_embedding_pooling_layer = shared_library(
+causallm_embedding_pooling_layer = library(
     'embedding_pooling_layer',
     causallm_embedding_pooling_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -105,11 +112,12 @@ causallm_embedding_pooling_layer_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_embedding_normalize_layer = shared_library(
+causallm_embedding_normalize_layer = library(
     'embedding_normalize_layer',
     causallm_embedding_normalize_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -119,11 +127,12 @@ causallm_embedding_normalize_layer_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_reshaped_rms_norm = shared_library(
+causallm_reshaped_rms_norm = library(
     'reshaped_rms_norm_layer', 
     causallm_reshaped_rms_norm_src_abs, 
     include_directories: causallm_layer_inc, 
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -132,11 +141,12 @@ causallm_reshaped_rms_norm_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_qkv_layer = shared_library(
+causallm_qkv_layer = library(
     'qkv_layer',
     causallm_qkv_layer_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -146,11 +156,12 @@ causallm_qkv_layer_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_deberta_attention_layer = shared_library(
+causallm_deberta_attention_layer = library(
     'deberta_attention_layer',
     causallm_deberta_attention_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )
@@ -160,11 +171,12 @@ causallm_deberta_attention_layer_dep = declare_dependency(
     include_directories: causallm_layer_inc
 )
 
-causallm_shared_fully_connected_layer = shared_library(
+causallm_shared_fully_connected_layer = library(
     'shared_fully_connected_layer',
     causallm_shared_fully_connected_src_abs,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -26,7 +26,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/qkv_layer.h
+++ b/Applications/CausalLM/layers/qkv_layer.h
@@ -18,7 +18,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -16,7 +16,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -16,7 +16,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -16,7 +16,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -21,7 +21,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -17,7 +17,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -306,6 +306,15 @@ int main(int argc, char *argv[]) {
       generation_cfg = causallm::LoadJsonFile(generation_config_path);
     }
     json nntr_cfg = causallm::LoadJsonFile(model_path + "/nntr_config.json");
+    if (nntr_cfg.contains("tokenizer_file") &&
+        nntr_cfg["tokenizer_file"].is_string()) {
+      std::filesystem::path tokenizer_file(
+        nntr_cfg["tokenizer_file"].get<std::string>());
+      if (tokenizer_file.is_relative()) {
+        nntr_cfg["tokenizer_file"] =
+          (std::filesystem::path(model_path) / tokenizer_file).string();
+      }
+    }
 
     if (nntr_cfg.contains("system_prompt")) {
       system_head_prompt =

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -22,6 +22,18 @@ causallm_rest_api_inc = [include_directories('rest_api')]
 causallm_inc_minja_inc = include_directories('third_party/minja/include')
 causallm_inc_nlohmann_inc = include_directories('third_party')
 
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
+enable_causallm_single_dll_abi = get_option('enable-causallm-single-dll-abi')
+
+if enable_causallm_single_dll_abi and (get_option('platform') == 'windows') and (get_option('default_library') == 'static')
+    cpp_args += [ '-DNNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS' ]
+endif
+
 # Build layer dependency
 causallm_layer_dependencies = []
 subdir('layers')
@@ -84,7 +96,7 @@ generate_windows_tokenizer = generate_windows_tokenizer and build_machine.system
 generate_windows_tokenizer = generate_windows_tokenizer and not fs.exists(tokenizer_path)
 
 if generate_windows_tokenizer
-    run_command(
+    tokenizer_build_args = [
         powershell_prog,
         '-ExecutionPolicy',
         'Bypass',
@@ -94,6 +106,12 @@ if generate_windows_tokenizer
         meson.build_root(),
         '-RustTarget',
         tokenizer_rust_target,
+    ]
+    if get_option('b_vscrt') in ['mt', 'mtd', 'static_from_buildtype']
+        tokenizer_build_args += '-StaticCrt'
+    endif
+    run_command(
+        tokenizer_build_args,
         check: true
     )
 endif
@@ -115,12 +133,6 @@ if get_option('platform') == 'windows'
         'userenv.lib',
         'ws2_32.lib'
     ]
-endif
-
-cpp_args = []
-
-if get_option('default_library') == 'shared'
-    cpp_args += [ '-DPLUGGABLE' ]
 endif
 
 if get_option('platform') == 'windows'
@@ -168,6 +180,46 @@ causallm_dep = declare_dependency(
     include_directories: causallm_inc + causallm_rest_api_inc,
     link_args: get_option('platform') == 'windows' ? tokenizer_link_args : []
 )
+
+if enable_causallm_single_dll_abi
+    capi_inc = include_directories('capi')
+    capi_src = [
+        meson.current_source_dir() / 'capi' / 'quick_ai.cpp',
+    ]
+
+    quick_ai_dll = shared_library('quick_ai',
+        capi_src,
+        include_directories: [
+            capi_inc,
+            causallm_inc,
+            causallm_rest_api_inc,
+            causallm_inc_minja_inc,
+            causallm_inc_nlohmann_inc
+        ],
+        dependencies: [
+            nntrainer_dep,
+            nntrainer_ccapi_dep,
+            causallm_layer_dependencies,
+            causallm_dep
+        ],
+        install: true,
+        install_dir: application_install_dir,
+        cpp_args: cpp_args
+    )
+
+    quick_ai_sample = executable('quick_ai_sample',
+        meson.current_source_dir() / 'capi' / 'sample' / 'quick_ai_sample.c',
+        include_directories: capi_inc,
+        dependencies: host_machine.system() == 'windows' ? [] : libdl_dep,
+        install: false,
+        override_options: ['c_std=c11']
+    )
+
+    install_headers(
+        meson.current_source_dir() / 'capi' / 'quick_ai.h',
+        install_dir: nntrainer_includedir
+    )
+endif
 
 e = executable('nntr_causallm',
     executable_src,

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -2,6 +2,7 @@ causallm_src = [
     meson.current_source_dir() / 'chat_template.cpp',
     meson.current_source_dir() / 'huggingface_tokenizer.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
+    meson.current_source_dir() / 'rest_api' / 'openai_protocol.cpp',
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',
     meson.current_source_dir() / 'api' / 'model_config.cpp',
     meson.current_source_dir() / 'kv_cache_manager.cpp',
@@ -11,8 +12,13 @@ executable_src = [
     meson.current_source_dir() / 'main.cpp',
 ]
 
+openai_server_src = [
+    meson.current_source_dir() / 'rest_api' / 'openai_server.cpp',
+]
+
 causallm_inc_abs = [meson.current_source_dir()]
 causallm_inc = [include_directories('.')]
+causallm_rest_api_inc = [include_directories('rest_api')]
 causallm_inc_minja_inc = include_directories('third_party/minja/include')
 causallm_inc_nlohmann_inc = include_directories('third_party')
 
@@ -128,6 +134,7 @@ if get_option('platform') == 'windows'
         ],
         include_directories: [
             causallm_inc,
+            causallm_rest_api_inc,
             causallm_inc_minja_inc,
             causallm_inc_nlohmann_inc
         ],
@@ -145,6 +152,7 @@ else
         ],
         include_directories: [
             causallm_inc,
+            causallm_rest_api_inc,
             causallm_inc_minja_inc,
             causallm_inc_nlohmann_inc
         ],
@@ -157,13 +165,19 @@ endif
 
 causallm_dep = declare_dependency(
     link_with: [causallm],
-    include_directories: causallm_inc,
+    include_directories: causallm_inc + causallm_rest_api_inc,
     link_args: get_option('platform') == 'windows' ? tokenizer_link_args : []
 )
 
 e = executable('nntr_causallm',
     executable_src,
     include_directories: [causallm_inc, causallm_inc_minja_inc, causallm_inc_nlohmann_inc],
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep, causallm_layer_dependencies, causallm_dep],
+)
+
+e_openai_server = executable('nntr_causallm_openai_server',
+    openai_server_src,
+    include_directories: [causallm_inc, causallm_rest_api_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep, causallm_layer_dependencies, causallm_dep],
 )
 
@@ -221,6 +235,7 @@ if get_option('enable-test')
       'unittest_causallm_models',
       [
         meson.source_root() / 'test' / 'unittest' / 'models' / 'causallm_test_utils.cpp',
+        meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_openai_protocol.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gemma3.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3.cpp',

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -42,6 +42,9 @@
 #include <causal_lm.h>
 #include <llm_util.hpp>
 
+/**
+ * @brief Namespace for CausalLM application components
+ */
 namespace causallm {
 
 CausalLM::CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
@@ -102,6 +105,10 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
   TEMPERATURE = generation_cfg.contains("temperature")
                   ? generation_cfg["temperature"].get<float>()
                   : 0.7;
+  DEFAULT_TEMPERATURE = TEMPERATURE;
+  DEFAULT_TOP_K = TOP_K;
+  DEFAULT_TOP_P = TOP_P;
+  DEFAULT_NUM_TO_GENERATE = NUM_TO_GENERATE;
   global_token_len = 0;
 }
 
@@ -238,6 +245,9 @@ void CausalLM::registerOutputs(
           std::cout.flush();
         }
         output_list[b].append(decoded_str);
+        if (on_token_ && !on_token_(decoded_str)) {
+          cancel_requested_ = true;
+        }
         pending_ids_.clear();
       }
     }
@@ -346,6 +356,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   allocateAndBindKVCache();
 
   has_run_ = false;
+  cancel_requested_ = false;
 
   output_list.clear();
   for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
@@ -355,6 +366,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   if (MAX_SEQ_LEN < INIT_SEQ_LEN) {
     throw std::invalid_argument(
       "MAX_SEQ_LEN must be greater than or equal to INIT_SEQ_LEN");
+  }
+  if (MAX_SEQ_LEN < 2) {
+    throw std::invalid_argument("MAX_SEQ_LEN must be at least 2");
   }
 
   /**
@@ -403,7 +417,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   std::vector<int64_t> init_input;
   unsigned int _len = _input.size();
-  unsigned int num_allow_str = MAX_SEQ_LEN - NUM_TO_GENERATE;
+  const unsigned int configured_generation =
+    NUM_TO_GENERATE > 0
+      ? std::min(static_cast<unsigned int>(NUM_TO_GENERATE), MAX_SEQ_LEN - 1)
+      : 0U;
+  const unsigned int num_allow_str = MAX_SEQ_LEN > configured_generation + 1
+                                       ? MAX_SEQ_LEN - configured_generation - 1
+                                       : 1U;
   unsigned int text_len = _len;
 
   if (_len > num_allow_str)
@@ -525,8 +545,14 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   std::vector<unsigned int> id_list(
     generate(output[0], do_sample, 1, ids_history, init_len));
 
-  if (init_len < INIT_SEQ_LEN)
+  const unsigned int requested_generation_limit =
+    NUM_TO_GENERATE > 0 ? static_cast<unsigned int>(NUM_TO_GENERATE) : 0U;
+  unsigned int prefill_generated_tokens = 0;
+  if (requested_generation_limit > 0 && init_len < INIT_SEQ_LEN) {
     registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+    ++generation_cnt;
+    prefill_generated_tokens = 1;
+  }
 
   // output should be deallocated after use
   for (auto &out : output) {
@@ -550,8 +576,18 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
+  const unsigned int remaining_generation_limit =
+    requested_generation_limit > prefill_generated_tokens
+      ? requested_generation_limit - prefill_generated_tokens
+      : 0U;
+  const unsigned int generation_limit =
+    (remaining_generation_limit > 0 && input_len + 1 < MAX_SEQ_LEN)
+      ? std::min(remaining_generation_limit, MAX_SEQ_LEN - input_len - 1)
+      : 0U;
+
   for (unsigned int token_generation_idx = input_len + 1;
-       token_generation_idx < input_len + 1 + NUM_TO_GENERATE;
+       token_generation_idx < input_len + 1 + generation_limit &&
+       !cancel_requested_;
        ++token_generation_idx) {
 
     allocateAndBindKVCache();
@@ -575,6 +611,10 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     // output should be deallocated after use
     for (auto out : output_interval) {
       delete[] out;
+    }
+
+    if (cancel_requested_) {
+      break;
     }
 
     // check FINISH
@@ -646,6 +686,70 @@ std::string CausalLM::getOutput(int batch_idx) const {
     return "";
   }
   return output_list[batch_idx];
+}
+
+void CausalLM::resetGenerationState() {
+  global_token_len = 0;
+  pending_ids_.clear();
+  output_list.clear();
+  for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
+    output_list.push_back("");
+  }
+
+  if (is_initialized && kv_cache.isAllocated()) {
+    setKVCachePosition(0);
+  }
+}
+
+void CausalLM::setOnToken(TokenCallback callback) {
+  on_token_ = std::move(callback);
+  cancel_requested_ = false;
+}
+
+void CausalLM::clearOnToken() {
+  on_token_ = nullptr;
+  cancel_requested_ = false;
+}
+
+void CausalLM::setGenerationOverrides(const GenerationOverrides &overrides) {
+  clearGenerationOverrides();
+
+  if (overrides.temperature.has_value()) {
+    TEMPERATURE = *overrides.temperature;
+    generation_overrides_active_ = true;
+  }
+  if (overrides.top_p.has_value()) {
+    TOP_P = *overrides.top_p;
+    generation_overrides_active_ = true;
+  }
+  if (overrides.top_k.has_value()) {
+    TOP_K = *overrides.top_k;
+    generation_overrides_active_ = true;
+  }
+  if (overrides.max_tokens.has_value()) {
+    const unsigned int max_allowed_by_sequence =
+      MAX_SEQ_LEN > 1 ? MAX_SEQ_LEN - 1 : 0;
+    const unsigned int max_allowed_by_graph =
+      DEFAULT_NUM_TO_GENERATE > 0
+        ? static_cast<unsigned int>(DEFAULT_NUM_TO_GENERATE)
+        : 0U;
+    const unsigned int max_allowed =
+      std::min(max_allowed_by_sequence, max_allowed_by_graph);
+    NUM_TO_GENERATE =
+      static_cast<int>(std::min(*overrides.max_tokens, max_allowed));
+    generation_overrides_active_ = true;
+  }
+}
+
+void CausalLM::clearGenerationOverrides() {
+  if (!generation_overrides_active_)
+    return;
+
+  TEMPERATURE = DEFAULT_TEMPERATURE;
+  TOP_K = DEFAULT_TOP_K;
+  TOP_P = DEFAULT_TOP_P;
+  NUM_TO_GENERATE = DEFAULT_NUM_TO_GENERATE;
+  generation_overrides_active_ = false;
 }
 
 } // namespace causallm

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -421,13 +421,21 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     NUM_TO_GENERATE > 0
       ? std::min(static_cast<unsigned int>(NUM_TO_GENERATE), MAX_SEQ_LEN - 1)
       : 0U;
-  const unsigned int num_allow_str = MAX_SEQ_LEN > configured_generation + 1
-                                       ? MAX_SEQ_LEN - configured_generation - 1
-                                       : 1U;
+  const unsigned int context_prompt_limit =
+    MAX_SEQ_LEN > configured_generation ? MAX_SEQ_LEN - configured_generation
+                                        : 1U;
+  const unsigned int max_prefill_len =
+    std::min(INIT_SEQ_LEN, context_prompt_limit);
   unsigned int text_len = _len;
 
-  if (_len > num_allow_str)
-    text_len = num_allow_str;
+  if (_len > max_prefill_len) {
+    throw std::invalid_argument(
+      "prompt token length " + std::to_string(_len) +
+      " exceeds configured prefill limit " + std::to_string(max_prefill_len) +
+      " for init_seq_len=" + std::to_string(INIT_SEQ_LEN) +
+      ", max_seq_len=" + std::to_string(MAX_SEQ_LEN) +
+      ", num_to_generate=" + std::to_string(configured_generation));
+  }
 
   // feed only available length
   // if _input is allowed, it feeds all of the _input
@@ -548,7 +556,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   const unsigned int requested_generation_limit =
     NUM_TO_GENERATE > 0 ? static_cast<unsigned int>(NUM_TO_GENERATE) : 0U;
   unsigned int prefill_generated_tokens = 0;
-  if (requested_generation_limit > 0 && init_len < INIT_SEQ_LEN) {
+  if (requested_generation_limit > 0 && init_len < MAX_SEQ_LEN) {
     registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
     ++generation_cnt;
     prefill_generated_tokens = 1;

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -30,7 +30,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #define WSTR std::string
 #define WCHAR_P std::string &
 #else

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -42,7 +42,20 @@
 #include <kv_cache_manager.h>
 #include <transformer.h>
 
+#include <functional>
+#include <optional>
+
 namespace causallm {
+
+/**
+ * @brief Optional generation settings for a single CausalLM run
+ */
+struct GenerationOverrides {
+  std::optional<float> temperature;       /**< Temporary sampling temperature */
+  std::optional<float> top_p;             /**< Temporary nucleus sampling */
+  std::optional<unsigned int> top_k;      /**< Temporary top-k sampling */
+  std::optional<unsigned int> max_tokens; /**< Temporary generation limit */
+};
 
 /**
  * @brief CausalLM Class
@@ -50,6 +63,11 @@ namespace causallm {
 WIN_EXPORT class CausalLM : virtual public Transformer {
 
 public:
+  /**
+   * @brief Callback invoked with each decoded text piece
+   */
+  using TokenCallback = std::function<bool(const std::string &)>;
+
   /**
    * @brief Construct a new CausalLM object
    * @param cfg Configuration for the model (config.json)
@@ -80,6 +98,33 @@ public:
    * @return Generated text string
    */
   std::string getOutput(int batch_idx = 0) const;
+
+  /**
+   * @brief Reset generated text and KV-cache cursor for an independent request
+   */
+  void resetGenerationState();
+
+  /**
+   * @brief Set callback invoked whenever visible decoded text is flushed
+   * @param callback Returns false to request generation cancellation
+   */
+  void setOnToken(TokenCallback callback);
+
+  /**
+   * @brief Clear token callback and any pending cancellation request
+   */
+  void clearOnToken();
+
+  /**
+   * @brief Apply temporary generation settings for the next run
+   * @param overrides Optional per-request generation settings
+   */
+  void setGenerationOverrides(const GenerationOverrides &overrides);
+
+  /**
+   * @brief Restore generation settings loaded from model configuration
+   */
+  void clearGenerationOverrides();
 
 protected:
   /**
@@ -138,6 +183,10 @@ protected:
   float TEMPERATURE;
   unsigned int TOP_K;
   float TOP_P;
+  float DEFAULT_TEMPERATURE = 0.0F;
+  unsigned int DEFAULT_TOP_K = 0;
+  float DEFAULT_TOP_P = 0.0F;
+  int DEFAULT_NUM_TO_GENERATE = 0;
 
   std::vector<unsigned int> BAD_WORD_IDS; /**< List of bad word IDs */
   unsigned int NUM_BADWORDS;              /**< Number of bad words */
@@ -147,6 +196,9 @@ protected:
   bool SAVE_KVCACHE;
   bool USE_KVCACHE;
   unsigned int global_token_len;
+  TokenCallback on_token_;
+  bool cancel_requested_ = false;
+  bool generation_overrides_active_ = false;
 
   std::mt19937 rng; /**< Random Number Gen */
 

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
@@ -18,7 +18,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/models/gpt_oss/meson.build
+++ b/Applications/CausalLM/models/gpt_oss/meson.build
@@ -7,11 +7,12 @@ gpt_oss_inc = include_directories('.')
 # Define Layers
 causallm_gptoss_moe_layer_src_abs = [meson.current_source_dir() / 'gpt_oss_moe_layer.cpp']
 
-causallm_gptoss_moe_layer = shared_library(
+causallm_gptoss_moe_layer = library(
     'gptoss_moe_layer',
     causallm_gptoss_moe_layer_src_abs,
     include_directories: [causallm_layer_inc, gpt_oss_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
@@ -18,7 +18,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/meson.build
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/meson.build
@@ -6,11 +6,12 @@ gpt_oss_cached_slim_inc = include_directories('.')
 
 causallm_gptoss_moe_layer_cached_src_abs = [meson.current_source_dir() / 'gpt_oss_moe_layer_cached.cpp']
 
-causallm_cached_slim_gptoss_moe_layer = shared_library(
+causallm_cached_slim_gptoss_moe_layer = library(
     'cached_slim_gptoss_moe_layer',
     causallm_gptoss_moe_layer_cached_src_abs,
     include_directories: [causallm_layer_inc, gpt_oss_cached_slim_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/meson.build
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/meson.build
@@ -6,11 +6,12 @@ qwen3_cached_slim_moe_inc = include_directories('.')
 
 causallm_cached_slim_moe_layer_src_abs = [meson.current_source_dir() / 'qwen_moe_layer_cached.cpp']
 
-causallm_cached_slim_moe_layer = shared_library(
+causallm_cached_slim_moe_layer = library(
     'qwen_moe_layer_cached',
     causallm_cached_slim_moe_layer_src_abs,
     include_directories: [causallm_layer_inc, qwen3_cached_slim_moe_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -23,7 +23,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/models/qwen3_moe/meson.build
+++ b/Applications/CausalLM/models/qwen3_moe/meson.build
@@ -7,11 +7,12 @@ qwen3_moe_inc = include_directories('.')
 # Define Layers
 causallm_moe_layer_src_abs = [meson.current_source_dir() / 'qwen_moe_layer.cpp']
 
-causallm_moe_layer = shared_library(
+causallm_moe_layer = library(
     'qwen_moe_layer',
     causallm_moe_layer_src_abs,
     include_directories: [causallm_layer_inc, qwen3_moe_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
@@ -23,7 +23,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/models/qwen3_slim_moe/meson.build
+++ b/Applications/CausalLM/models/qwen3_slim_moe/meson.build
@@ -6,11 +6,12 @@ qwen3_slim_moe_inc = include_directories('.')
 
 causallm_slim_moe_layer_src_abs = [meson.current_source_dir() / 'qwen_moe_layer_fsu.cpp']
 
-causallm_slim_moe_layer = shared_library(
+causallm_slim_moe_layer = library(
     'qwen_moe_layer_fsu',
     causallm_slim_moe_layer_src_abs,
     include_directories: [causallm_layer_inc, qwen3_slim_moe_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    cpp_args: cpp_args,
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
@@ -23,7 +23,11 @@
 #pragma once
 #ifndef WIN_EXPORT
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #else
 #define WIN_EXPORT
 #endif

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -20,6 +20,11 @@
 #include <map>
 #include <transformer.h>
 
+#if defined(_WIN32) && defined(NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS)
+#undef WIN_EXPORT
+#define WIN_EXPORT
+#endif
+
 namespace causallm {
 
 /**

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -25,7 +25,11 @@
 
 #pragma once
 #ifdef _WIN32
+#ifdef NNTRAINER_CAUSALLM_HIDE_INTERNAL_EXPORTS
+#define WIN_EXPORT
+#else
 #define WIN_EXPORT __declspec(dllexport)
+#endif
 #define WSTR std::string
 #define WCHAR_P std::string &
 #else
@@ -130,6 +134,31 @@ public:
    * @brief get the status of run
    */
   bool hasRun() const { return has_run_; }
+
+  /**
+   * @brief Get maximum sequence length
+   */
+  unsigned int getMaxSeqLen() const { return MAX_SEQ_LEN; }
+
+  /**
+   * @brief Get initial sequence length
+   */
+  unsigned int getInitSeqLen() const { return INIT_SEQ_LEN; }
+
+  /**
+   * @brief Get number of tokens to generate
+   */
+  int getNumToGenerate() const { return NUM_TO_GENERATE; }
+
+  /**
+   * @brief Get model batch size
+   */
+  unsigned int getBatchSize() const { return BATCH_SIZE; }
+
+  /**
+   * @brief Get hidden dimension
+   */
+  int getHiddenDim() const { return DIM; }
 
 protected:
   /**

--- a/Applications/CausalLM/rest_api/openai_protocol.cpp
+++ b/Applications/CausalLM/rest_api/openai_protocol.cpp
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   openai_protocol.cpp
+ * @date   27 May 2026
+ * @brief  OpenAI-compatible CausalLM JSON protocol helpers
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <openai_protocol.h>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+/**
+ * @brief Namespace for OpenAI-compatible CausalLM protocol helpers
+ */
+namespace causallm::openai {
+
+/**
+ * @brief Anonymous namespace for local protocol helper functions
+ */
+namespace {
+
+/**
+ * @brief Return current Unix timestamp in seconds.
+ */
+long long nowSeconds() {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+           std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+
+/**
+ * @brief Read required string field from a JSON object.
+ */
+std::string requireString(const nlohmann::json &payload,
+                          const std::string &field) {
+  if (!payload.contains(field) || !payload[field].is_string()) {
+    throw std::invalid_argument("missing or invalid '" + field + "'");
+  }
+  return payload[field].get<std::string>();
+}
+
+/**
+ * @brief Read text from a chat content field for non-template fallback.
+ */
+std::string chatContentText(const nlohmann::json &message) {
+  if (!message.contains("content") || message["content"].is_null())
+    return "";
+
+  const auto &content = message["content"];
+  if (content.is_string())
+    return content.get<std::string>();
+
+  if (!content.is_array()) {
+    throw std::invalid_argument(
+      "message content must be a string or text parts");
+  }
+
+  std::string text;
+  for (const auto &part : content) {
+    if (!part.is_object() || !part.contains("type") ||
+        !part["type"].is_string()) {
+      throw std::invalid_argument("chat content parts must include a type");
+    }
+
+    if (part["type"].get<std::string>() != "text") {
+      throw std::invalid_argument(
+        "non-text chat content parts are unsupported");
+    }
+
+    if (part.contains("text") && part["text"].is_string())
+      text += part["text"].get<std::string>();
+  }
+  return text;
+}
+
+/**
+ * @brief Build the JSON request forwarded to ChatTemplate.
+ */
+nlohmann::json makeChatTemplateInput(const nlohmann::json &payload) {
+  nlohmann::json input;
+  input["messages"] = payload["messages"];
+
+  for (const char *field : {"tools", "functions", "add_generation_prompt",
+                            "continue_final_message", "template_name"}) {
+    if (payload.contains(field))
+      input[field] = payload[field];
+  }
+
+  return input;
+}
+
+/**
+ * @brief Read an optional floating point field.
+ */
+std::optional<float> optionalFloat(const nlohmann::json &payload,
+                                   const std::string &field) {
+  if (!payload.contains(field))
+    return std::nullopt;
+  if (!payload[field].is_number()) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+  try {
+    const float value = payload[field].get<float>();
+    if (!std::isfinite(value)) {
+      throw std::invalid_argument("invalid '" + field + "'");
+    }
+    return value;
+  } catch (const nlohmann::json::exception &) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+}
+
+/**
+ * @brief Read an optional boolean field.
+ */
+bool optionalBool(const nlohmann::json &payload, const std::string &field,
+                  bool default_value) {
+  if (!payload.contains(field))
+    return default_value;
+  if (!payload[field].is_boolean()) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+  return payload[field].get<bool>();
+}
+
+/**
+ * @brief Read an optional positive unsigned integer field.
+ */
+std::optional<unsigned int> optionalUInt(const nlohmann::json &payload,
+                                         const std::string &field) {
+  if (!payload.contains(field))
+    return std::nullopt;
+  if (!payload[field].is_number_integer()) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+  long long value = 0;
+  try {
+    value = payload[field].get<long long>();
+  } catch (const nlohmann::json::exception &) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+  if (value < 1 || value > static_cast<long long>(
+                             std::numeric_limits<unsigned int>::max())) {
+    throw std::invalid_argument("invalid '" + field + "'");
+  }
+  return static_cast<unsigned int>(value);
+}
+
+/**
+ * @brief Read stop field as string or string array.
+ */
+std::vector<std::string> optionalStop(const nlohmann::json &payload) {
+  std::vector<std::string> stop;
+  if (!payload.contains("stop") || payload["stop"].is_null())
+    return stop;
+
+  if (payload["stop"].is_string()) {
+    stop.push_back(payload["stop"].get<std::string>());
+    return stop;
+  }
+
+  if (!payload["stop"].is_array()) {
+    throw std::invalid_argument("invalid 'stop'");
+  }
+
+  for (const auto &item : payload["stop"]) {
+    if (!item.is_string()) {
+      throw std::invalid_argument("invalid 'stop'");
+    }
+    stop.push_back(item.get<std::string>());
+  }
+  return stop;
+}
+
+/**
+ * @brief Parse shared generation options from request JSON.
+ */
+GenerationOptions parseGenerationOptions(const nlohmann::json &payload) {
+  GenerationOptions options;
+  options.temperature = optionalFloat(payload, "temperature");
+  options.top_p = optionalFloat(payload, "top_p");
+  options.top_k = optionalUInt(payload, "top_k");
+  options.max_tokens = optionalUInt(payload, "max_tokens");
+  options.stop = optionalStop(payload);
+  return options;
+}
+
+/**
+ * @brief Trim ASCII whitespace in place.
+ */
+void trimInPlace(std::string &text) {
+  auto is_space = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  text.erase(text.begin(),
+             std::find_if_not(text.begin(), text.end(), is_space));
+  text.erase(std::find_if_not(text.rbegin(), text.rend(), is_space).base(),
+             text.end());
+}
+
+/**
+ * @brief Erase every occurrence of a marker string.
+ */
+void eraseAll(std::string &text, const std::string &needle) {
+  if (needle.empty())
+    return;
+
+  size_t pos = 0;
+  while ((pos = text.find(needle, pos)) != std::string::npos) {
+    text.erase(pos, needle.size());
+  }
+}
+
+/**
+ * @brief Return whether text starts with marker.
+ */
+bool startsWith(const std::string &text, const std::string &marker) {
+  return text.size() >= marker.size() &&
+         text.compare(0, marker.size(), marker) == 0;
+}
+
+/**
+ * @brief Return whether text is a non-empty prefix of marker.
+ */
+bool isPartialPrefix(const std::string &text, const std::string &marker) {
+  return !text.empty() && text.size() < marker.size() &&
+         marker.compare(0, text.size(), text) == 0;
+}
+
+/**
+ * @brief Build response usage object.
+ */
+nlohmann::json makeUsage(unsigned int prompt_tokens,
+                         unsigned int completion_tokens) {
+  return {
+    {"prompt_tokens", prompt_tokens},
+    {"completion_tokens", completion_tokens},
+    {"total_tokens", prompt_tokens + completion_tokens},
+  };
+}
+
+} // namespace
+
+ChatCompletionRequest
+parseChatCompletionRequest(const nlohmann::json &payload) {
+  if (!payload.is_object()) {
+    throw std::invalid_argument("request body must be a JSON object");
+  }
+
+  ChatCompletionRequest request;
+  request.model = requireString(payload, "model");
+  request.stream = optionalBool(payload, "stream", false);
+  request.options = parseGenerationOptions(payload);
+
+  if (!payload.contains("messages") || !payload["messages"].is_array() ||
+      payload["messages"].empty()) {
+    throw std::invalid_argument("'messages' must be a non-empty array");
+  }
+
+  for (const auto &item : payload["messages"]) {
+    if (!item.is_object()) {
+      throw std::invalid_argument("each message must be a JSON object");
+    }
+
+    ChatMessage message;
+    message.role = requireString(item, "role");
+    message.content = chatContentText(item);
+    request.messages.push_back(std::move(message));
+  }
+  request.chat_input = makeChatTemplateInput(payload);
+
+  return request;
+}
+
+CompletionRequest parseCompletionRequest(const nlohmann::json &payload) {
+  if (!payload.is_object()) {
+    throw std::invalid_argument("request body must be a JSON object");
+  }
+
+  CompletionRequest request;
+  request.model = requireString(payload, "model");
+  request.prompt = requireString(payload, "prompt");
+  request.stream = optionalBool(payload, "stream", false);
+  request.options = parseGenerationOptions(payload);
+  return request;
+}
+
+std::string cleanGeneratedText(std::string generated) {
+  const std::string think_end = "</think>";
+  const size_t think_end_pos = generated.find(think_end);
+  if (think_end_pos != std::string::npos) {
+    generated.erase(0, think_end_pos + think_end.size());
+  }
+
+  const std::vector<std::string> stop_markers = {
+    "<|im_end|>",
+    "<|endoftext|>",
+    "</s>",
+  };
+  for (const auto &marker : stop_markers) {
+    const size_t pos = generated.find(marker);
+    if (pos != std::string::npos) {
+      generated.erase(pos);
+    }
+  }
+
+  eraseAll(generated, "<think>");
+  eraseAll(generated, "</think>");
+  eraseAll(generated, "\xEF\xBF\xBD");
+  trimInPlace(generated);
+  return generated;
+}
+
+nlohmann::json makeChatCompletionResponse(const std::string &model,
+                                          const std::string &content,
+                                          unsigned int prompt_tokens,
+                                          unsigned int completion_tokens) {
+  return {
+    {"id", "chatcmpl-nntrainer"},
+    {"object", "chat.completion"},
+    {"created", nowSeconds()},
+    {"model", model},
+    {"choices",
+     {{{"index", 0},
+       {"message", {{"role", "assistant"}, {"content", content}}},
+       {"finish_reason", "stop"}}}},
+    {"usage", makeUsage(prompt_tokens, completion_tokens)},
+  };
+}
+
+nlohmann::json makeChatCompletionChunk(const std::string &model,
+                                       const std::string &role,
+                                       const std::string &content,
+                                       const std::string &finish_reason) {
+  nlohmann::json delta = nlohmann::json::object();
+  if (!role.empty())
+    delta["role"] = role;
+  if (!content.empty())
+    delta["content"] = content;
+
+  return {
+    {"id", "chatcmpl-nntrainer"},
+    {"object", "chat.completion.chunk"},
+    {"created", nowSeconds()},
+    {"model", model},
+    {"choices",
+     {{{"index", 0},
+       {"delta", delta},
+       {"finish_reason", finish_reason.empty()
+                           ? nlohmann::json(nullptr)
+                           : nlohmann::json(finish_reason)}}}},
+  };
+}
+
+nlohmann::json makeCompletionResponse(const std::string &model,
+                                      const std::string &content,
+                                      unsigned int prompt_tokens,
+                                      unsigned int completion_tokens) {
+  return {
+    {"id", "cmpl-nntrainer"},
+    {"object", "text_completion"},
+    {"created", nowSeconds()},
+    {"model", model},
+    {"choices", {{{"index", 0}, {"text", content}, {"finish_reason", "stop"}}}},
+    {"usage", makeUsage(prompt_tokens, completion_tokens)},
+  };
+}
+
+nlohmann::json makeErrorResponse(const std::string &message,
+                                 const std::string &type,
+                                 const std::string &code) {
+  nlohmann::json error = {
+    {"message", message},
+    {"type", type},
+    {"param", nullptr},
+    {"code", nullptr},
+  };
+  if (!code.empty())
+    error["code"] = code;
+  return {{"error", error}};
+}
+
+StreamingTextFilter::StreamingTextFilter(std::vector<std::string> stop_markers,
+                                         bool enable_thinking) :
+  stop_markers_(std::move(stop_markers)), enable_thinking_(enable_thinking) {
+  stop_markers_.erase(
+    std::remove_if(stop_markers_.begin(), stop_markers_.end(),
+                   [](const std::string &marker) { return marker.empty(); }),
+    stop_markers_.end());
+  stop_markers_.push_back("<|im_end|>");
+  stop_markers_.push_back("<|endoftext|>");
+  stop_markers_.push_back("</s>");
+
+  marker_prefixes_ = stop_markers_;
+  if (!enable_thinking_) {
+    marker_prefixes_.push_back("<think>");
+    marker_prefixes_.push_back("</think>");
+  }
+}
+
+StreamingFilterResult StreamingTextFilter::push(const std::string &piece) {
+  StreamingFilterResult result;
+  if (stopped_)
+    return result;
+
+  pending_.append(piece);
+  eraseAll(pending_, "\xEF\xBF\xBD");
+
+  while (!pending_.empty()) {
+    bool matched_stop = false;
+    for (const auto &marker : stop_markers_) {
+      if (startsWith(pending_, marker)) {
+        stopped_ = true;
+        pending_.clear();
+        result.stop = true;
+        matched_stop = true;
+        break;
+      }
+    }
+    if (matched_stop)
+      break;
+
+    if (!enable_thinking_ && !in_think_ && startsWith(pending_, "<think>")) {
+      pending_.erase(0, 7);
+      in_think_ = true;
+      continue;
+    }
+
+    if (!enable_thinking_ && in_think_ && startsWith(pending_, "</think>")) {
+      pending_.erase(0, 8);
+      in_think_ = false;
+      continue;
+    }
+
+    bool waiting_for_marker = false;
+    for (const auto &marker : marker_prefixes_) {
+      if (isPartialPrefix(pending_, marker)) {
+        waiting_for_marker = true;
+        break;
+      }
+    }
+    if (waiting_for_marker)
+      break;
+
+    const char ch = pending_.front();
+    pending_.erase(0, 1);
+    if (!in_think_)
+      result.text.push_back(ch);
+  }
+
+  return result;
+}
+
+std::string StreamingTextFilter::flush() {
+  if (stopped_ || in_think_) {
+    pending_.clear();
+    return "";
+  }
+
+  std::string text = pending_;
+  pending_.clear();
+  return text;
+}
+
+} // namespace causallm::openai

--- a/Applications/CausalLM/rest_api/openai_protocol.h
+++ b/Applications/CausalLM/rest_api/openai_protocol.h
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   openai_protocol.h
+ * @date   27 May 2026
+ * @brief  OpenAI-compatible CausalLM JSON protocol helpers
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __CAUSALLM_OPENAI_PROTOCOL_H__
+#define __CAUSALLM_OPENAI_PROTOCOL_H__
+
+#include <json.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Namespace for OpenAI-compatible CausalLM protocol helpers
+ */
+namespace causallm::openai {
+
+/**
+ * @brief OpenAI-style chat message used by protocol parsing.
+ */
+struct ChatMessage {
+  std::string role;    /**< Message role, such as system, user, assistant */
+  std::string content; /**< Plain text message content */
+};
+
+/**
+ * @brief Optional generation settings parsed from an OpenAI-compatible request
+ */
+struct GenerationOptions {
+  std::optional<float> temperature;       /**< Per-request temperature */
+  std::optional<float> top_p;             /**< Per-request nucleus sampling */
+  std::optional<unsigned int> top_k;      /**< Per-request top-k sampling */
+  std::optional<unsigned int> max_tokens; /**< Per-request generation limit */
+  std::vector<std::string> stop;          /**< Stop marker strings */
+};
+
+/**
+ * @brief Parsed OpenAI-compatible chat completion request
+ */
+struct ChatCompletionRequest {
+  std::string model;                 /**< Requested model id */
+  std::vector<ChatMessage> messages; /**< Conversation messages */
+  nlohmann::json chat_input;         /**< Template-ready chat request */
+  bool stream = false;               /**< Whether to stream SSE chunks */
+  GenerationOptions options;         /**< Optional generation settings */
+};
+
+/**
+ * @brief Parsed OpenAI-compatible text completion request
+ */
+struct CompletionRequest {
+  std::string model;         /**< Requested model id */
+  std::string prompt;        /**< Prompt text */
+  bool stream = false;       /**< Whether streaming was requested */
+  GenerationOptions options; /**< Optional generation settings */
+};
+
+/**
+ * @brief Output from one incremental streaming text filter push.
+ */
+struct StreamingFilterResult {
+  std::string text;  /**< Clean text safe to send to the client */
+  bool stop = false; /**< Whether a stop marker ended the stream */
+};
+
+/**
+ * @brief Parse a /v1/chat/completions request body.
+ * @param payload JSON request body
+ * @return Parsed request
+ * @throws std::invalid_argument on unsupported or malformed payloads
+ */
+ChatCompletionRequest parseChatCompletionRequest(const nlohmann::json &payload);
+
+/**
+ * @brief Parse a /v1/completions request body.
+ * @param payload JSON request body
+ * @return Parsed request
+ * @throws std::invalid_argument on unsupported or malformed payloads
+ */
+CompletionRequest parseCompletionRequest(const nlohmann::json &payload);
+
+/**
+ * @brief Remove reasoning tags, end markers, and surrounding whitespace.
+ * @param generated Raw generated text
+ * @return Clean assistant-visible text
+ */
+std::string cleanGeneratedText(std::string generated);
+
+/**
+ * @brief Build a chat completion response body.
+ */
+nlohmann::json makeChatCompletionResponse(const std::string &model,
+                                          const std::string &content,
+                                          unsigned int prompt_tokens,
+                                          unsigned int completion_tokens);
+
+/**
+ * @brief Build a chat completion streaming chunk body.
+ */
+nlohmann::json makeChatCompletionChunk(const std::string &model,
+                                       const std::string &role,
+                                       const std::string &content,
+                                       const std::string &finish_reason);
+
+/**
+ * @brief Build a text completion response body.
+ */
+nlohmann::json makeCompletionResponse(const std::string &model,
+                                      const std::string &content,
+                                      unsigned int prompt_tokens,
+                                      unsigned int completion_tokens);
+
+/**
+ * @brief Build an OpenAI-style error response body.
+ */
+nlohmann::json makeErrorResponse(const std::string &message,
+                                 const std::string &type,
+                                 const std::string &code = "");
+
+/**
+ * @brief Incrementally clean model output for SSE streaming.
+ */
+class StreamingTextFilter {
+public:
+  /**
+   * @brief Construct a streaming filter.
+   * @param stop_markers User-provided stop markers
+   * @param enable_thinking Whether <think> blocks should be forwarded
+   */
+  explicit StreamingTextFilter(std::vector<std::string> stop_markers = {},
+                               bool enable_thinking = false);
+
+  /**
+   * @brief Push a raw decoded piece and return clean visible text.
+   */
+  StreamingFilterResult push(const std::string &piece);
+
+  /**
+   * @brief Flush any non-marker pending text after generation ends.
+   */
+  std::string flush();
+
+private:
+  std::vector<std::string> stop_markers_;
+  std::vector<std::string> marker_prefixes_;
+  std::string pending_;
+  bool enable_thinking_;
+  bool in_think_ = false;
+  bool stopped_ = false;
+};
+
+} // namespace causallm::openai
+
+#endif // __CAUSALLM_OPENAI_PROTOCOL_H__

--- a/Applications/CausalLM/rest_api/openai_server.cpp
+++ b/Applications/CausalLM/rest_api/openai_server.cpp
@@ -1,0 +1,951 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   openai_server.cpp
+ * @date   27 May 2026
+ * @brief  OpenAI-compatible REST server for CausalLM
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <climits>
+#include <csignal>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include "json.hpp"
+#include <factory.h>
+#include <openai_protocol.h>
+
+#include "causal_lm.h"
+#include "chat_template.h"
+#include "deberta_v2.h"
+#include "embedding_gemma.h"
+#include "gemma3_causallm.h"
+#if !defined(_WIN32)
+#include "gptoss_cached_slim_causallm.h"
+#endif
+#include "gptoss_causallm.h"
+#if !defined(_WIN32) && !defined(__ANDROID__)
+#include "multilingual_tinybert_16mb.h"
+#endif
+#include "qwen2_causallm.h"
+#include "qwen2_embedding.h"
+#if !defined(_WIN32)
+#include "qwen3_cached_slim_moe_causallm.h"
+#endif
+#include "qwen3_causallm.h"
+#include "qwen3_embedding.h"
+#include "qwen3_moe_causallm.h"
+#include "qwen3_slim_moe_causallm.h"
+#include "timm_vit/timm_vit_transformer.h"
+
+using json = nlohmann::json;
+
+/**
+ * @brief Anonymous namespace for OpenAI server implementation details
+ */
+namespace {
+
+#ifdef _WIN32
+using SocketHandle = SOCKET;
+constexpr SocketHandle invalid_socket_handle = INVALID_SOCKET;
+#else
+using SocketHandle = int;
+constexpr SocketHandle invalid_socket_handle = -1;
+#endif
+
+std::atomic<bool> keep_running{true};
+constexpr size_t max_http_body_size = 16 * 1024 * 1024;
+
+/**
+ * @brief Close a platform socket.
+ */
+void closeSocket(SocketHandle socket) {
+#ifdef _WIN32
+  closesocket(socket);
+#else
+  close(socket);
+#endif
+}
+
+/**
+ * @brief Send all bytes in a response buffer.
+ */
+bool sendAll(SocketHandle socket, const std::string &data) {
+  const char *ptr = data.data();
+  size_t remaining = data.size();
+  while (remaining > 0) {
+#ifdef _WIN32
+    const int chunk = static_cast<int>(std::min<size_t>(remaining, INT_MAX));
+    const int sent = send(socket, ptr, chunk, 0);
+#else
+    const ssize_t sent = send(socket, ptr, remaining, 0);
+#endif
+    if (sent <= 0)
+      return false;
+    ptr += sent;
+    remaining -= static_cast<size_t>(sent);
+  }
+  return true;
+}
+
+/**
+ * @brief Receive bytes from a socket.
+ */
+int recvSome(SocketHandle socket, char *buffer, int size) {
+#ifdef _WIN32
+  return recv(socket, buffer, size, 0);
+#else
+  return static_cast<int>(recv(socket, buffer, static_cast<size_t>(size), 0));
+#endif
+}
+
+/**
+ * @brief Lowercase an ASCII string.
+ */
+std::string lowercase(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return text;
+}
+
+/**
+ * @brief Trim ASCII whitespace from a string.
+ */
+std::string trim(std::string text) {
+  auto is_space = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  text.erase(text.begin(),
+             std::find_if_not(text.begin(), text.end(), is_space));
+  text.erase(std::find_if_not(text.rbegin(), text.rend(), is_space).base(),
+             text.end());
+  return text;
+}
+
+/**
+ * @brief Parsed HTTP request.
+ */
+struct HttpRequest {
+  std::string method;                        /**< HTTP method */
+  std::string path;                          /**< Request target path */
+  std::map<std::string, std::string> header; /**< Lowercase headers */
+  std::string body;                          /**< Request body */
+};
+
+/**
+ * @brief Read one HTTP/1.1 request. Supports Content-Length bodies.
+ */
+HttpRequest readHttpRequest(SocketHandle socket) {
+  std::string data;
+  char buffer[4096];
+  size_t header_end = std::string::npos;
+
+  while ((header_end = data.find("\r\n\r\n")) == std::string::npos) {
+    const int received = recvSome(socket, buffer, sizeof(buffer));
+    if (received <= 0)
+      throw std::runtime_error("connection closed before HTTP headers");
+    data.append(buffer, static_cast<size_t>(received));
+    if (data.size() > 1024 * 1024)
+      throw std::runtime_error("HTTP headers are too large");
+  }
+
+  std::istringstream header_stream(data.substr(0, header_end));
+  std::string request_line;
+  std::getline(header_stream, request_line);
+  if (!request_line.empty() && request_line.back() == '\r')
+    request_line.pop_back();
+
+  HttpRequest request;
+  std::istringstream request_line_stream(request_line);
+  request_line_stream >> request.method >> request.path;
+  if (request.method.empty() || request.path.empty())
+    throw std::runtime_error("invalid HTTP request line");
+
+  const size_t query_pos = request.path.find('?');
+  if (query_pos != std::string::npos)
+    request.path.erase(query_pos);
+
+  std::string line;
+  while (std::getline(header_stream, line)) {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back();
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos)
+      continue;
+    request.header[lowercase(trim(line.substr(0, colon)))] =
+      trim(line.substr(colon + 1));
+  }
+
+  size_t content_length = 0;
+  if (auto it = request.header.find("content-length");
+      it != request.header.end()) {
+    content_length = static_cast<size_t>(std::stoul(it->second));
+  }
+  if (content_length > max_http_body_size)
+    throw std::runtime_error("HTTP body is too large");
+
+  const size_t body_start = header_end + 4;
+  request.body = data.substr(body_start);
+  while (request.body.size() < content_length) {
+    const int received = recvSome(socket, buffer, sizeof(buffer));
+    if (received <= 0)
+      throw std::runtime_error("connection closed before HTTP body");
+    request.body.append(buffer, static_cast<size_t>(received));
+  }
+  if (request.body.size() > content_length)
+    request.body.resize(content_length);
+
+  return request;
+}
+
+/**
+ * @brief Create a JSON HTTP response.
+ */
+std::string httpJson(int status, const std::string &reason,
+                     const json &payload) {
+  const std::string body = payload.dump();
+  std::ostringstream response;
+  response << "HTTP/1.1 " << status << ' ' << reason << "\r\n"
+           << "Content-Type: application/json\r\n"
+           << "Content-Length: " << body.size() << "\r\n"
+           << "Connection: close\r\n\r\n"
+           << body;
+  return response.str();
+}
+
+/**
+ * @brief Create an SSE HTTP response header.
+ */
+std::string httpSseHeader() {
+  return "HTTP/1.1 200 OK\r\n"
+         "Content-Type: text/event-stream\r\n"
+         "Cache-Control: no-cache\r\n"
+         "Connection: close\r\n\r\n";
+}
+
+/**
+ * @brief Create one SSE data frame.
+ */
+std::string sseData(const std::string &payload) {
+  return "data: " + payload + "\n\n";
+}
+
+/**
+ * @brief Send one OpenAI-style SSE JSON frame.
+ */
+bool sendSseJson(SocketHandle client, const json &payload) {
+  return sendAll(client, sseData(payload.dump()));
+}
+
+/**
+ * @brief Send the OpenAI SSE stream terminator.
+ */
+bool sendSseDone(SocketHandle client) {
+  return sendAll(client, sseData("[DONE]"));
+}
+
+/**
+ * @brief Resolve config architecture names to registered factory names.
+ */
+std::string resolveArchitecture(std::string model_type,
+                                const std::string &architecture) {
+  std::transform(model_type.begin(), model_type.end(), model_type.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  if (model_type == "embedding") {
+    if (architecture == "Qwen3ForCausalLM") {
+      return "Qwen3Embedding";
+    } else if (architecture == "Gemma3ForCausalLM" ||
+               architecture == "Gemma3TextModel") {
+      return "EmbeddingGemma";
+    } else if (architecture == "Qwen2Model") {
+      return "Qwen2Embedding";
+    } else if (architecture == "BertForMaskedLM") {
+      return "MultilingualTinyBert";
+    } else if (architecture == "TimmViT" ||
+               architecture == "vit_base_patch16_siglip_224") {
+      return "TimmViT";
+    } else if (architecture == "deberta-v2" ||
+               architecture == "DebertaV2Model" ||
+               architecture == "DebertaV2ForMaskedLM") {
+      return "DebertaV2";
+    }
+    throw std::invalid_argument("Unsupported embedding architecture: " +
+                                architecture);
+  }
+
+  if (architecture == "TimmViT" ||
+      architecture == "vit_base_patch16_siglip_224") {
+    return "TimmViT";
+  }
+
+  return architecture;
+}
+
+/**
+ * @brief Register runnable CausalLM models in the local factory.
+ */
+void registerModels() {
+  auto &factory = causallm::Factory::Instance();
+  factory.registerModel("LlamaForCausalLM", [](json cfg, json generation_cfg,
+                                               json nntr_cfg) {
+    return std::make_unique<causallm::CausalLM>(cfg, generation_cfg, nntr_cfg);
+  });
+  factory.registerModel("Qwen2ForCausalLM",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen2CausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("Qwen2Embedding",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen2Embedding>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("Qwen3ForCausalLM",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen3CausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("Qwen3MoeForCausalLM",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen3MoECausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("Qwen3SlimMoeForCausalLM", [](json cfg,
+                                                      json generation_cfg,
+                                                      json nntr_cfg) {
+    return std::make_unique<causallm::Qwen3SlimMoECausalLM>(cfg, generation_cfg,
+                                                            nntr_cfg);
+  });
+#if !defined(_WIN32)
+  factory.registerModel(
+    "Qwen3CachedSlimMoeForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::Qwen3CachedSlimMoECausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+#endif
+  factory.registerModel("Qwen3Embedding",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen3Embedding>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("GptOssForCausalLM",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::GptOssForCausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+#if !defined(_WIN32)
+  factory.registerModel(
+    "GptOssCachedSlimCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::GptOssCachedSlimCausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+#endif
+  factory.registerModel("Gemma3ForCausalLM",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Gemma3CausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("EmbeddingGemma",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::EmbeddingGemma>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("DebertaV2", [](json cfg, json generation_cfg,
+                                        json nntr_cfg) {
+    return std::make_unique<causallm::DebertaV2>(cfg, generation_cfg, nntr_cfg);
+  });
+#if !defined(_WIN32) && !defined(__ANDROID__)
+  factory.registerModel(
+    "MultilingualTinyBert", [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::MultilingualTinyBert>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+#endif
+  factory.registerModel("TimmViT",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::TimmViTTransformer>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+}
+
+/**
+ * @brief Loaded server model state.
+ */
+struct LoadedModel {
+  std::string model_id;           /**< Public model id */
+  std::string model_path;         /**< Model directory */
+  std::string architecture;       /**< Factory architecture */
+  std::string system_head_prompt; /**< Optional head prompt */
+  std::string system_tail_prompt; /**< Optional tail prompt */
+  bool do_sample = false;         /**< Sampling mode */
+  bool enable_thinking = false;   /**< Qwen thinking template mode */
+  std::optional<causallm::ChatTemplate>
+    chat_template;                              /**< Optional chat template */
+  std::unique_ptr<causallm::Transformer> model; /**< Loaded model */
+  std::mutex mutex; /**< Single-model request guard */
+};
+
+/**
+ * @brief Convert a possibly relative model file name to an absolute path.
+ */
+std::string absoluteModelFile(const std::filesystem::path &model_dir,
+                              const std::string &path) {
+  const std::filesystem::path file(path);
+  return file.is_absolute() ? file.string() : (model_dir / file).string();
+}
+
+/**
+ * @brief Load a CausalLM model from a file-based model directory.
+ */
+std::unique_ptr<LoadedModel> loadModel(const std::string &model_path,
+                                       const std::string &model_id,
+                                       bool enable_thinking) {
+  registerModels();
+
+  auto loaded = std::make_unique<LoadedModel>();
+  loaded->model_path = std::filesystem::absolute(model_path).string();
+  loaded->model_id =
+    model_id.empty()
+      ? std::filesystem::path(loaded->model_path).filename().string()
+      : model_id;
+  loaded->enable_thinking = enable_thinking;
+
+  const std::filesystem::path model_dir(loaded->model_path);
+  json cfg = causallm::LoadJsonFile((model_dir / "config.json").string());
+  json generation_cfg = json::object();
+  if (std::filesystem::exists(model_dir / "generation_config.json")) {
+    generation_cfg =
+      causallm::LoadJsonFile((model_dir / "generation_config.json").string());
+  }
+  json nntr_cfg =
+    causallm::LoadJsonFile((model_dir / "nntr_config.json").string());
+
+  if (nntr_cfg.contains("tokenizer_file") &&
+      nntr_cfg["tokenizer_file"].is_string()) {
+    nntr_cfg["tokenizer_file"] =
+      absoluteModelFile(model_dir, nntr_cfg["tokenizer_file"]);
+  }
+
+  if (nntr_cfg.contains("system_prompt")) {
+    loaded->system_head_prompt =
+      nntr_cfg["system_prompt"]["head_prompt"].get<std::string>();
+    loaded->system_tail_prompt =
+      nntr_cfg["system_prompt"]["tail_prompt"].get<std::string>();
+  }
+
+  std::string architecture;
+  if (cfg.contains("architectures") && cfg["architectures"].is_array() &&
+      !cfg["architectures"].empty()) {
+    architecture = cfg["architectures"].get<std::vector<std::string>>()[0];
+  } else if (cfg.contains("architecture") && cfg["architecture"].is_string()) {
+    architecture = cfg["architecture"].get<std::string>();
+  } else if (cfg.contains("model_type") && cfg["model_type"].is_string()) {
+    architecture = cfg["model_type"].get<std::string>();
+  } else {
+    throw std::invalid_argument(
+      "config.json must contain architecture metadata.");
+  }
+
+  if (nntr_cfg.contains("model_type")) {
+    architecture = resolveArchitecture(
+      nntr_cfg["model_type"].get<std::string>(), architecture);
+  }
+  loaded->architecture = architecture;
+
+  const std::string weight_file = absoluteModelFile(
+    model_dir, nntr_cfg["model_file_name"].get<std::string>());
+
+  if (causallm::ChatTemplate::Exists(model_dir.string()))
+    loaded->chat_template.emplace(
+      causallm::ChatTemplate::Load(model_dir.string()));
+
+  loaded->model = causallm::Factory::Instance().create(
+    architecture, cfg, generation_cfg, nntr_cfg);
+  if (!loaded->model) {
+    std::ostringstream os;
+    os << "Unknown architecture: " << architecture
+       << ". Registered architectures:";
+    causallm::Factory::Instance().printRegistered(os);
+    throw std::runtime_error(os.str());
+  }
+
+  loaded->model->initialize();
+  loaded->model->load_weight(weight_file);
+  loaded->do_sample = generation_cfg.value("do_sample", false);
+  return loaded;
+}
+
+/**
+ * @brief Join messages when no tokenizer chat template is available.
+ */
+std::string
+fallbackPrompt(const std::vector<causallm::openai::ChatMessage> &messages) {
+  std::ostringstream prompt;
+  for (const auto &message : messages) {
+    prompt << message.role << ": " << message.content << '\n';
+  }
+  prompt << "assistant: ";
+  return prompt.str();
+}
+
+/**
+ * @brief Add server-controlled template settings to parsed chat input.
+ */
+json withServerChatTemplateOptions(const json &chat_input,
+                                   bool enable_thinking) {
+  json request = chat_input;
+  if (!request.contains("add_generation_prompt"))
+    request["add_generation_prompt"] = true;
+  request["enable_thinking"] = enable_thinking;
+  return request;
+}
+
+/**
+ * @brief Restore temporary CausalLM request state when a run exits.
+ */
+class CausalRunGuard {
+public:
+  explicit CausalRunGuard(causallm::CausalLM *model) : model_(model) {}
+
+  CausalRunGuard(const CausalRunGuard &) = delete;
+  CausalRunGuard &operator=(const CausalRunGuard &) = delete;
+
+  ~CausalRunGuard() {
+    if (!model_)
+      return;
+
+    model_->clearOnToken();
+    model_->clearGenerationOverrides();
+  }
+
+private:
+  causallm::CausalLM *model_;
+};
+
+/**
+ * @brief Convert OpenAI request options into CausalLM generation overrides.
+ */
+causallm::GenerationOverrides
+toGenerationOverrides(const causallm::openai::GenerationOptions &options) {
+  causallm::GenerationOverrides overrides;
+  overrides.temperature = options.temperature;
+  overrides.top_p = options.top_p;
+  overrides.top_k = options.top_k;
+  overrides.max_tokens = options.max_tokens;
+  return overrides;
+}
+
+/**
+ * @brief Choose sampling mode for one request.
+ */
+bool requestDoSample(bool default_do_sample,
+                     const causallm::openai::GenerationOptions &options) {
+  if ((options.temperature.has_value() && *options.temperature > 0.0F) ||
+      options.top_p.has_value() || options.top_k.has_value()) {
+    return true;
+  }
+
+  if (options.temperature.has_value())
+    return false;
+
+  return default_do_sample;
+}
+
+/**
+ * @brief Clean a full generated string with the streaming filter rules.
+ */
+std::string
+cleanGeneratedText(const std::string &raw,
+                   const causallm::openai::GenerationOptions &options,
+                   bool enable_thinking) {
+  causallm::openai::StreamingTextFilter filter(options.stop, enable_thinking);
+  auto result = filter.push(raw);
+  std::string text = std::move(result.text);
+  text += filter.flush();
+  return trim(text);
+}
+
+/**
+ * @brief Run one prompt through the loaded model.
+ */
+std::pair<std::string, TransformerPerformanceMetrics>
+runPrompt(LoadedModel &loaded, const std::string &prompt,
+          const causallm::openai::GenerationOptions &options) {
+  std::lock_guard<std::mutex> lock(loaded.mutex);
+
+  auto *causal_model = dynamic_cast<causallm::CausalLM *>(loaded.model.get());
+  CausalRunGuard run_guard(causal_model);
+  if (causal_model) {
+    causal_model->resetGenerationState();
+    causal_model->setGenerationOverrides(toGenerationOverrides(options));
+  }
+
+  loaded.model->run(prompt, requestDoSample(loaded.do_sample, options),
+                    loaded.system_head_prompt, loaded.system_tail_prompt,
+                    false);
+
+  std::string output;
+  if (causal_model) {
+    output = causal_model->getOutput(0);
+  }
+
+  return {cleanGeneratedText(output, options, loaded.enable_thinking),
+          loaded.model->getPerformanceMetrics()};
+}
+
+/**
+ * @brief Stream one prompt through the loaded CausalLM model.
+ */
+void streamPrompt(LoadedModel &loaded, const std::string &prompt,
+                  const causallm::openai::GenerationOptions &options,
+                  SocketHandle client) {
+  std::lock_guard<std::mutex> lock(loaded.mutex);
+
+  auto *causal_model = dynamic_cast<causallm::CausalLM *>(loaded.model.get());
+  if (!causal_model) {
+    throw std::invalid_argument("loaded model does not support chat streaming");
+  }
+
+  CausalRunGuard run_guard(causal_model);
+  causallm::openai::StreamingTextFilter filter(options.stop,
+                                               loaded.enable_thinking);
+  bool client_open = true;
+  bool stop_requested = false;
+
+  causal_model->resetGenerationState();
+  causal_model->setGenerationOverrides(toGenerationOverrides(options));
+
+  client_open = sendSseJson(client, causallm::openai::makeChatCompletionChunk(
+                                      loaded.model_id, "assistant", "", ""));
+  if (!client_open)
+    return;
+
+  causal_model->setOnToken([&](const std::string &piece) {
+    auto result = filter.push(piece);
+    if (!result.text.empty()) {
+      client_open =
+        sendSseJson(client, causallm::openai::makeChatCompletionChunk(
+                              loaded.model_id, "", result.text, ""));
+    }
+    stop_requested = stop_requested || result.stop;
+    return client_open && !stop_requested;
+  });
+
+  loaded.model->run(prompt, requestDoSample(loaded.do_sample, options),
+                    loaded.system_head_prompt, loaded.system_tail_prompt,
+                    false);
+
+  if (client_open && !stop_requested) {
+    const std::string tail = filter.flush();
+    if (!tail.empty()) {
+      client_open =
+        sendSseJson(client, causallm::openai::makeChatCompletionChunk(
+                              loaded.model_id, "", tail, ""));
+    }
+  }
+
+  if (!client_open)
+    return;
+
+  // A stop marker is a normal stream completion, so still emit terminal chunks.
+  client_open = sendSseJson(client, causallm::openai::makeChatCompletionChunk(
+                                      loaded.model_id, "", "", "stop"));
+  if (client_open)
+    sendSseDone(client);
+}
+
+/**
+ * @brief Verify that a request targets the loaded model.
+ */
+void verifyRequestedModel(const LoadedModel &loaded,
+                          const std::string &requested_model) {
+  if (requested_model != loaded.model_id) {
+    throw std::invalid_argument("model is not loaded: " + requested_model);
+  }
+}
+
+/**
+ * @brief Handle one HTTP request and write the HTTP response.
+ */
+void handleRequest(LoadedModel &loaded, const HttpRequest &request,
+                   SocketHandle client) {
+  try {
+    if (request.method == "GET" && request.path == "/health") {
+      sendAll(client, httpJson(200, "OK", {{"status", "ok"}}));
+      return;
+    }
+
+    if (request.method == "GET" && request.path == "/v1/models") {
+      sendAll(client, httpJson(200, "OK",
+                               {{"object", "list"},
+                                {"data",
+                                 {{{"id", loaded.model_id},
+                                   {"object", "model"},
+                                   {"created", 0},
+                                   {"owned_by", "nntrainer"}}}}}));
+      return;
+    }
+
+    if (request.method != "POST") {
+      sendAll(client,
+              httpJson(405, "Method Not Allowed",
+                       causallm::openai::makeErrorResponse(
+                         "method is not allowed", "invalid_request_error")));
+      return;
+    }
+
+    const json payload =
+      json::parse(request.body.empty() ? "{}" : request.body);
+    if (request.path == "/v1/chat/completions") {
+      const auto parsed = causallm::openai::parseChatCompletionRequest(payload);
+      verifyRequestedModel(loaded, parsed.model);
+      const std::string prompt =
+        loaded.chat_template.has_value()
+          ? loaded.chat_template->apply(withServerChatTemplateOptions(
+              parsed.chat_input, loaded.enable_thinking))
+          : fallbackPrompt(parsed.messages);
+      if (parsed.stream) {
+        if (!sendAll(client, httpSseHeader()))
+          return;
+
+        try {
+          streamPrompt(loaded, prompt, parsed.options, client);
+        } catch (const std::exception &e) {
+          sendSseJson(client, causallm::openai::makeErrorResponse(
+                                e.what(), "server_error"));
+          sendSseDone(client);
+        }
+        return;
+      }
+
+      auto [content, metrics] = runPrompt(loaded, prompt, parsed.options);
+      sendAll(client,
+              httpJson(200, "OK",
+                       causallm::openai::makeChatCompletionResponse(
+                         loaded.model_id, content, metrics.prefill_tokens,
+                         metrics.generation_tokens)));
+      return;
+    }
+
+    if (request.path == "/v1/completions") {
+      const auto parsed = causallm::openai::parseCompletionRequest(payload);
+      verifyRequestedModel(loaded, parsed.model);
+      if (parsed.stream) {
+        throw std::invalid_argument(
+          "streaming text completions are not supported");
+      }
+
+      auto [content, metrics] =
+        runPrompt(loaded, parsed.prompt, parsed.options);
+      sendAll(client,
+              httpJson(200, "OK",
+                       causallm::openai::makeCompletionResponse(
+                         loaded.model_id, content, metrics.prefill_tokens,
+                         metrics.generation_tokens)));
+      return;
+    }
+
+    sendAll(client, httpJson(404, "Not Found",
+                             causallm::openai::makeErrorResponse(
+                               "unknown endpoint", "invalid_request_error")));
+  } catch (const json::parse_error &e) {
+    sendAll(client, httpJson(400, "Bad Request",
+                             causallm::openai::makeErrorResponse(
+                               std::string("invalid JSON: ") + e.what(),
+                               "invalid_request_error")));
+  } catch (const std::invalid_argument &e) {
+    sendAll(client, httpJson(400, "Bad Request",
+                             causallm::openai::makeErrorResponse(
+                               e.what(), "invalid_request_error")));
+  } catch (const std::exception &e) {
+    sendAll(client, httpJson(500, "Internal Server Error",
+                             causallm::openai::makeErrorResponse(
+                               e.what(), "server_error")));
+  }
+}
+
+/**
+ * @brief Create and bind a listening socket.
+ */
+SocketHandle listenSocket(const std::string &host, unsigned short port) {
+  SocketHandle server = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (server == invalid_socket_handle)
+    throw std::runtime_error("failed to create socket");
+
+  int opt = 1;
+#ifdef _WIN32
+  setsockopt(server, SOL_SOCKET, SO_REUSEADDR,
+             reinterpret_cast<const char *>(&opt), sizeof(opt));
+#else
+  setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+#endif
+
+  sockaddr_in address{};
+  address.sin_family = AF_INET;
+  address.sin_port = htons(port);
+  if (inet_pton(AF_INET, host.c_str(), &address.sin_addr) != 1) {
+    closeSocket(server);
+    throw std::runtime_error("host must be an IPv4 address");
+  }
+
+  if (bind(server, reinterpret_cast<sockaddr *>(&address), sizeof(address)) !=
+      0) {
+    closeSocket(server);
+    throw std::runtime_error("failed to bind server socket");
+  }
+
+  if (listen(server, 16) != 0) {
+    closeSocket(server);
+    throw std::runtime_error("failed to listen on server socket");
+  }
+
+  return server;
+}
+
+/**
+ * @brief Print command usage.
+ */
+void printUsage(const char *program) {
+  std::cerr << "Usage: " << program
+            << " <model_path> [--host 127.0.0.1] [--port 8000]"
+               " [--model qwen3-0.6b] [--enable-thinking]\n";
+}
+
+/**
+ * @brief Process Ctrl+C where supported.
+ */
+void handleSignal(int) { keep_running.store(false); }
+
+} // namespace
+
+/**
+ * @brief Entry point for the OpenAI-compatible CausalLM server.
+ */
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    printUsage(argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  std::string model_path = argv[1];
+  std::string host = "127.0.0.1";
+  unsigned short port = 8000;
+  std::string model_id;
+  bool enable_thinking = false;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--host" && i + 1 < argc) {
+      host = argv[++i];
+    } else if (arg == "--port" && i + 1 < argc) {
+      try {
+        const int parsed_port = std::stoi(argv[++i]);
+        if (parsed_port < 1 || parsed_port > 65535)
+          throw std::out_of_range("port");
+        port = static_cast<unsigned short>(parsed_port);
+      } catch (const std::exception &) {
+        std::cerr << "Invalid --port value\n";
+        return EXIT_FAILURE;
+      }
+    } else if (arg == "--model" && i + 1 < argc) {
+      model_id = argv[++i];
+    } else if (arg == "--enable-thinking") {
+      enable_thinking = true;
+    } else {
+      printUsage(argv[0]);
+      return EXIT_FAILURE;
+    }
+  }
+
+#ifdef _WIN32
+  WSADATA wsa_data{};
+  if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0) {
+    std::cerr << "WSAStartup failed\n";
+    return EXIT_FAILURE;
+  }
+#endif
+
+  std::signal(SIGINT, handleSignal);
+#if !defined(_WIN32)
+  std::signal(SIGPIPE, SIG_IGN);
+#endif
+
+  try {
+    auto loaded = loadModel(model_path, model_id, enable_thinking);
+    SocketHandle server = listenSocket(host, port);
+    std::cout << "nntrainer OpenAI-compatible server listening on http://"
+              << host << ':' << port << "\n"
+              << "model: " << loaded->model_id << "\n";
+
+    while (keep_running.load()) {
+      sockaddr_in client_addr{};
+#ifdef _WIN32
+      int client_len = sizeof(client_addr);
+#else
+      socklen_t client_len = sizeof(client_addr);
+#endif
+      SocketHandle client =
+        accept(server, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
+      if (client == invalid_socket_handle) {
+        if (!keep_running.load())
+          break;
+        continue;
+      }
+
+      try {
+        const auto request = readHttpRequest(client);
+        handleRequest(*loaded, request, client);
+      } catch (const std::exception &e) {
+        sendAll(client, httpJson(400, "Bad Request",
+                                 causallm::openai::makeErrorResponse(
+                                   e.what(), "invalid_request_error")));
+      }
+      closeSocket(client);
+    }
+
+    closeSocket(server);
+  } catch (const std::exception &e) {
+    std::cerr << "[!] FATAL ERROR: " << e.what() << "\n";
+#ifdef _WIN32
+    WSACleanup();
+#endif
+    return EXIT_FAILURE;
+  }
+
+#ifdef _WIN32
+  WSACleanup();
+#endif
+  return EXIT_SUCCESS;
+}

--- a/Applications/CausalLM/windows_package/README-WINDOWS-QWEN3.md
+++ b/Applications/CausalLM/windows_package/README-WINDOWS-QWEN3.md
@@ -1,0 +1,80 @@
+# NNTrainer Qwen3 0.6B Windows Package
+
+This folder contains a Windows build of NNTrainer CausalLM, Qwen3 0.6B
+model files, and helper scripts for command-line inference and an
+OpenAI-compatible local REST server.
+
+## Contents
+
+- `bin/nntr_causallm.exe`: command-line CausalLM runner.
+- `bin/nntr_causallm_openai_server.exe`: OpenAI-compatible REST server.
+- `bin/**/*.dll`: NNTrainer CausalLM custom layer plugins and runtime DLLs.
+- `model/`: Qwen3 0.6B config, tokenizer, and NNTrainer weight files.
+- `run_cli.ps1`: smoke-test CLI inference.
+- `run_openai_server.ps1`: start the local REST server.
+
+## CLI Smoke Test
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\run_cli.ps1
+```
+
+The output should contain a normal completion sentence such as
+`Paris, and the capital of Italy is Rome.`
+
+## OpenAI-Compatible Server
+
+Start the server:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\run_openai_server.ps1 -Port 8000
+```
+
+Query it from another terminal:
+
+```powershell
+$body = @{
+  model = "qwen3-0.6b"
+  messages = @(@{ role = "user"; content = "Say exactly: Hello from NNTrainer." })
+} | ConvertTo-Json -Depth 4
+
+Invoke-RestMethod -Method Post `
+  -Uri http://127.0.0.1:8000/v1/chat/completions `
+  -ContentType application/json `
+  -Body $body
+```
+
+Supported endpoints:
+
+- `GET /health`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `POST /v1/completions`
+
+Chat completions support OpenAI-style SSE streaming with `stream = $true`:
+
+```powershell
+$body = @{
+  model = "qwen3-0.6b"
+  stream = $true
+  max_tokens = 32
+  messages = @(@{ role = "user"; content = "Say exactly: Hello from NNTrainer." })
+} | ConvertTo-Json -Depth 4
+
+Invoke-WebRequest -Method Post `
+  -Uri http://127.0.0.1:8000/v1/chat/completions `
+  -ContentType application/json `
+  -Body $body
+```
+
+The stream emits `chat.completion.chunk` frames followed by `data: [DONE]`.
+The server disables Qwen thinking mode by default and strips
+`<think>...</think>` and special end markers from the returned OpenAI
+`content`/`text` field.
+
+## Runtime Notes
+
+This build targets x64 Windows and expects the Microsoft Visual C++ 2015-2022
+runtime to be installed. The package includes the common MSVC runtime DLLs in
+`bin/`; if Windows still reports a missing runtime DLL, install the official
+Microsoft Visual C++ Redistributable for x64.

--- a/Applications/CausalLM/windows_package/run_cli.ps1
+++ b/Applications/CausalLM/windows_package/run_cli.ps1
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file run_cli.ps1
+# @brief Run Qwen3 0.6B with the packaged NNTrainer CausalLM CLI.
+
+param(
+    [string]$Prompt = "The capital of France is",
+    [int]$Threads = 4
+)
+
+$ErrorActionPreference = "Stop"
+
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Bin = Join-Path $Root "bin"
+$Model = Join-Path $Root "model"
+$Exe = Join-Path $Bin "nntr_causallm.exe"
+
+if (-Not (Test-Path $Exe)) {
+    throw "Missing executable: $Exe"
+}
+if (-Not (Test-Path $Model)) {
+    throw "Missing model directory: $Model"
+}
+
+$DllDirs = Get-ChildItem $Bin -Filter *.dll -Recurse |
+    ForEach-Object { Split-Path -Parent $_.FullName } |
+    Sort-Object -Unique
+
+$env:PATH = (($DllDirs + @($Bin)) -join ";") + ";" + $env:PATH
+$env:NNTR_NUM_THREADS = [string]$Threads
+
+$Output = & $Exe $Model $Prompt 2>&1
+$ExitCode = $LASTEXITCODE
+
+if ($ExitCode -ne 0) {
+    $Output
+    exit $ExitCode
+}
+
+$Text = ($Output | Out-String)
+$ThinkEnd = $Text.LastIndexOf("</think>")
+if ($ThinkEnd -ge 0) {
+    $Text = $Text.Substring($ThinkEnd + "</think>".Length)
+}
+
+$EndMarker = $Text.IndexOf("<|im_end|>")
+if ($EndMarker -ge 0) {
+    $Text = $Text.Substring(0, $EndMarker)
+}
+
+$ReplacementMarker = [string][char]0xfffd
+$Utf8ReplacementMojibake = ([string][char]0x5360) + ([string][char]0xc3d9) + ([string][char]0xc619)
+$LatinReplacementMojibake = ([string][char]0x00ef) + ([string][char]0x00bf) + ([string][char]0x00bd)
+
+$Text = $Text.Replace("<think>", "").Replace("</think>", "")
+$Text = $Text.Replace($ReplacementMarker, "")
+$Text = $Text.Replace($Utf8ReplacementMojibake, "")
+$Text = $Text.Replace($LatinReplacementMojibake, "")
+$EscapedModel = [regex]::Escape($Model)
+$EscapedPrompt = [regex]::Escape($Prompt)
+$Line = $Text -split "\r?\n" |
+    ForEach-Object { $_.Trim() } |
+    Where-Object {
+        $_ -and
+        $_ -notmatch "^(=|prefill:|generation:|total:|peak memory:|\[e2e time\]|Max Resident)" -and
+        $_ -notmatch "^$EscapedModel([/\\].*)?$" -and
+        $_ -notmatch "^$EscapedPrompt$"
+    } |
+    Select-Object -First 1
+
+if ($Line) {
+    Write-Output $Line
+} else {
+    $Output
+}

--- a/Applications/CausalLM/windows_package/run_openai_server.ps1
+++ b/Applications/CausalLM/windows_package/run_openai_server.ps1
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file run_openai_server.ps1
+# @brief Start the packaged NNTrainer OpenAI-compatible CausalLM server.
+
+param(
+    [string]$HostAddress = "127.0.0.1",
+    [int]$Port = 8000,
+    [string]$ModelId = "qwen3-0.6b",
+    [int]$Threads = 4,
+    [switch]$EnableThinking
+)
+
+$ErrorActionPreference = "Stop"
+
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Bin = Join-Path $Root "bin"
+$Model = Join-Path $Root "model"
+$Exe = Join-Path $Bin "nntr_causallm_openai_server.exe"
+
+if (-Not (Test-Path $Exe)) {
+    throw "Missing executable: $Exe"
+}
+if (-Not (Test-Path $Model)) {
+    throw "Missing model directory: $Model"
+}
+
+$DllDirs = Get-ChildItem $Bin -Filter *.dll -Recurse |
+    ForEach-Object { Split-Path -Parent $_.FullName } |
+    Sort-Object -Unique
+
+$env:PATH = (($DllDirs + @($Bin)) -join ";") + ";" + $env:PATH
+$env:NNTR_NUM_THREADS = [string]$Threads
+
+$Args = @(
+    $Model,
+    "--host", $HostAddress,
+    "--port", [string]$Port,
+    "--model", $ModelId
+)
+
+if ($EnableThinking) {
+    $Args += "--enable-thinking"
+}
+
+& $Exe @Args

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -70,6 +70,8 @@ option('nnstreamer-subplugin-install-path', type: 'string', value: 'lib/nnstream
 option('enable-transformer', type: 'boolean', value: false)
 option('causallm-tokenizer-lib', type: 'string', value: '',
        description: 'Windows-only path to tokenizers_c.lib for CausalLM. The default is generated under <builddir>/tokenizers_c_win/target.')
+option('enable-causallm-single-dll-abi', type: 'boolean', value: false,
+       description: 'Build the optional CausalLM single-DLL C ABI target.')
 
 # ARM architecture options
 option('arm-arch', type: 'combo',

--- a/test/unittest/models/unittest_causallm_openai_protocol.cpp
+++ b/test/unittest/models/unittest_causallm_openai_protocol.cpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_causallm_openai_protocol.cpp
+ * @date   27 May 2026
+ * @brief  OpenAI-compatible CausalLM protocol unit tests
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <openai_protocol.h>
+
+#include <gtest/gtest.h>
+
+TEST(CausalLMOpenAIProtocolTest, ParsesChatCompletionMessages) {
+  nlohmann::json payload = {
+    {"model", "qwen3-0.6b"},
+    {"messages",
+     {{{"role", "system"}, {"content", "Be concise."}},
+      {{"role", "user"}, {"content", "Say hello."}}}},
+  };
+
+  auto request = causallm::openai::parseChatCompletionRequest(payload);
+
+  ASSERT_EQ(request.model, "qwen3-0.6b");
+  ASSERT_EQ(request.messages.size(), 2u);
+  EXPECT_EQ(request.messages[0].role, "system");
+  EXPECT_EQ(request.messages[0].content, "Be concise.");
+  EXPECT_EQ(request.messages[1].role, "user");
+  EXPECT_EQ(request.messages[1].content, "Say hello.");
+  EXPECT_EQ(request.chat_input["messages"], payload["messages"]);
+}
+
+TEST(CausalLMOpenAIProtocolTest, PreservesTemplateChatInput) {
+  nlohmann::json payload = {
+    {"model", "qwen3-0.6b"},
+    {"messages",
+     {{{"role", "user"},
+       {"content",
+        {{{"type", "text"}, {"text", "Say "}},
+         {{"type", "text"}, {"text", "hello."}}}}}}},
+    {"tools",
+     {{{"type", "function"},
+       {"function", {{"name", "noop"}, {"parameters", {}}}}}}},
+    {"add_generation_prompt", false},
+  };
+
+  auto request = causallm::openai::parseChatCompletionRequest(payload);
+
+  ASSERT_EQ(request.messages.size(), 1u);
+  EXPECT_EQ(request.messages[0].content, "Say hello.");
+  EXPECT_EQ(request.chat_input["messages"], payload["messages"]);
+  EXPECT_EQ(request.chat_input["tools"], payload["tools"]);
+  EXPECT_FALSE(request.chat_input["add_generation_prompt"].get<bool>());
+  EXPECT_FALSE(request.chat_input.contains("model"));
+  EXPECT_FALSE(request.chat_input.contains("stream"));
+}
+
+TEST(CausalLMOpenAIProtocolTest, ParsesStringCompletionPrompt) {
+  nlohmann::json payload = {
+    {"model", "qwen3-0.6b"},
+    {"prompt", "Say hello."},
+  };
+
+  auto request = causallm::openai::parseCompletionRequest(payload);
+
+  EXPECT_EQ(request.model, "qwen3-0.6b");
+  EXPECT_EQ(request.prompt, "Say hello.");
+}
+
+TEST(CausalLMOpenAIProtocolTest, ParsesStreamingRequests) {
+  nlohmann::json payload = {
+    {"model", "qwen3-0.6b"},
+    {"messages", {{{"role", "user"}, {"content", "Hi"}}}},
+    {"stream", true},
+  };
+
+  auto request = causallm::openai::parseChatCompletionRequest(payload);
+
+  EXPECT_TRUE(request.stream);
+}
+
+TEST(CausalLMOpenAIProtocolTest, ParsesStreamingGenerationOptions) {
+  nlohmann::json payload = {
+    {"model", "qwen3-0.6b"},
+    {"messages", {{{"role", "user"}, {"content", "Hi"}}}},
+    {"stream", true},
+    {"temperature", 0.2},
+    {"top_p", 0.75},
+    {"max_tokens", 11},
+    {"stop", {"<END>", "</custom>"}},
+  };
+
+  auto request = causallm::openai::parseChatCompletionRequest(payload);
+
+  EXPECT_TRUE(request.stream);
+  ASSERT_TRUE(request.options.temperature.has_value());
+  EXPECT_FLOAT_EQ(*request.options.temperature, 0.2f);
+  ASSERT_TRUE(request.options.top_p.has_value());
+  EXPECT_FLOAT_EQ(*request.options.top_p, 0.75f);
+  ASSERT_TRUE(request.options.max_tokens.has_value());
+  EXPECT_EQ(*request.options.max_tokens, 11u);
+  ASSERT_EQ(request.options.stop.size(), 2u);
+  EXPECT_EQ(request.options.stop[0], "<END>");
+  EXPECT_EQ(request.options.stop[1], "</custom>");
+}
+
+TEST(CausalLMOpenAIProtocolTest, RejectsInvalidGenerationOptions) {
+  nlohmann::json zero_tokens = {
+    {"model", "qwen3-0.6b"},
+    {"messages", {{{"role", "user"}, {"content", "Hi"}}}},
+    {"max_tokens", 0},
+  };
+  nlohmann::json invalid_stream = {
+    {"model", "qwen3-0.6b"},
+    {"messages", {{{"role", "user"}, {"content", "Hi"}}}},
+    {"stream", "true"},
+  };
+  nlohmann::json huge_tokens = nlohmann::json::parse(
+    R"({"model":"qwen3-0.6b","messages":[{"role":"user","content":"Hi"}],"max_tokens":18446744073709551616})");
+
+  EXPECT_THROW(causallm::openai::parseChatCompletionRequest(zero_tokens),
+               std::invalid_argument);
+  EXPECT_THROW(causallm::openai::parseChatCompletionRequest(invalid_stream),
+               std::invalid_argument);
+  EXPECT_THROW(causallm::openai::parseChatCompletionRequest(huge_tokens),
+               std::invalid_argument);
+}
+
+TEST(CausalLMOpenAIProtocolTest, RejectsMissingModel) {
+  nlohmann::json payload = {
+    {"messages", {{{"role", "user"}, {"content", "Hi"}}}},
+  };
+
+  EXPECT_THROW(causallm::openai::parseChatCompletionRequest(payload),
+               std::invalid_argument);
+}
+
+TEST(CausalLMOpenAIProtocolTest, CleansReasoningAndSpecialEndToken) {
+  const std::string generated =
+    "<think>\nchecking\n</think>\n\nHello from NNTrainer! <|im_end|>\n";
+
+  EXPECT_EQ(causallm::openai::cleanGeneratedText(generated),
+            "Hello from NNTrainer!");
+}
+
+TEST(CausalLMOpenAIProtocolTest, BuildsChatCompletionResponseShape) {
+  auto response =
+    causallm::openai::makeChatCompletionResponse("qwen3-0.6b", "Hello.", 3, 2);
+
+  EXPECT_EQ(response["object"], "chat.completion");
+  EXPECT_EQ(response["model"], "qwen3-0.6b");
+  EXPECT_EQ(response["choices"][0]["message"]["role"], "assistant");
+  EXPECT_EQ(response["choices"][0]["message"]["content"], "Hello.");
+  EXPECT_EQ(response["usage"]["prompt_tokens"], 3);
+  EXPECT_EQ(response["usage"]["completion_tokens"], 2);
+}
+
+TEST(CausalLMOpenAIProtocolTest, BuildsChatCompletionChunkShape) {
+  auto role_chunk = causallm::openai::makeChatCompletionChunk(
+    "qwen3-0.6b", "assistant", "", "");
+  auto content_chunk =
+    causallm::openai::makeChatCompletionChunk("qwen3-0.6b", "", "Hello", "");
+  auto finish_chunk =
+    causallm::openai::makeChatCompletionChunk("qwen3-0.6b", "", "", "stop");
+
+  EXPECT_EQ(role_chunk["object"], "chat.completion.chunk");
+  EXPECT_EQ(role_chunk["choices"][0]["delta"]["role"], "assistant");
+  EXPECT_EQ(role_chunk["choices"][0]["finish_reason"], nullptr);
+  EXPECT_EQ(content_chunk["choices"][0]["delta"]["content"], "Hello");
+  EXPECT_EQ(finish_chunk["choices"][0]["delta"], nlohmann::json::object());
+  EXPECT_EQ(finish_chunk["choices"][0]["finish_reason"], "stop");
+}
+
+TEST(CausalLMOpenAIProtocolTest, StreamingFilterSuppressesThinkAndStops) {
+  causallm::openai::StreamingTextFilter filter({"<STOP>"}, false);
+
+  EXPECT_EQ(filter.push("<thi").text, "");
+  EXPECT_EQ(filter.push("nk>hidden</thi").text, "");
+  auto visible = filter.push("nk>Hel");
+  EXPECT_FALSE(visible.stop);
+  EXPECT_EQ(visible.text, "Hel");
+  auto stopped = filter.push("lo<ST");
+  EXPECT_FALSE(stopped.stop);
+  EXPECT_EQ(stopped.text, "lo");
+  stopped = filter.push("OP>ignored");
+  EXPECT_TRUE(stopped.stop);
+  EXPECT_EQ(stopped.text, "");
+  EXPECT_EQ(filter.flush(), "");
+}
+
+TEST(CausalLMOpenAIProtocolTest, StreamingFilterFlushesPartialStopPrefix) {
+  causallm::openai::StreamingTextFilter filter({"<STOP>"}, false);
+
+  auto visible = filter.push("Value <ST");
+
+  EXPECT_EQ(visible.text, "Value ");
+  EXPECT_FALSE(visible.stop);
+  EXPECT_EQ(filter.flush(), "<ST");
+}

--- a/test/unittest/models/unittest_causallm_qwen3.cpp
+++ b/test/unittest/models/unittest_causallm_qwen3.cpp
@@ -178,6 +178,21 @@ public:
   bool hasRun() const override { return causallm::CausalLM::hasRun(); }
 
   /**
+   * @brief Get current generation limit used by CausalLM
+   */
+  unsigned int currentGenerationLimit() const {
+    return NUM_TO_GENERATE > 0 ? static_cast<unsigned int>(NUM_TO_GENERATE)
+                               : 0U;
+  }
+
+  /**
+   * @brief Get generated token count reported by CausalLM
+   */
+  unsigned int generatedTokenCount() const {
+    return getPerformanceMetrics().generation_tokens;
+  }
+
+  /**
    * @brief Read one token from the Qwen3 input/output history
    */
   unsigned int tokenAt(size_t idx) const override { return ids_history[idx]; }
@@ -557,6 +572,47 @@ TEST_P(CausalLMTinyModelTest, WeightRoundTripProducesSameLogits) {
 TEST_P(CausalLMTinyModelTest, PromptProducesExpectedLogits) {
   const auto files = makeFiles();
   causallm_test::expectPromptProducesExpectedLogits(GetParam(), files);
+}
+
+/**
+ * @brief Test that max_tokens cannot exceed the initialized graph window
+ */
+TEST(Qwen3CausalLMTinyModelTest, MaxTokensOverrideIsClampedToGraphWindow) {
+  const auto files = causallm_test::makeTinyCausalLMFiles(
+    "Qwen3CausalLMTinyModelTest", "MaxTokensOverrideIsClampedToGraphWindow",
+    "Qwen3_FP32");
+  auto test_case = makeQwen3Case(causallm_test::makeTinyFp32DataType());
+  auto config =
+    causallm_test::makeTinyCausalLMConfig(test_case, files.tokenizer_path);
+  TinyQwen3CausalLM model(config.model, config.generation, config.nntrainer);
+
+  causallm::GenerationOverrides overrides;
+  overrides.max_tokens = 7U;
+  model.setGenerationOverrides(overrides);
+
+  EXPECT_EQ(model.currentGenerationLimit(), 1U);
+}
+
+/**
+ * @brief Test that max_tokens counts the token emitted from prefill
+ */
+TEST(Qwen3CausalLMTinyModelTest, MaxTokensIncludesPrefillToken) {
+  const auto files = causallm_test::makeTinyCausalLMFiles(
+    "Qwen3CausalLMTinyModelTest", "MaxTokensIncludesPrefillToken",
+    "Qwen3_FP32");
+  auto test_case = makeQwen3Case(causallm_test::makeTinyFp32DataType());
+  auto config =
+    causallm_test::makeTinyCausalLMConfig(test_case, files.tokenizer_path);
+  TinyQwen3CausalLM model(config.model, config.generation, config.nntrainer);
+  model.initializeModel();
+  model.setDeterministicWeights();
+
+  causallm::GenerationOverrides overrides;
+  overrides.max_tokens = 1U;
+  model.setGenerationOverrides(overrides);
+  model.run("hello", false, "", "", false);
+
+  EXPECT_EQ(model.generatedTokenCount(), 1U);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
- Add an opt-in quick.ai single-DLL C ABI target for external in-process runtime integration.
- Expose a small native C interface for model context, generation, embeddings, metrics, cancellation, errors, and versioning.
- Use OpenAI-style chat-completions and embeddings JSON request shapes inside the ABI, without adding REST serving.
- Preserve the existing executable build path by default and add package docs plus a minimal C sample.

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>