### PR TITLE
[CausalLM] Fix qwen3-0.6b weight_converter.py

### DIFF
--- a/Applications/CausalLM/res/qwen3/qwen3-0.6b/weight_converter.py
+++ b/Applications/CausalLM/res/qwen3/qwen3-0.6b/weight_converter.py
@@ -90,7 +90,7 @@ def save_qwen3_for_nntrainer(
         save_weight(params[f"{layer_name}post_attention_layernorm.weight"])
 
         # Keep the existing nntrainer binary weight order.
-        for proj in ["gate_proj", "up_proj", "down_proj"]:
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
             save_projection(layer_name, f"mlp.{proj}")
 
     save_weight(params["model.embed_tokens.weight"])


### PR DESCRIPTION
With #3949, we should use previous version of weight convert script.