### PR TITLE
[meson] Update compile configurations

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ title: Getting Started
 
 The following dependencies are needed to compile/build/run.
 
-* gcc/g++ >= 7 ( std=c++17 is used )
+* gcc/g++ >= 8 ( std=gnu17, std=c++17 is used )
    - (note)  >= 13 is recommended to enable fp16 support
 * meson >= 0.55.0
 * libopenblas-dev and base
@@ -29,6 +29,8 @@ sudo apt install nntrainer
 ```
 
 ## Clean build with pdebuild (Ubuntu 18.04)
+> [!WARNING]  
+> Ubuntu 18.04 is deprecated! Information below may be outdated.
 
 Use the NNStreamer PPA to resolve additional build-dependencies (Tensorflow/Tensorflow-Lite).
 

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('nntrainer', 'c', 'cpp',
   default_options: [
     'werror=true',
     'warning_level=1',
-    'c_std=gnu89',
+    'c_std=gnu17',
     'cpp_std=c++17',
     'buildtype=release'
   ]
@@ -75,7 +75,6 @@ warning_flags = [
   '-Wno-error=varargs',
   '-Wno-error=ignored-attributes',
   '-Wno-error=sign-compare',
-  '-Wdefaulted-function-deleted',
   '-ftree-vectorize',
   '-Wno-unused-variable',
   '-Wno-comment',
@@ -92,15 +91,16 @@ else
   warning_flags += '-Wno-maybe-uninitialized'
 endif
 
+warning_cxx_flags = [
+  '-Wdefaulted-function-deleted'
+]
+
 warning_c_flags = [
   '-Wmissing-declarations',
   '-Wmissing-include-dirs',
   '-Wmissing-prototypes',
   '-Wnested-externs',
-  '-Waggregate-return',
-  '-Wold-style-definition',
-  '-Wdeclaration-after-statement',
-  '-Wno-error=varargs'
+  '-Wold-style-definition'
 ]
 
 arch = host_machine.cpu_family()
@@ -287,6 +287,12 @@ if cc.get_id() != 'msvc' and cxx.get_id() != 'msvc'
     if cc.has_argument (extra_arg)
       add_project_arguments([extra_arg], language: 'c')
     endif
+    if cxx.has_argument (extra_arg)
+      add_project_arguments([extra_arg], language: 'cpp')
+    endif
+  endforeach
+
+  foreach extra_arg : warning_cxx_flags
     if cxx.has_argument (extra_arg)
       add_project_arguments([extra_arg], language: 'cpp')
     endif


### PR DESCRIPTION
This commit updates C/C++ compilation configurations.
* update C standard from gnu89 to gnu17
* trim warning options

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

---

nntrainer has used an old C standard `gnu89`. Let's update it to the default standard of ubuntu 22.04.