### PR TITLE
[Application] Add unified CausalLM weight converter

### DIFF
--- a/Applications/CausalLM/converter/README.md
+++ b/Applications/CausalLM/converter/README.md
@@ -33,6 +33,7 @@ Applications/CausalLM/
 | `gpt_oss`      | GPT-OSS 20B MoE | `AutoModelForCausalLM` | attn bias + sink, split `gate_up_proj` |
 | `kalm`         | KaLM-embedding | `SentenceTransformer` | Qwen2 backbone |
 | `deberta_v2`   | DeBERTa V2 encoder | `DebertaV2Model` / `SentenceTransformer` | encoder-only, relative attention |
+| `bert`         | (multilingual tiny) BERT encoder | `AutoModel` | encoder-only, optional pooler |
 | `vit`          | timm ViT | checkpoint file | `--model_path` is a `.safetensors`/`.bin` file |
 
 If `--model_type` is omitted, it is auto-detected from the HuggingFace config

--- a/Applications/CausalLM/converter/README.md
+++ b/Applications/CausalLM/converter/README.md
@@ -54,7 +54,7 @@ python converter/weight_converter.py \
 # float16 weights
 python converter/weight_converter.py --model_path Qwen/Qwen2-0.5B --data_type float16
 
-# safetensors output (Qwen3 only)
+# safetensors output (qwen2, qwen3, kalm, deberta_v2, bert)
 python converter/weight_converter.py --model_path Qwen/Qwen3-0.6B --safetensors
 
 # Embedding variants
@@ -78,7 +78,7 @@ python converter/weight_converter.py \
 | `--output_name` | `res/<model>/nntr_<model>_<dtype>.bin` | Output weight file path |
 | `--data_type` | `float32` | `float32` or `float16` |
 | `--model_type` | auto-detect | Override model type detection |
-| `--safetensors` | off | Save weights in safetensors format (Qwen3 only) |
+| `--safetensors` | off | Save weights in safetensors format (qwen2, qwen3, qwen3_moe via qwen3, kalm, deberta_v2, bert) |
 | `--patch_size` | `16` | (ViT only) patch size in pixels |
 | `--img_size` | `224` | (ViT only) input image size in pixels |
 

--- a/Applications/CausalLM/converter/README.md
+++ b/Applications/CausalLM/converter/README.md
@@ -1,0 +1,137 @@
+# NNTrainer CausalLM Weight Converter
+
+Unified weight conversion tool that converts HuggingFace / timm models into the
+NNTrainer weight format. A single entry point (`weight_converter.py`) dispatches
+to per-model converter modules based on the model type.
+
+## Layout
+
+```
+Applications/CausalLM/
+├── converter/                 # conversion code (this directory)
+│   ├── weight_converter.py    # unified entry point
+│   ├── utils.py               # shared helpers (tensor I/O, safetensors, config saving)
+│   ├── qwen2.py               # Qwen2 + KaLM-embedding
+│   ├── qwen3.py               # Qwen3 dense (binary + safetensors)
+│   ├── qwen3_moe.py           # Qwen3 MoE
+│   ├── gemma3.py              # Gemma3 causal + embedding
+│   ├── gpt_oss.py             # GPT-OSS 20B MoE
+│   ├── deberta_v2.py          # DeBERTa V2 encoder
+│   └── vit.py                 # timm ViT
+└── res/                       # default output location (weights + config JSON)
+```
+
+## Supported models
+
+| `--model_type` | Description | Loader | Notes |
+|----------------|-------------|--------|-------|
+| `qwen2`        | Qwen2 (e.g. `Qwen/Qwen2-0.5B`) | `AutoModelForCausalLM` | QKV bias, tied embedding |
+| `qwen3`        | Qwen3 dense (e.g. `Qwen/Qwen3-0.6B`, `Qwen3-4B`) | `AutoModelForCausalLM` | Q/K norm, supports safetensors output |
+| `qwen3_moe`    | Qwen3 MoE (e.g. `Qwen/Qwen3-30B-A3B`) | `AutoModelForCausalLM` | gate routing + per-expert FFN |
+| `gemma3`       | Gemma3 causal LM | `AutoModelForCausalLM` | RMSNorm (+1), pre/post FFN norm |
+| `gemma3_emb`   | Gemma3 embedding model | `SentenceTransformer` | embedding variant |
+| `gpt_oss`      | GPT-OSS 20B MoE | `AutoModelForCausalLM` | attn bias + sink, split `gate_up_proj` |
+| `kalm`         | KaLM-embedding | `SentenceTransformer` | Qwen2 backbone |
+| `deberta_v2`   | DeBERTa V2 encoder | `DebertaV2Model` / `SentenceTransformer` | encoder-only, relative attention |
+| `vit`          | timm ViT | checkpoint file | `--model_path` is a `.safetensors`/`.bin` file |
+
+If `--model_type` is omitted, it is auto-detected from the HuggingFace config
+(`config.model_type`). `gpt_oss` and `vit` usually need to be specified explicitly.
+
+## Usage
+
+```bash
+# From Applications/CausalLM/
+# Auto-detect model type; output defaults to res/<model>/nntr_<model>_<dtype>.bin
+python converter/weight_converter.py --model_path Qwen/Qwen3-0.6B
+
+# Explicit output path
+python converter/weight_converter.py \
+    --model_path Qwen/Qwen3-0.6B \
+    --output_name /tmp/nntr_qwen3.bin
+
+# float16 weights
+python converter/weight_converter.py --model_path Qwen/Qwen2-0.5B --data_type float16
+
+# safetensors output (Qwen3 only)
+python converter/weight_converter.py --model_path Qwen/Qwen3-0.6B --safetensors
+
+# Embedding variants
+python converter/weight_converter.py --model_path <kalm_id>   --model_type kalm
+python converter/weight_converter.py --model_path <gemma_id>  --model_type gemma3_emb
+
+# GPT-OSS (non-standard model_type → specify explicitly)
+python converter/weight_converter.py --model_path . --model_type gpt_oss
+
+# timm ViT — model_path is a checkpoint file, not an HF hub id
+python converter/weight_converter.py \
+    --model_path ./model.safetensors --model_type vit \
+    --patch_size 16 --img_size 224
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--model_path` | (required) | HF model id, local directory, or checkpoint file (ViT) |
+| `--output_name` | `res/<model>/nntr_<model>_<dtype>.bin` | Output weight file path |
+| `--data_type` | `float32` | `float32` or `float16` |
+| `--model_type` | auto-detect | Override model type detection |
+| `--safetensors` | off | Save weights in safetensors format (Qwen3 only) |
+| `--patch_size` | `16` | (ViT only) patch size in pixels |
+| `--img_size` | `224` | (ViT only) input image size in pixels |
+
+## Output files
+
+Every conversion writes the weight file plus companion files into the **same
+directory** as `--output_name`. By default each model gets its own subdirectory,
+`res/<model_name>/`, so all of a model's artifacts stay grouped together:
+
+| File | Source | When |
+|------|--------|------|
+| `nntr_<model>_<dtype>.bin` / `.safetensors` | converted weights | always |
+| `nntr_config.json` | generated runtime config | always |
+| `config.json` | `hf_config.save_pretrained()` | HF models |
+| `generation_config.json` | `GenerationConfig.from_pretrained()` | if the model ships one |
+| `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json` | `AutoTokenizer.save_pretrained()` | HF models |
+| `chat_template.jinja` | tokenizer | if the model defines a chat template |
+
+The tokenizer (including the **chat template**) is re-emitted via
+`save_pretrained`, so it follows the model automatically even when the source
+repo only ships the standalone template file. This keeps the output directory
+self-contained — `nntr_config.json`'s `tokenizer_file` points to the
+`tokenizer.json` saved alongside it.
+
+ViT loads from a checkpoint file (`--model_path` is not an HF directory), so it
+skips `config.json` / `generation_config.json` / tokenizer saving and sets
+`skip_tokenizer: true` in `nntr_config.json`.
+
+## Adding a new model
+
+1. Create `converter/<model>.py` exposing:
+
+   ```python
+   def convert(model_path, output_name, dtype, **kwargs):
+       ...
+   ```
+
+2. Use the shared helpers in `utils.py`:
+   - `save_tensor(file, tensor, dtype, transpose=False, add_one=False)`
+   - `save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)`
+   - `save_safetensors(weights, output_path, dtype)` (for safetensors output)
+   - `save_configs(output_name, dtype, hf_config=, model_path=, nntr_extra=)`
+
+3. Define a module-level `SAMPLE_INPUT` constant and pass it through `nntr_extra`.
+
+4. Register the model type in `_MODULE_MAP` (and `_EXTRA_KWARGS` if it needs
+   extra flags) in `weight_converter.py`.
+
+## Verification
+
+There is no automatic numerical test bundled here. To validate a new or changed
+converter, compare its byte output against a known-good reference:
+
+```bash
+python converter/weight_converter.py --model_path <id> --output_name new.bin
+cmp old.bin new.bin   # no output means the files are identical
+```

--- a/Applications/CausalLM/converter/README.md
+++ b/Applications/CausalLM/converter/README.md
@@ -28,7 +28,7 @@ Applications/CausalLM/
 | `qwen2`        | Qwen2 (e.g. `Qwen/Qwen2-0.5B`) | `AutoModelForCausalLM` | QKV bias, tied embedding |
 | `qwen3`        | Qwen3 dense (e.g. `Qwen/Qwen3-0.6B`, `Qwen3-4B`) | `AutoModelForCausalLM` | Q/K norm, supports safetensors output |
 | `qwen3_moe`    | Qwen3 MoE (e.g. `Qwen/Qwen3-30B-A3B`) | `AutoModelForCausalLM` | gate routing + per-expert FFN |
-| `gemma3`       | Gemma3 causal LM | `AutoModelForCausalLM` | RMSNorm (+1), pre/post FFN norm |
+| `gemma3` / `gemma3_text` | Gemma3 causal LM | `AutoModelForCausalLM` | RMSNorm (+1), pre/post FFN norm; text-only configs report `gemma3_text` |
 | `gemma3_emb`   | Gemma3 embedding model | `SentenceTransformer` | embedding variant |
 | `gpt_oss`      | GPT-OSS 20B MoE | `AutoModelForCausalLM` | attn bias + sink, split `gate_up_proj` |
 | `kalm`         | KaLM-embedding | `SentenceTransformer` | Qwen2 backbone |

--- a/Applications/CausalLM/converter/deberta_v2.py
+++ b/Applications/CausalLM/converter/deberta_v2.py
@@ -110,4 +110,5 @@ def convert(model_path, output_name, dtype, **kwargs):
         "model_type": "embedding",
         "sample_input": SAMPLE_INPUT,
     }
-    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path,
+                 nntr_extra=nntr_extra, sentence_transformer=True)

--- a/Applications/CausalLM/converter/deberta_v2.py
+++ b/Applications/CausalLM/converter/deberta_v2.py
@@ -5,9 +5,70 @@ import numpy as np
 import torch
 from pathlib import Path
 
-from utils import save_configs
+from utils import save_configs, tensor_to_numpy, get_safetensors_output_name, save_safetensors
 
 SAMPLE_INPUT = "This is an example sentence"
+
+
+def _uses_relative_bias(config):
+    pos_att_type = getattr(config, "pos_att_type", None) or []
+    return getattr(config, "relative_attention", False) and (
+        "c2p" in pos_att_type or "p2c" in pos_att_type
+    )
+
+
+def _norm_rel(config):
+    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none") or "none"
+    return "layer_norm" in norm_rel_ebd.lower()
+
+
+def _collect_safetensors(params, config, dtype):
+    """Collect (nntrainer_name, ndarray) pairs for safetensors export.
+
+    safetensors is name-based, so ordering does not matter for loading.
+    """
+    uses_rel = _uses_relative_bias(config)
+    norm_rel = _norm_rel(config)
+
+    weights = []
+
+    def add(name, hf_key, transpose=False):
+        weights.append((name, tensor_to_numpy(params[hf_key], dtype, transpose=transpose)))
+
+    add("embedding0:Embedding", "embeddings.word_embeddings.weight")
+    add("embeddings_norm:gamma", "embeddings.LayerNorm.weight")
+    add("embeddings_norm:beta", "embeddings.LayerNorm.bias")
+
+    for i in range(config.num_hidden_layers):
+        hf = f"encoder.layer.{i}."
+        nn = f"layer{i}"
+        sa = f"{hf}attention.self."
+
+        add(f"{nn}_wq:weight", f"{sa}query_proj.weight", transpose=True)
+        add(f"{nn}_wq:bias", f"{sa}query_proj.bias")
+        add(f"{nn}_wk:weight", f"{sa}key_proj.weight", transpose=True)
+        add(f"{nn}_wk:bias", f"{sa}key_proj.bias")
+        add(f"{nn}_wv:weight", f"{sa}value_proj.weight", transpose=True)
+        add(f"{nn}_wv:bias", f"{sa}value_proj.bias")
+
+        if i == 0 and uses_rel:
+            add("rel_embeddings:weight", "encoder.rel_embeddings.weight")
+            if norm_rel:
+                add("rel_embeddings_norm:gamma", "encoder.LayerNorm.weight")
+                add("rel_embeddings_norm:beta", "encoder.LayerNorm.bias")
+
+        add(f"{nn}_attention_out:weight", f"{hf}attention.output.dense.weight", transpose=True)
+        add(f"{nn}_attention_out:bias", f"{hf}attention.output.dense.bias")
+        add(f"{nn}_attention_norm:gamma", f"{hf}attention.output.LayerNorm.weight")
+        add(f"{nn}_attention_norm:beta", f"{hf}attention.output.LayerNorm.bias")
+        add(f"{nn}_intermediate:weight", f"{hf}intermediate.dense.weight", transpose=True)
+        add(f"{nn}_intermediate:bias", f"{hf}intermediate.dense.bias")
+        add(f"{nn}_output_dense:weight", f"{hf}output.dense.weight", transpose=True)
+        add(f"{nn}_output_dense:bias", f"{hf}output.dense.bias")
+        add(f"{nn}_output:gamma", f"{hf}output.LayerNorm.weight")
+        add(f"{nn}_output:beta", f"{hf}output.LayerNorm.bias")
+
+    return weights
 
 
 def _to_numpy(weight, dtype):
@@ -100,20 +161,27 @@ def _load(model_path):
 
 def convert(model_path, output_name, dtype, **kwargs):
     """Convert DeBERTa V2 weights to nntrainer binary format."""
+    use_safetensors = kwargs.get("safetensors", False)
     np_dtype = np.float16 if dtype == "float16" else np.float32
     config, params = _load(model_path)
 
-    output_path = Path(output_name)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with torch.no_grad(), output_path.open("wb") as f:
-        _save_weights(params, config, np_dtype, f)
-
-    print(f"Saved binary: {output_name}")
+    with torch.no_grad():
+        if use_safetensors:
+            effective_output = get_safetensors_output_name(output_name)
+            Path(effective_output).parent.mkdir(parents=True, exist_ok=True)
+            weights = _collect_safetensors(params, config, dtype)
+            save_safetensors(weights, effective_output, dtype)
+        else:
+            effective_output = output_name
+            output_path = Path(output_name)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with output_path.open("wb") as f:
+                _save_weights(params, config, np_dtype, f)
+            print(f"Saved binary: {output_name}")
 
     nntr_extra = {
         "model_type": "embedding",
         "sample_input": SAMPLE_INPUT,
     }
-    save_configs(output_name, dtype, hf_config=config, model_path=model_path,
+    save_configs(effective_output, dtype, hf_config=config, model_path=model_path,
                  nntr_extra=nntr_extra, sentence_transformer=True)

--- a/Applications/CausalLM/converter/deberta_v2.py
+++ b/Applications/CausalLM/converter/deberta_v2.py
@@ -24,17 +24,29 @@ def _save_linear(file, params, prefix, dtype):
 
 
 def _save_weights(params, config, dtype, file):
+    """Save DeBERTa V2 encoder weights in nntrainer layer order.
+
+    Order matches the graph construction sequence in deberta_v2.cpp:
+      embeddings (word + LayerNorm)
+      encoder.rel_embeddings.weight        <- global, before any layer
+      [encoder.LayerNorm] if norm_rel_ebd contains "layer_norm"
+      per layer: query_proj key_proj value_proj
+                 attention.output.dense attention.output.LayerNorm
+                 intermediate.dense output.dense output.LayerNorm
+    """
     _save_weight(file, params["embeddings.word_embeddings.weight"], dtype)
     _save_weight(file, params["embeddings.LayerNorm.weight"], dtype)
     _save_weight(file, params["embeddings.LayerNorm.bias"], dtype)
 
-    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none").lower().split("|")
-    norm_rel_ebd = [item.strip() for item in norm_rel_ebd]
-    pos_att_type = getattr(config, "pos_att_type", None) or []
-    uses_relative_bias = getattr(config, "relative_attention", False) and (
-        "c2p" in pos_att_type or "p2c" in pos_att_type
-    )
-    saved_relative_embeddings = False
+    # Relative embeddings are a single global tensor created before the encoder
+    # loop in constructTransformerModule(), so they are saved here — before any
+    # per-layer weights.
+    _save_weight(file, params["encoder.rel_embeddings.weight"], dtype)
+
+    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none") or "none"
+    if "layer_norm" in norm_rel_ebd.lower():
+        _save_weight(file, params["encoder.LayerNorm.weight"], dtype)
+        _save_weight(file, params["encoder.LayerNorm.bias"], dtype)
 
     for i in range(config.num_hidden_layers):
         layer_prefix = f"encoder.layer.{i}"
@@ -44,14 +56,7 @@ def _save_weights(params, config, dtype, file):
         _save_linear(file, params, f"{self_prefix}.query_proj", dtype)
         _save_linear(file, params, f"{self_prefix}.key_proj", dtype)
         _save_linear(file, params, f"{self_prefix}.value_proj", dtype)
-
-        if uses_relative_bias and not saved_relative_embeddings:
-            _save_weight(file, params["encoder.rel_embeddings.weight"], dtype)
-            if "layer_norm" in norm_rel_ebd:
-                _save_weight(file, params["encoder.LayerNorm.weight"], dtype)
-                _save_weight(file, params["encoder.LayerNorm.bias"], dtype)
-            saved_relative_embeddings = True
-
+        # wq_rel/wk_rel share weights with wq/wk; deberta_attention has no params.
         _save_linear(file, params, f"{attn_prefix}.output.dense", dtype)
         _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.weight"], dtype)
         _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.bias"], dtype)

--- a/Applications/CausalLM/converter/deberta_v2.py
+++ b/Applications/CausalLM/converter/deberta_v2.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import numpy as np
+import torch
+from pathlib import Path
+
+from utils import save_configs
+
+SAMPLE_INPUT = "This is an example sentence"
+
+
+def _to_numpy(weight, dtype):
+    return weight.detach().cpu().numpy().astype(dtype, copy=False)
+
+
+def _save_weight(file, weight, dtype):
+    _to_numpy(weight, dtype).tofile(file)
+
+
+def _save_linear(file, params, prefix, dtype):
+    _save_weight(file, params[f"{prefix}.weight"].transpose(0, 1), dtype)
+    _save_weight(file, params[f"{prefix}.bias"], dtype)
+
+
+def _save_weights(params, config, dtype, file):
+    _save_weight(file, params["embeddings.word_embeddings.weight"], dtype)
+    _save_weight(file, params["embeddings.LayerNorm.weight"], dtype)
+    _save_weight(file, params["embeddings.LayerNorm.bias"], dtype)
+
+    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none").lower().split("|")
+    norm_rel_ebd = [item.strip() for item in norm_rel_ebd]
+    pos_att_type = getattr(config, "pos_att_type", None) or []
+    uses_relative_bias = getattr(config, "relative_attention", False) and (
+        "c2p" in pos_att_type or "p2c" in pos_att_type
+    )
+    saved_relative_embeddings = False
+
+    for i in range(config.num_hidden_layers):
+        layer_prefix = f"encoder.layer.{i}"
+        attn_prefix = f"{layer_prefix}.attention"
+        self_prefix = f"{attn_prefix}.self"
+
+        _save_linear(file, params, f"{self_prefix}.query_proj", dtype)
+        _save_linear(file, params, f"{self_prefix}.key_proj", dtype)
+        _save_linear(file, params, f"{self_prefix}.value_proj", dtype)
+
+        if uses_relative_bias and not saved_relative_embeddings:
+            _save_weight(file, params["encoder.rel_embeddings.weight"], dtype)
+            if "layer_norm" in norm_rel_ebd:
+                _save_weight(file, params["encoder.LayerNorm.weight"], dtype)
+                _save_weight(file, params["encoder.LayerNorm.bias"], dtype)
+            saved_relative_embeddings = True
+
+        _save_linear(file, params, f"{attn_prefix}.output.dense", dtype)
+        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.weight"], dtype)
+        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.bias"], dtype)
+        _save_linear(file, params, f"{layer_prefix}.intermediate.dense", dtype)
+        _save_linear(file, params, f"{layer_prefix}.output.dense", dtype)
+        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.weight"], dtype)
+        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.bias"], dtype)
+
+
+def _strip_encoder_prefix(params):
+    if "embeddings.word_embeddings.weight" in params:
+        return params
+    prefixes = (
+        "0.auto_model.",
+        "0.auto_model.deberta.",
+        "auto_model.",
+        "auto_model.deberta.",
+        "deberta.",
+    )
+    for prefix in prefixes:
+        key = prefix + "embeddings.word_embeddings.weight"
+        if key in params:
+            return {name[len(prefix):]: value for name, value in params.items() if name.startswith(prefix)}
+    raise KeyError("Cannot find DeBERTa V2 encoder weights in state_dict")
+
+
+def _load(model_path):
+    from transformers import DebertaV2Model
+    try:
+        model = DebertaV2Model.from_pretrained(model_path)
+        params = model.deberta.state_dict() if hasattr(model, "deberta") else model.state_dict()
+        return model.config, _strip_encoder_prefix(params)
+    except Exception:
+        from sentence_transformers import SentenceTransformer
+        st = SentenceTransformer(model_path, trust_remote_code=True)
+        auto_model = getattr(st[0], "auto_model", None)
+        if auto_model is None:
+            raise AttributeError("first SentenceTransformer module has no auto_model")
+        return auto_model.config, _strip_encoder_prefix(st.state_dict())
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert DeBERTa V2 weights to nntrainer binary format."""
+    np_dtype = np.float16 if dtype == "float16" else np.float32
+    config, params = _load(model_path)
+
+    output_path = Path(output_name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with torch.no_grad(), output_path.open("wb") as f:
+        _save_weights(params, config, np_dtype, f)
+
+    print(f"Saved binary: {output_name}")
+
+    nntr_extra = {
+        "model_type": "embedding",
+        "sample_input": SAMPLE_INPUT,
+    }
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/gemma3.py
+++ b/Applications/CausalLM/converter/gemma3.py
@@ -114,4 +114,5 @@ def convert(model_path, output_name, dtype, **kwargs):
         }
 
     print(f"Saved binary: {output_name}")
-    save_configs(output_name, dtype, hf_config=hf_config, model_path=model_path, nntr_extra=nntr_extra)
+    save_configs(output_name, dtype, hf_config=hf_config, model_path=model_path,
+                 nntr_extra=nntr_extra, sentence_transformer=is_embedding)

--- a/Applications/CausalLM/converter/gemma3.py
+++ b/Applications/CausalLM/converter/gemma3.py
@@ -4,9 +4,14 @@
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from utils import save_tensor, save_lora_or_weight, save_configs
+from utils import save_tensor, save_lora_or_weight, save_configs, make_chat_input
 
-SAMPLE_INPUT = "Explain the concept of AI"
+# Plain user question; the chat_template is applied at inference time via chat_input.
+CHAT_QUESTION = "Explain the concept of AI"
+# Gemma3 chat-formatted fallback, used only when no chat_template is available.
+SAMPLE_INPUT = (
+    "<start_of_turn>user\nExplain the concept of AI<end_of_turn>\n<start_of_turn>model\n"
+)
 # Embedding variant — use a plain sentence to embed.
 SAMPLE_INPUT_EMBEDDING = "This is an example sentence"
 
@@ -105,6 +110,7 @@ def convert(model_path, output_name, dtype, **kwargs):
         nntr_extra = {
             "model_type": "CausalLM",
             "sample_input": SAMPLE_INPUT,
+            "chat_input": make_chat_input(CHAT_QUESTION),
         }
 
     print(f"Saved binary: {output_name}")

--- a/Applications/CausalLM/converter/gemma3.py
+++ b/Applications/CausalLM/converter/gemma3.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from utils import save_tensor, save_lora_or_weight, save_configs
+
+SAMPLE_INPUT = "Explain the concept of AI"
+# Embedding variant — use a plain sentence to embed.
+SAMPLE_INPUT_EMBEDDING = "This is an example sentence"
+
+
+def _save_weights(params, config, dtype, file, save_lm_head=True):
+    n_layers = config.num_hidden_layers
+
+    def save(tensor, is_rms=False):
+        save_tensor(file, tensor, dtype, add_one=is_rms)
+
+    def save_proj(layer_name, proj_name):
+        save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)
+
+    def save_attention(layer_name):
+        save(params[f"{layer_name}input_layernorm.weight"], is_rms=True)
+        save_proj(layer_name, "self_attn.q_proj")
+        q_norm = f"{layer_name}self_attn.q_norm.weight"
+        if q_norm in params:
+            save(params[q_norm], is_rms=True)
+        save_proj(layer_name, "self_attn.k_proj")
+        k_norm = f"{layer_name}self_attn.k_norm.weight"
+        if k_norm in params:
+            save(params[k_norm], is_rms=True)
+        save_proj(layer_name, "self_attn.v_proj")
+        save_proj(layer_name, "self_attn.o_proj")
+
+    def save_feed_forward(layer_name):
+        save(params[f"{layer_name}post_attention_layernorm.weight"], is_rms=True)
+        save(params[f"{layer_name}pre_feedforward_layernorm.weight"], is_rms=True)
+        for proj in ["gate_proj", "up_proj", "down_proj"]:
+            save_proj(layer_name, f"mlp.{proj}")
+        save(params[f"{layer_name}post_feedforward_layernorm.weight"], is_rms=True)
+
+    save(params["model.embed_tokens.weight"])
+
+    for i in range(n_layers):
+        layer_name = f"model.layers.{i}."
+        save_attention(layer_name)
+        save_feed_forward(layer_name)
+
+    save(params["model.norm.weight"], is_rms=True)
+
+    if save_lm_head and "lm_head.weight" in params:
+        save_tensor(file, params["lm_head.weight"], dtype, transpose=True)
+
+
+def _save_embedding_model(model, dtype, file):
+    """Save Gemma3-backed SentenceTransformer embedding model."""
+    raw_params = model.state_dict()
+    gemma_params = {
+        key.removeprefix("0.auto_model.").removeprefix("0."): value
+        for key, value in raw_params.items()
+        if key.startswith("0.")
+    }
+    _save_weights(gemma_params, model[0].auto_model.config, dtype, file, save_lm_head=False)
+
+    for module_name, module in model._modules.items():
+        component = module.__class__.__name__
+        if component in ["Transformer", "Pooling", "Normalize"]:
+            continue
+        if component != "Dense":
+            raise NotImplementedError(f"Unsupported SentenceTransformer module: {module_name} ({component})")
+        save_tensor(file, raw_params[f"{module_name}.linear.weight"], dtype, transpose=True)
+        bias_key = f"{module_name}.linear.bias"
+        if bias_key in raw_params:
+            save_tensor(file, raw_params[bias_key], dtype)
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert Gemma3 weights to nntrainer binary format.
+
+    Pass is_embedding=True (or --embedding_model CLI flag) to load as a
+    SentenceTransformer embedding model instead of AutoModelForCausalLM.
+    """
+    is_embedding = kwargs.get("is_embedding", False)
+
+    if is_embedding:
+        from sentence_transformers import SentenceTransformer
+        torch_dtype = torch.float16 if dtype == "float16" else torch.float32
+        model = SentenceTransformer(model_path, trust_remote_code=True, model_kwargs={"torch_dtype": torch_dtype})
+        model.eval()
+        hf_config = model[0].auto_model.config
+        with open(output_name, "wb") as f:
+            _save_embedding_model(model, dtype, f)
+        nntr_extra = {
+            "model_type": "embedding",
+            "sample_input": SAMPLE_INPUT_EMBEDDING,
+        }
+    else:
+        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+        model.eval()
+        save_lm_head = not getattr(hf_config, "tie_word_embeddings", False)
+        with open(output_name, "wb") as f:
+            _save_weights(model.state_dict(), hf_config, dtype, f, save_lm_head=save_lm_head)
+        nntr_extra = {
+            "model_type": "CausalLM",
+            "sample_input": SAMPLE_INPUT,
+        }
+
+    print(f"Saved binary: {output_name}")
+    save_configs(output_name, dtype, hf_config=hf_config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/gpt_oss.py
+++ b/Applications/CausalLM/converter/gpt_oss.py
@@ -4,7 +4,9 @@
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from utils import save_tensor, save_lora_or_weight, save_configs
+from utils import save_tensor, save_lora_or_weight, save_configs, make_chat_input
+
+CHAT_QUESTION = "What is on-device AI?"
 
 
 SAMPLE_INPUT = (
@@ -77,5 +79,6 @@ def convert(model_path, output_name, dtype, **kwargs):
         "model_type": "CausalLM",
         "lmhead_dtype": "FP32" if dtype == "float32" else "FP16",
         "sample_input": SAMPLE_INPUT,
+        "chat_input": make_chat_input(CHAT_QUESTION),
     }
     save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/gpt_oss.py
+++ b/Applications/CausalLM/converter/gpt_oss.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from utils import save_tensor, save_lora_or_weight, save_configs
+
+
+SAMPLE_INPUT = (
+    "<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.\n"
+    "Knowledge cutoff: 2024-06\nCurrent date: 2025-09-10\n\nReasoning: low\n\n"
+    "# Valid channels: analysis, commentary, final. Channel must be included for every message."
+    "<|end|><|start|>user<|message|>What is on-device AI?<|im_end|>\n<|end|><|start|>assistant"
+)
+
+
+def _save_weights(params, config, dtype, file):
+    n_experts = config.num_local_experts
+
+    def save(name, transpose=False):
+        save_tensor(file, params[name], dtype, transpose=transpose)
+
+    def save_proj(layer_name, proj_name):
+        save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)
+
+    def save_attention(layer_name):
+        for proj in ["q_proj", "k_proj", "v_proj"]:
+            save_proj(layer_name, f"self_attn.{proj}")
+            save(f"{layer_name}self_attn.{proj}.bias")
+        save(f"{layer_name}self_attn.sinks")
+        save_proj(layer_name, "self_attn.o_proj")
+        save(f"{layer_name}self_attn.o_proj.bias")
+
+    def save_feed_forward(layer_name):
+        save(f"{layer_name}mlp.router.weight", transpose=True)
+        save(f"{layer_name}mlp.router.bias")
+
+        gate_up = params[f"{layer_name}mlp.experts.gate_up_proj"]
+        gate_up_bias = params[f"{layer_name}mlp.experts.gate_up_proj_bias"]
+        down = params[f"{layer_name}mlp.experts.down_proj"]
+        down_bias = params[f"{layer_name}mlp.experts.down_proj_bias"]
+        for n in range(n_experts):
+            # gate_up_proj interleaves up (odd) and gate (even) columns.
+            save_tensor(file, gate_up[..., 1::2][n], dtype)       # up_proj
+            save_tensor(file, gate_up_bias[..., 1::2][n], dtype)
+            save_tensor(file, gate_up[..., ::2][n], dtype)        # gate_proj
+            save_tensor(file, gate_up_bias[..., ::2][n], dtype)
+            save_tensor(file, down[n], dtype)                     # down_proj
+            save_tensor(file, down_bias[n], dtype)
+
+    save("model.embed_tokens.weight")
+
+    for i in range(config.num_hidden_layers):
+        layer_name = f"model.layers.{i}."
+        save(f"{layer_name}input_layernorm.weight")
+        save_attention(layer_name)
+        save(f"{layer_name}post_attention_layernorm.weight")
+        save_feed_forward(layer_name)
+
+    save("model.norm.weight")
+    save("lm_head.weight", transpose=True)
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert GPT-OSS 20B MoE weights to nntrainer binary format."""
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+    model.eval()
+
+    with open(output_name, "wb") as f:
+        _save_weights(model.state_dict(), config, dtype, f)
+
+    print(f"Saved binary: {output_name}")
+
+    nntr_extra = {
+        "model_type": "CausalLM",
+        "lmhead_dtype": "FP32" if dtype == "float32" else "FP16",
+        "sample_input": SAMPLE_INPUT,
+    }
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen2.py
+++ b/Applications/CausalLM/converter/qwen2.py
@@ -108,4 +108,5 @@ def convert(model_path, output_name, dtype, **kwargs):
         nntr_extra["is_causal"] = False
     else:
         nntr_extra["chat_input"] = make_chat_input(CHAT_QUESTION)
-    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path,
+                 nntr_extra=nntr_extra, sentence_transformer=is_kalm)

--- a/Applications/CausalLM/converter/qwen2.py
+++ b/Applications/CausalLM/converter/qwen2.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from utils import save_tensor, save_lora_or_weight, save_configs, get_tie_word_embeddings
+
+# Qwen2 chat template prompt for causal generation.
+SAMPLE_INPUT = (
+    "<|im_start|>user\nGive me a short introduction to large language model."
+    "<|im_end|>\n<|im_start|>assistant\n"
+)
+# KaLM is an embedding model — use a plain sentence instead of a chat prompt.
+SAMPLE_INPUT_KALM = "This is an example sentence"
+
+
+def _save_weights(params, n_layers, dtype, file, layer_prefix_fn=None, save_lm_head=False):
+    """Core Qwen2-architecture weight saver.
+
+    layer_prefix_fn: callable(layer_idx) -> str. Defaults to standard HF naming.
+    The KaLM-embedding model uses '0.auto_model.layers.{i}.' prefix instead.
+    save_lm_head: save lm_head.weight separately (only when embeddings are NOT tied).
+    """
+    if layer_prefix_fn is None:
+        layer_prefix_fn = lambda i: f"model.layers.{i}."
+
+    def save(tensor, transpose=False):
+        save_tensor(file, tensor, dtype, transpose=transpose)
+
+    def save_proj(layer_name, proj_name):
+        save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)
+
+    def save_attention(layer_name):
+        save(params[f"{layer_name}input_layernorm.weight"])
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            save_proj(layer_name, f"self_attn.{proj}")
+            if proj != "o_proj":
+                save(params[f"{layer_name}self_attn.{proj}.bias"])
+
+    def save_feed_forward(layer_name):
+        save(params[f"{layer_name}post_attention_layernorm.weight"])
+        for proj in ["gate_proj", "up_proj", "down_proj"]:
+            save_proj(layer_name, f"mlp.{proj}")
+
+    embed_key = "0.auto_model.embed_tokens.weight" if "0.auto_model.embed_tokens.weight" in params else "model.embed_tokens.weight"
+    save(params[embed_key])
+
+    for i in range(n_layers):
+        layer_name = layer_prefix_fn(i)
+        save_attention(layer_name)
+        save_feed_forward(layer_name)
+
+    norm_key = "0.auto_model.norm.weight" if "0.auto_model.norm.weight" in params else "model.norm.weight"
+    save(params[norm_key])
+
+    # For tied-embedding models (e.g. Qwen2-0.5B, Qwen2.5-0.5B/1.5B) lm_head shares
+    # model.embed_tokens.weight and is not saved separately. Larger Qwen2.5 variants
+    # (3B/7B/...) set tie_word_embeddings=false and ship a separate lm_head.weight.
+    if save_lm_head and "lm_head.weight" in params:
+        save(params["lm_head.weight"], transpose=True)
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert Qwen2 (or KaLM-embedding) weights to nntrainer binary format."""
+    is_kalm = kwargs.get("is_kalm", False)
+
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+
+    if is_kalm:
+        from sentence_transformers import SentenceTransformer
+        model = SentenceTransformer(model_path, trust_remote_code=True, model_kwargs={"torch_dtype": torch.float32})
+        model.eval()
+        layer_prefix_fn = lambda i: f"0.auto_model.layers.{i}."
+        # KaLM is an embedding model — no lm_head.
+        save_lm_head = False
+    else:
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+        model.eval()
+        layer_prefix_fn = None
+        # Save lm_head only when embeddings are not tied (e.g. Qwen2.5-3B/7B/...).
+        save_lm_head = not get_tie_word_embeddings(config)
+        print(f"tie_word_embeddings: {not save_lm_head}")
+
+    params = model.state_dict()
+
+    with open(output_name, "wb") as f:
+        _save_weights(params, config.num_hidden_layers, dtype, f,
+                      layer_prefix_fn=layer_prefix_fn, save_lm_head=save_lm_head)
+
+    print(f"Saved binary: {output_name}")
+
+    nntr_extra = {
+        "model_type": "embedding" if is_kalm else "CausalLM",
+        "sample_input": SAMPLE_INPUT_KALM if is_kalm else SAMPLE_INPUT,
+    }
+    if is_kalm:
+        nntr_extra["is_causal"] = False
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen2.py
+++ b/Applications/CausalLM/converter/qwen2.py
@@ -4,9 +4,17 @@
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from utils import save_tensor, save_lora_or_weight, save_configs, get_tie_word_embeddings
+from utils import (
+    save_tensor,
+    save_lora_or_weight,
+    save_configs,
+    get_tie_word_embeddings,
+    make_chat_input,
+)
 
-# Qwen2 chat template prompt for causal generation.
+# Plain user question; the chat_template is applied at inference time via chat_input.
+CHAT_QUESTION = "Give me a short introduction to large language model."
+# Pre-formatted fallback used only when no chat_template is available.
 SAMPLE_INPUT = (
     "<|im_start|>user\nGive me a short introduction to large language model."
     "<|im_end|>\n<|im_start|>assistant\n"
@@ -98,4 +106,6 @@ def convert(model_path, output_name, dtype, **kwargs):
     }
     if is_kalm:
         nntr_extra["is_causal"] = False
+    else:
+        nntr_extra["chat_input"] = make_chat_input(CHAT_QUESTION)
     save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen2.py
+++ b/Applications/CausalLM/converter/qwen2.py
@@ -40,7 +40,9 @@ def _save_weights(params, n_layers, dtype, file, layer_prefix_fn=None, save_lm_h
 
     def save_feed_forward(layer_name):
         save(params[f"{layer_name}post_attention_layernorm.weight"])
-        for proj in ["gate_proj", "up_proj", "down_proj"]:
+        # nntrainer's createMlp builds ffn_up before ffn_gate, so the binary must
+        # store mlp weights in up, gate, down order (see models/transformer.cpp).
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
             save_proj(layer_name, f"mlp.{proj}")
 
     embed_key = "0.auto_model.embed_tokens.weight" if "0.auto_model.embed_tokens.weight" in params else "model.embed_tokens.weight"

--- a/Applications/CausalLM/converter/qwen2.py
+++ b/Applications/CausalLM/converter/qwen2.py
@@ -10,6 +10,9 @@ from utils import (
     save_configs,
     get_tie_word_embeddings,
     make_chat_input,
+    tensor_to_numpy,
+    get_safetensors_output_name,
+    save_safetensors,
 )
 
 # Plain user question; the chat_template is applied at inference time via chat_input.
@@ -71,9 +74,54 @@ def _save_weights(params, n_layers, dtype, file, layer_prefix_fn=None, save_lm_h
         save(params["lm_head.weight"], transpose=True)
 
 
+def _collect_safetensors(params, n_layers, dtype, layer_prefix_fn=None, save_lm_head=False):
+    """Collect (nntrainer_name, ndarray) pairs for safetensors export."""
+    if layer_prefix_fn is None:
+        layer_prefix_fn = lambda i: f"model.layers.{i}."
+    embed_key = "0.auto_model.embed_tokens.weight" if "0.auto_model.embed_tokens.weight" in params else "model.embed_tokens.weight"
+    norm_key = "0.auto_model.norm.weight" if "0.auto_model.norm.weight" in params else "model.norm.weight"
+
+    weights = []
+
+    def add(name, tensor, transpose=False):
+        weights.append((name, tensor_to_numpy(tensor, dtype, transpose=transpose)))
+
+    def add_proj(nntr_name, layer_name, proj_name):
+        prefix = f"{layer_name}{proj_name}"
+        if f"{prefix}.lora_A.default.weight" in params:
+            add(nntr_name, params[f"{prefix}.base_layer.weight"], transpose=True)
+        else:
+            add(nntr_name, params[f"{prefix}.weight"], transpose=True)
+
+    add("embedding0:Embedding", params[embed_key])
+
+    for i in range(n_layers):
+        hf = layer_prefix_fn(i)
+        p = f"layer{i}"
+        add(f"{p}_attention_norm:gamma", params[f"{hf}input_layernorm.weight"])
+        for proj, nntr in [("q_proj", "wq"), ("k_proj", "wk"), ("v_proj", "wv")]:
+            add_proj(f"{p}_{nntr}:weight", hf, f"self_attn.{proj}")
+            bias_key = f"{hf}self_attn.{proj}.bias"
+            if bias_key in params:
+                add(f"{p}_{nntr}:bias", params[bias_key])
+        add_proj(f"{p}_attention_out:weight", hf, "self_attn.o_proj")
+        add(f"{p}_ffn_norm:gamma", params[f"{hf}post_attention_layernorm.weight"])
+        add_proj(f"{p}_ffn_up:weight", hf, "mlp.up_proj")
+        add_proj(f"{p}_ffn_gate:weight", hf, "mlp.gate_proj")
+        add_proj(f"{p}_ffn_down:weight", hf, "mlp.down_proj")
+
+    add("output_norm:gamma", params[norm_key])
+
+    if save_lm_head and "lm_head.weight" in params:
+        add("output_of_causallm:weight", params["lm_head.weight"], transpose=True)
+
+    return weights
+
+
 def convert(model_path, output_name, dtype, **kwargs):
     """Convert Qwen2 (or KaLM-embedding) weights to nntrainer binary format."""
     is_kalm = kwargs.get("is_kalm", False)
+    use_safetensors = kwargs.get("safetensors", False)
 
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
@@ -94,11 +142,17 @@ def convert(model_path, output_name, dtype, **kwargs):
 
     params = model.state_dict()
 
-    with open(output_name, "wb") as f:
-        _save_weights(params, config.num_hidden_layers, dtype, f,
-                      layer_prefix_fn=layer_prefix_fn, save_lm_head=save_lm_head)
-
-    print(f"Saved binary: {output_name}")
+    if use_safetensors:
+        effective_output = get_safetensors_output_name(output_name)
+        weights = _collect_safetensors(params, config.num_hidden_layers, dtype,
+                                       layer_prefix_fn=layer_prefix_fn, save_lm_head=save_lm_head)
+        save_safetensors(weights, effective_output, dtype)
+    else:
+        effective_output = output_name
+        with open(output_name, "wb") as f:
+            _save_weights(params, config.num_hidden_layers, dtype, f,
+                          layer_prefix_fn=layer_prefix_fn, save_lm_head=save_lm_head)
+        print(f"Saved binary: {output_name}")
 
     nntr_extra = {
         "model_type": "embedding" if is_kalm else "CausalLM",
@@ -108,5 +162,5 @@ def convert(model_path, output_name, dtype, **kwargs):
         nntr_extra["is_causal"] = False
     else:
         nntr_extra["chat_input"] = make_chat_input(CHAT_QUESTION)
-    save_configs(output_name, dtype, hf_config=config, model_path=model_path,
+    save_configs(effective_output, dtype, hf_config=config, model_path=model_path,
                  nntr_extra=nntr_extra, sentence_transformer=is_kalm)

--- a/Applications/CausalLM/converter/qwen3.py
+++ b/Applications/CausalLM/converter/qwen3.py
@@ -12,8 +12,11 @@ from utils import (
     get_safetensors_output_name,
     save_safetensors,
     save_configs,
+    make_chat_input,
 )
 
+CHAT_QUESTION = "Give me a short introduction to large language model."
+# Pre-formatted fallback used only when no chat_template is available.
 SAMPLE_INPUT = (
     "<|im_start|>user\nGive me a short introduction to large language model."
     "<|im_end|>\n<|im_start|>assistant\n"
@@ -131,5 +134,6 @@ def convert(model_path, output_name, dtype, **kwargs):
     nntr_extra = {
         "model_type": "CausalLM",
         "sample_input": SAMPLE_INPUT,
+        "chat_input": make_chat_input(CHAT_QUESTION),
     }
     save_configs(effective_output, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen3.py
+++ b/Applications/CausalLM/converter/qwen3.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from utils import (
+    tensor_to_numpy,
+    save_tensor,
+    save_lora_or_weight,
+    get_tie_word_embeddings,
+    get_safetensors_output_name,
+    save_safetensors,
+    save_configs,
+)
+
+SAMPLE_INPUT = (
+    "<|im_start|>user\nGive me a short introduction to large language model."
+    "<|im_end|>\n<|im_start|>assistant\n"
+)
+
+
+def _save_binary(params, n_layers, dtype, file, tie_word_embeddings=True):
+    def save(tensor, transpose=False):
+        save_tensor(file, tensor, dtype, transpose=transpose)
+
+    def save_proj(layer_name, proj_name):
+        save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)
+
+    def save_attention(layer_name):
+        save(params[f"{layer_name}input_layernorm.weight"])
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            save_proj(layer_name, f"self_attn.{proj}")
+            norm_key = f"{layer_name}self_attn.{proj[0]}_norm.weight"
+            if norm_key in params:
+                save(params[norm_key])
+
+    def save_feed_forward(layer_name):
+        save(params[f"{layer_name}post_attention_layernorm.weight"])
+        # Keep existing nntrainer binary weight order: up, gate, down
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
+            save_proj(layer_name, f"mlp.{proj}")
+
+    save(params["model.embed_tokens.weight"])
+
+    for i in range(n_layers):
+        layer_name = f"model.layers.{i}."
+        save_attention(layer_name)
+        save_feed_forward(layer_name)
+
+    save(params["model.norm.weight"])
+
+    if not tie_word_embeddings:
+        save(params["lm_head.weight"], transpose=True)
+
+
+def _collect_safetensors(params, n_layers, dtype, tie_word_embeddings=True):
+    """Collect (nntrainer_name, ndarray) pairs for safetensors export."""
+    weights = []
+
+    def add(name, tensor, transpose=False):
+        weights.append((name, tensor_to_numpy(tensor, dtype, transpose=transpose)))
+
+    def add_proj(nntr_name, layer_name, proj_name):
+        prefix = f"{layer_name}{proj_name}"
+        lora_key = f"{prefix}.lora_A.default.weight"
+        if lora_key in params:
+            add(nntr_name, params[f"{prefix}.base_layer.weight"], transpose=True)
+        else:
+            add(nntr_name, params[f"{prefix}.weight"], transpose=True)
+
+    add("embedding0:Embedding", params["model.embed_tokens.weight"])
+
+    for i in range(n_layers):
+        hf = f"model.layers.{i}."
+        p = f"layer{i}"
+
+        add(f"{p}_attention_norm:gamma", params[f"{hf}input_layernorm.weight"])
+        add_proj(f"{p}_wq:weight", hf, "self_attn.q_proj")
+
+        q_norm = f"{hf}self_attn.q_norm.weight"
+        if q_norm in params:
+            add(f"{p}_q_norm:gamma", params[q_norm])
+
+        add_proj(f"{p}_wk:weight", hf, "self_attn.k_proj")
+
+        k_norm = f"{hf}self_attn.k_norm.weight"
+        if k_norm in params:
+            add(f"{p}_k_norm:gamma", params[k_norm])
+
+        add_proj(f"{p}_wv:weight", hf, "self_attn.v_proj")
+        add_proj(f"{p}_attention_out:weight", hf, "self_attn.o_proj")
+
+        add(f"{p}_ffn_norm:gamma", params[f"{hf}post_attention_layernorm.weight"])
+        add_proj(f"{p}_ffn_gate:weight", hf, "mlp.gate_proj")
+        add_proj(f"{p}_ffn_up:weight", hf, "mlp.up_proj")
+        add_proj(f"{p}_ffn_down:weight", hf, "mlp.down_proj")
+
+    add("output_norm:gamma", params["model.norm.weight"])
+
+    if not tie_word_embeddings:
+        add("output_of_causallm:weight", params["lm_head.weight"], transpose=True)
+
+    return weights
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert Qwen3 dense weights to nntrainer binary or safetensors format."""
+    use_safetensors = kwargs.get("safetensors", False)
+
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+    model.eval()
+
+    tie = get_tie_word_embeddings(config)
+    print(f"tie_word_embeddings: {tie}")
+
+    params = model.state_dict()
+
+    if use_safetensors:
+        out_path = get_safetensors_output_name(output_name)
+        weights = _collect_safetensors(params, config.num_hidden_layers, dtype, tie_word_embeddings=tie)
+        save_safetensors(weights, out_path, dtype)
+        effective_output = out_path
+    else:
+        with open(output_name, "wb") as f:
+            _save_binary(params, config.num_hidden_layers, dtype, f, tie_word_embeddings=tie)
+        print(f"Saved binary: {output_name}")
+        effective_output = output_name
+
+    nntr_extra = {
+        "model_type": "CausalLM",
+        "sample_input": SAMPLE_INPUT,
+    }
+    save_configs(effective_output, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen3_moe.py
+++ b/Applications/CausalLM/converter/qwen3_moe.py
@@ -4,8 +4,10 @@
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from utils import save_tensor, save_lora_or_weight, save_configs
+from utils import save_tensor, save_lora_or_weight, save_configs, make_chat_input
 
+CHAT_QUESTION = "Give me a short introduction to large language model."
+# Pre-formatted fallback used only when no chat_template is available.
 SAMPLE_INPUT = (
     "<|im_start|>user\nGive me a short introduction to large language model."
     "<|im_end|>\n<|im_start|>assistant\n"
@@ -61,5 +63,6 @@ def convert(model_path, output_name, dtype, **kwargs):
     nntr_extra = {
         "model_type": "CausalLM",
         "sample_input": SAMPLE_INPUT,
+        "chat_input": make_chat_input(CHAT_QUESTION),
     }
     save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/qwen3_moe.py
+++ b/Applications/CausalLM/converter/qwen3_moe.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from utils import save_tensor, save_lora_or_weight, save_configs
+
+SAMPLE_INPUT = (
+    "<|im_start|>user\nGive me a short introduction to large language model."
+    "<|im_end|>\n<|im_start|>assistant\n"
+)
+
+
+def _save_weights(params, config, dtype, file):
+    n_experts = config.num_experts
+
+    def save(name, transpose=False):
+        save_tensor(file, params[name], dtype, transpose=transpose)
+
+    def save_proj(layer_name, proj_name):
+        save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True)
+
+    def save_attention(layer_name):
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            save_proj(layer_name, f"self_attn.{proj}")
+            norm_key = f"{layer_name}self_attn.{proj[0]}_norm.weight"
+            if norm_key in params:
+                save(norm_key)
+
+    def save_feed_forward(layer_name):
+        save(f"{layer_name}mlp.gate.weight", transpose=True)
+        for expert_id in range(n_experts):
+            for proj in ["up_proj", "gate_proj", "down_proj"]:
+                save_proj(layer_name, f"mlp.experts.{expert_id}.{proj}")
+
+    save("model.embed_tokens.weight")
+
+    for i in range(config.num_hidden_layers):
+        layer_name = f"model.layers.{i}."
+        save(f"{layer_name}input_layernorm.weight")
+        save_attention(layer_name)
+        save(f"{layer_name}post_attention_layernorm.weight")
+        save_feed_forward(layer_name)
+
+    save("model.norm.weight")
+    save("lm_head.weight", transpose=True)
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert Qwen3 MoE weights to nntrainer binary format."""
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+    model.eval()
+
+    with open(output_name, "wb") as f:
+        _save_weights(model.state_dict(), config, dtype, f)
+
+    print(f"Saved binary: {output_name}")
+
+    nntr_extra = {
+        "model_type": "CausalLM",
+        "sample_input": SAMPLE_INPUT,
+    }
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/tiny_bert.py
+++ b/Applications/CausalLM/converter/tiny_bert.py
@@ -4,7 +4,7 @@
 import torch
 from transformers import AutoConfig, AutoModel
 
-from utils import save_tensor, save_configs
+from utils import save_tensor, save_configs, tensor_to_numpy, get_safetensors_output_name, save_safetensors
 
 SAMPLE_INPUT = "This is a sentence"
 
@@ -48,19 +48,63 @@ def _save_weights(params, config, dtype, file):
         save("pooler.dense.bias")
 
 
+def _collect_safetensors(params, config, dtype):
+    """Collect (nntrainer_name, ndarray) pairs for safetensors export."""
+    weights = []
+
+    def add(name, hf_key, transpose=False):
+        weights.append((name, tensor_to_numpy(params[hf_key], dtype, transpose=transpose)))
+
+    add("embedding0:Embedding", "embeddings.word_embeddings.weight")
+    add("position_embedding:Embedding", "embeddings.position_embeddings.weight")
+    add("token_type_embedding:Embedding", "embeddings.token_type_embeddings.weight")
+    add("embedding_norm:gamma", "embeddings.LayerNorm.weight")
+    add("embedding_norm:beta", "embeddings.LayerNorm.bias")
+
+    for i in range(config.num_hidden_layers):
+        hf = f"encoder.layer.{i}."
+        nn = f"layer{i}"
+        sa = f"{hf}attention.self."
+        add(f"{nn}_wq:weight", f"{sa}query.weight", transpose=True)
+        add(f"{nn}_wq:bias", f"{sa}query.bias")
+        add(f"{nn}_wk:weight", f"{sa}key.weight", transpose=True)
+        add(f"{nn}_wk:bias", f"{sa}key.bias")
+        add(f"{nn}_wv:weight", f"{sa}value.weight", transpose=True)
+        add(f"{nn}_wv:bias", f"{sa}value.bias")
+        add(f"{nn}_attention_out:weight", f"{hf}attention.output.dense.weight", transpose=True)
+        add(f"{nn}_attention_out:bias", f"{hf}attention.output.dense.bias")
+        add(f"{nn}_attention_norm:gamma", f"{hf}attention.output.LayerNorm.weight")
+        add(f"{nn}_attention_norm:beta", f"{hf}attention.output.LayerNorm.bias")
+        add(f"{nn}_ffn_fc1:weight", f"{hf}intermediate.dense.weight", transpose=True)
+        add(f"{nn}_ffn_fc1:bias", f"{hf}intermediate.dense.bias")
+        add(f"{nn}_ffn_down:weight", f"{hf}output.dense.weight", transpose=True)
+        add(f"{nn}_ffn_down:bias", f"{hf}output.dense.bias")
+        add(f"{nn}_ffn_norm:gamma", f"{hf}output.LayerNorm.weight")
+        add(f"{nn}_ffn_norm:beta", f"{hf}output.LayerNorm.bias")
+
+    return weights
+
+
 def convert(model_path, output_name, dtype, **kwargs):
     """Convert a (multilingual tiny) BERT encoder to nntrainer binary format."""
+    use_safetensors = kwargs.get("safetensors", False)
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     model = AutoModel.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
     model.eval()
+    params = model.state_dict()
 
-    with open(output_name, "wb") as f:
-        _save_weights(model.state_dict(), config, dtype, f)
-
-    print(f"Saved binary: {output_name}")
+    if use_safetensors:
+        effective_output = get_safetensors_output_name(output_name)
+        weights = _collect_safetensors(params, config, dtype)
+        save_safetensors(weights, effective_output, dtype)
+    else:
+        effective_output = output_name
+        with open(output_name, "wb") as f:
+            _save_weights(params, config, dtype, f)
+        print(f"Saved binary: {output_name}")
 
     nntr_extra = {
         "model_type": "embedding",
         "sample_input": SAMPLE_INPUT,
     }
-    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)
+    save_configs(effective_output, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/tiny_bert.py
+++ b/Applications/CausalLM/converter/tiny_bert.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import torch
+from transformers import AutoConfig, AutoModel
+
+from utils import save_tensor, save_configs
+
+SAMPLE_INPUT = "This is a sentence"
+
+
+def _save_weights(params, config, dtype, file):
+    """Save BERT encoder weights in nntrainer layer order."""
+
+    def save(name, transpose=False):
+        save_tensor(file, params[name], dtype, transpose=transpose)
+
+    # Embeddings
+    save("embeddings.word_embeddings.weight")
+    save("embeddings.token_type_embeddings.weight")
+    save("embeddings.position_embeddings.weight")
+    save("embeddings.LayerNorm.weight")
+    save("embeddings.LayerNorm.bias")
+
+    # Encoder layers
+    for i in range(config.num_hidden_layers):
+        p = f"encoder.layer.{i}."
+        save(f"{p}attention.self.query.weight", transpose=True)
+        save(f"{p}attention.self.query.bias")
+        save(f"{p}attention.self.key.weight", transpose=True)
+        save(f"{p}attention.self.key.bias")
+        save(f"{p}attention.self.value.weight", transpose=True)
+        save(f"{p}attention.self.value.bias")
+        save(f"{p}attention.output.dense.weight", transpose=True)
+        save(f"{p}attention.output.dense.bias")
+        save(f"{p}attention.output.LayerNorm.weight")
+        save(f"{p}attention.output.LayerNorm.bias")
+        save(f"{p}intermediate.dense.weight", transpose=True)
+        save(f"{p}intermediate.dense.bias")
+        save(f"{p}output.dense.weight", transpose=True)
+        save(f"{p}output.dense.bias")
+        save(f"{p}output.LayerNorm.weight")
+        save(f"{p}output.LayerNorm.bias")
+
+    # Pooler (optional)
+    if "pooler.dense.weight" in params:
+        save("pooler.dense.weight", transpose=True)
+        save("pooler.dense.bias")
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert a (multilingual tiny) BERT encoder to nntrainer binary format."""
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModel.from_pretrained(model_path, torch_dtype=torch.float32, trust_remote_code=True)
+    model.eval()
+
+    with open(output_name, "wb") as f:
+        _save_weights(model.state_dict(), config, dtype, f)
+
+    print(f"Saved binary: {output_name}")
+
+    nntr_extra = {
+        "model_type": "embedding",
+        "sample_input": SAMPLE_INPUT,
+    }
+    save_configs(output_name, dtype, hf_config=config, model_path=model_path, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/utils.py
+++ b/Applications/CausalLM/converter/utils.py
@@ -109,6 +109,16 @@ def save_safetensors(weights, output_path, dtype):
 # Config saving helpers
 # ---------------------------------------------------------------------------
 
+def make_chat_input(text):
+    """Build a chat_input payload for nntr_config.json.
+
+    nntrainer applies the model's chat_template to chat_input at inference time.
+    sample_input (plain text) is only used as a fallback when no chat_template
+    is available, so causal models should provide both.
+    """
+    return {"messages": [{"role": "user", "content": text}]}
+
+
 def _dtype_tag(dtype):
     return "FP32" if dtype == "float32" else "FP16"
 
@@ -172,6 +182,7 @@ def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra
     # save_pretrained re-emits the chat_template (embedded in tokenizer_config.json
     # or as a standalone chat_template.jinja), so it follows the model automatically
     # even when the source only ships the template file.
+    tokenizer = None
     if model_path is not None:
         try:
             from transformers import AutoTokenizer
@@ -185,6 +196,20 @@ def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra
     nntr = _default_nntr_config(output_name, dtype, hf_config=hf_config)
     if nntr_extra:
         nntr.update(nntr_extra)
+
+    # Render sample_input from chat_input using the model's own chat_template, so
+    # the fallback prompt is already correctly formatted for this exact model
+    # (matches what the runtime produces from chat_input at inference time).
+    chat_input = nntr.get("chat_input")
+    if tokenizer is not None and chat_input and getattr(tokenizer, "chat_template", None):
+        messages = chat_input["messages"] if isinstance(chat_input, dict) else chat_input
+        try:
+            nntr["sample_input"] = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        except Exception as e:
+            print(f"Warning: could not render sample_input from chat_template ({e})")
+
     nntr_path = os.path.join(output_dir, "nntr_config.json")
     with open(nntr_path, "w") as f:
         json.dump(nntr, f, indent=4)

--- a/Applications/CausalLM/converter/utils.py
+++ b/Applications/CausalLM/converter/utils.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import shutil
 import struct
 
 import numpy as np
@@ -149,7 +150,64 @@ def _default_nntr_config(output_name, dtype, hf_config=None):
     }
 
 
-def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra=None):
+def _resolve_local_dir(model_path):
+    """Return a local directory for model_path, downloading config-only files if it
+    is a HuggingFace hub id. Returns None if it cannot be resolved."""
+    if os.path.isdir(model_path):
+        return model_path
+    try:
+        from huggingface_hub import snapshot_download
+        return snapshot_download(
+            model_path,
+            allow_patterns=[
+                "modules.json",
+                "config_sentence_transformers.json",
+                "*/config.json",
+                "*/sentence_bert_config.json",
+            ],
+        )
+    except Exception as e:
+        print(f"Warning: could not fetch SentenceTransformer module configs ({e})")
+        return None
+
+
+def save_st_module_configs(model_path, output_dir):
+    """Copy a SentenceTransformer's modules.json and per-module config.json into
+    output_dir, preserving the module subdirectory layout.
+
+    The nntrainer runtime reads modules.json and a config.json per module
+    (models/sentence_transformer.cpp), so only those small files are copied — not
+    the duplicate transformer weights. Returns the copied modules.json path, or
+    None if the source has no modules.json.
+    """
+    src = _resolve_local_dir(model_path)
+    if src is None:
+        return None
+
+    modules_src = os.path.join(src, "modules.json")
+    if not os.path.isfile(modules_src):
+        return None
+
+    shutil.copy(modules_src, os.path.join(output_dir, "modules.json"))
+
+    with open(modules_src) as f:
+        modules = json.load(f)
+
+    for module in modules:
+        rel_path = module.get("path", "")
+        if not rel_path:
+            continue
+        cfg_src = os.path.join(src, rel_path, "config.json")
+        if os.path.isfile(cfg_src):
+            dst_dir = os.path.join(output_dir, rel_path)
+            os.makedirs(dst_dir, exist_ok=True)
+            shutil.copy(cfg_src, os.path.join(dst_dir, "config.json"))
+
+    return os.path.join(output_dir, "modules.json")
+
+
+def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra=None,
+                 sentence_transformer=False):
     """Save config.json, generation_config.json, tokenizer files, and nntr_config.json.
 
     Args:
@@ -159,6 +217,9 @@ def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra
         model_path:  HuggingFace model id or local directory. Used to load the
                      generation config and tokenizer (incl. chat_template).
         nntr_extra:  dict of model-specific fields that override the defaults in nntr_config.json.
+        sentence_transformer: if True, copy modules.json + per-module config.json and
+                     set module_config_path (required for embedding models run as a
+                     SentenceTransformer pipeline by the nntrainer runtime).
     """
     output_dir = os.path.dirname(os.path.abspath(output_name))
     os.makedirs(output_dir, exist_ok=True)
@@ -192,10 +253,21 @@ def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra
         except Exception as e:
             print(f"Warning: could not save tokenizer ({e})")
 
+    # -- SentenceTransformer module configs (modules.json + per-module config) -
+    module_config_path = None
+    if sentence_transformer and model_path is not None:
+        module_config_path = save_st_module_configs(model_path, output_dir)
+        if module_config_path is not None:
+            print(f"Saved SentenceTransformer module configs to: {output_dir}")
+        else:
+            print("Warning: no modules.json found; module_config_path not set")
+
     # -- nntr_config.json -----------------------------------------------------
     nntr = _default_nntr_config(output_name, dtype, hf_config=hf_config)
     if nntr_extra:
         nntr.update(nntr_extra)
+    if module_config_path is not None:
+        nntr["module_config_path"] = module_config_path
 
     # Render sample_input from chat_input using the model's own chat_template, so
     # the fallback prompt is already correctly formatted for this exact model

--- a/Applications/CausalLM/converter/utils.py
+++ b/Applications/CausalLM/converter/utils.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import json
+import os
+import struct
+
+import numpy as np
+
+
+SAFETENSORS_DTYPE_MAP = {
+    "float32": "F32",
+    "float16": "F16",
+}
+
+
+def tensor_to_numpy(tensor, dtype, transpose=False, add_one=False):
+    """Convert a torch tensor to a contiguous numpy array.
+
+    transpose: permute the first two dims (PyTorch OI -> nntrainer IO).
+    add_one:   add 1.0 before casting (Gemma3 RMSNorm convention).
+    """
+    if transpose:
+        tensor = tensor.permute(1, 0)
+    arr = tensor.detach().cpu().numpy()
+    if add_one:
+        arr = arr + 1.0
+    return np.ascontiguousarray(arr.astype(dtype))
+
+
+def write_array(file, arr):
+    """Write a numpy array to an open binary file."""
+    if not arr.flags["C_CONTIGUOUS"]:
+        arr = np.ascontiguousarray(arr)
+    arr.tofile(file)
+
+
+def save_tensor(file, tensor, dtype, transpose=False, add_one=False):
+    """Convert tensor and write to file."""
+    write_array(file, tensor_to_numpy(tensor, dtype, transpose=transpose, add_one=add_one))
+
+
+def has_lora(params, layer_name, proj_name):
+    return f"{layer_name}{proj_name}.lora_A.default.weight" in params
+
+
+def save_lora_or_weight(file, params, layer_name, proj_name, dtype, transpose=True):
+    """Save projection weight. If LoRA weights exist, save base + lora_A + lora_B."""
+    prefix = f"{layer_name}{proj_name}"
+    if has_lora(params, layer_name, proj_name):
+        save_tensor(file, params[f"{prefix}.base_layer.weight"], dtype, transpose=transpose)
+        save_tensor(file, params[f"{prefix}.lora_A.default.weight"], dtype, transpose=transpose)
+        save_tensor(file, params[f"{prefix}.lora_B.default.weight"], dtype, transpose=transpose)
+    else:
+        save_tensor(file, params[f"{prefix}.weight"], dtype, transpose=transpose)
+
+
+def get_tie_word_embeddings(config):
+    return getattr(config, "tie_word_embeddings", True)
+
+
+def get_safetensors_output_name(output_name):
+    if output_name.endswith(".bin"):
+        return output_name[:-4] + ".safetensors"
+    if output_name.endswith(".safetensors"):
+        return output_name
+    return output_name + ".safetensors"
+
+
+def save_safetensors(weights, output_path, dtype):
+    """Write (name, ndarray) pairs to a safetensors file."""
+    if dtype not in SAFETENSORS_DTYPE_MAP:
+        raise ValueError(f"Unsupported safetensors dtype: {dtype}")
+
+    safetensors_dtype = SAFETENSORS_DTYPE_MAP[dtype]
+    offset = 0
+    tensor_meta = {}
+    raw_buffers = []
+
+    for name, arr in weights:
+        if not arr.flags["C_CONTIGUOUS"]:
+            arr = np.ascontiguousarray(arr)
+        nbytes = arr.nbytes
+        tensor_meta[name] = {
+            "dtype": safetensors_dtype,
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        raw_buffers.append(arr.tobytes(order="C"))
+        offset += nbytes
+
+    header = {"__metadata__": {"format": "pt"}}
+    header.update(tensor_meta)
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(output_path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        for buf in raw_buffers:
+            f.write(buf)
+
+    print(f"Saved safetensors: {output_path}")
+    print(f"Tensor data size: {offset / 1e9:.2f} GB")
+
+
+# ---------------------------------------------------------------------------
+# Config saving helpers
+# ---------------------------------------------------------------------------
+
+def _dtype_tag(dtype):
+    return "FP32" if dtype == "float32" else "FP16"
+
+
+def _default_nntr_config(output_name, dtype, hf_config=None):
+    """Build the default nntr_config dict from common fields."""
+    tag = _dtype_tag(dtype)
+    max_seq = getattr(hf_config, "max_position_embeddings", 2048) if hf_config else 2048
+    output_dir = os.path.dirname(os.path.abspath(output_name))
+    return {
+        "model_type": "CausalLM",
+        "model_tensor_type": f"{tag}-{tag}",
+        "model_file_name": os.path.basename(output_name),
+        "fc_layer_dtype": tag,
+        "embedding_dtype": tag,
+        "lora_rank": 0,
+        "lora_alpha": 0,
+        "lora_target": [],
+        "bad_word_ids": [],
+        "fsu": False,
+        "fsu_lookahead": 2,
+        "num_to_generate": 512,
+        "init_seq_len": 1024,
+        "max_seq_len": max_seq,
+        "batch_size": 1,
+        "tokenizer_file": os.path.join(output_dir, "tokenizer.json"),
+        "sample_input": "",
+    }
+
+
+def save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra=None):
+    """Save config.json, generation_config.json, tokenizer files, and nntr_config.json.
+
+    Args:
+        output_name: path to the converted weight file (used to derive output dir and filename).
+        dtype:       data type string ("float32" or "float16").
+        hf_config:   loaded HuggingFace PretrainedConfig object (or None for timm ViT).
+        model_path:  HuggingFace model id or local directory. Used to load the
+                     generation config and tokenizer (incl. chat_template).
+        nntr_extra:  dict of model-specific fields that override the defaults in nntr_config.json.
+    """
+    output_dir = os.path.dirname(os.path.abspath(output_name))
+    os.makedirs(output_dir, exist_ok=True)
+
+    # -- config.json ----------------------------------------------------------
+    if hf_config is not None:
+        hf_config.save_pretrained(output_dir)
+        print(f"Saved config.json: {os.path.join(output_dir, 'config.json')}")
+
+    # -- generation_config.json -----------------------------------------------
+    if model_path is not None:
+        try:
+            from transformers import GenerationConfig
+            gen_config = GenerationConfig.from_pretrained(model_path)
+            gen_config.save_pretrained(output_dir)
+            print(f"Saved generation_config.json: {os.path.join(output_dir, 'generation_config.json')}")
+        except Exception:
+            pass  # not all models ship a generation_config
+
+    # -- tokenizer (tokenizer.json, tokenizer_config.json, chat_template) ------
+    # save_pretrained re-emits the chat_template (embedded in tokenizer_config.json
+    # or as a standalone chat_template.jinja), so it follows the model automatically
+    # even when the source only ships the template file.
+    if model_path is not None:
+        try:
+            from transformers import AutoTokenizer
+            tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+            tokenizer.save_pretrained(output_dir)
+            print(f"Saved tokenizer files to: {output_dir}")
+        except Exception as e:
+            print(f"Warning: could not save tokenizer ({e})")
+
+    # -- nntr_config.json -----------------------------------------------------
+    nntr = _default_nntr_config(output_name, dtype, hf_config=hf_config)
+    if nntr_extra:
+        nntr.update(nntr_extra)
+    nntr_path = os.path.join(output_dir, "nntr_config.json")
+    with open(nntr_path, "w") as f:
+        json.dump(nntr, f, indent=4)
+    print(f"Saved nntr_config.json: {nntr_path}")

--- a/Applications/CausalLM/converter/vit.py
+++ b/Applications/CausalLM/converter/vit.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+import numpy as np
+import torch
+
+from utils import save_configs
+
+# ViT consumes an image file rather than text.
+SAMPLE_INPUT = "sample.png"
+
+
+def _load_state_dict(model_path):
+    if model_path.endswith(".safetensors"):
+        import safetensors.torch
+        state_dict = safetensors.torch.load_file(model_path)
+    else:
+        state_dict = torch.load(model_path, map_location="cpu")
+
+    if isinstance(state_dict, dict):
+        for key in ("state_dict", "model"):
+            if key in state_dict and isinstance(state_dict[key], dict):
+                state_dict = state_dict[key]
+                break
+
+    return {key.removeprefix("module."): value for key, value in state_dict.items()}
+
+
+def _save(file, weight, dtype, transpose=False):
+    arr = weight.detach().cpu().numpy() if not isinstance(weight, np.ndarray) else weight
+    if transpose and arr.ndim >= 2:
+        arr = arr.T
+    arr.astype(dtype).tofile(file)
+
+
+def convert(model_path, output_name, dtype, **kwargs):
+    """Convert timm ViT weights to nntrainer binary format.
+
+    model_path: path to a .safetensors or .bin checkpoint file (not an HF hub ID).
+    """
+    np_dtype = np.float16 if dtype == "float16" else np.float32
+
+    print(f"Loading model from: {model_path}")
+    state_dict = _load_state_dict(model_path)
+
+    # Infer number of transformer blocks instead of hard-coding 12.
+    num_layers = sum(1 for k in state_dict if k.startswith("blocks.") and k.endswith("norm1.weight"))
+    if num_layers == 0:
+        raise ValueError("Could not detect transformer blocks in state_dict. Check model_path.")
+
+    dim = state_dict["patch_embed.proj.bias"].shape[0]
+
+    print(f"Converting to: {output_name}  (layers={num_layers}, dim={dim})")
+
+    with open(output_name, "wb") as f:
+        # 1. Patch embedding (Conv2D — no transpose)
+        _save(f, state_dict["patch_embed.proj.weight"], np_dtype, transpose=False)
+        if "patch_embed.proj.bias" in state_dict:
+            _save(f, state_dict["patch_embed.proj.bias"], np_dtype)
+
+        # 2. Position embedding — reshape to [1, 1, seq_len, dim]
+        pos_embed = state_dict["pos_embed"].unsqueeze(1)
+        _save(f, pos_embed, np_dtype, transpose=False)
+
+        # 3. Transformer blocks
+        for i in range(num_layers):
+            p = f"blocks.{i}."
+
+            _save(f, state_dict[f"{p}norm1.weight"], np_dtype)
+            _save(f, state_dict[f"{p}norm1.bias"], np_dtype)
+
+            qkv_w = state_dict[f"{p}attn.qkv.weight"]
+            qkv_b = state_dict[f"{p}attn.qkv.bias"]
+            for chunk_w, chunk_b in [
+                (qkv_w[:dim], qkv_b[:dim]),
+                (qkv_w[dim:2*dim], qkv_b[dim:2*dim]),
+                (qkv_w[2*dim:], qkv_b[2*dim:]),
+            ]:
+                _save(f, chunk_w, np_dtype, transpose=True)
+                _save(f, chunk_b, np_dtype)
+
+            _save(f, state_dict[f"{p}attn.proj.weight"], np_dtype, transpose=True)
+            _save(f, state_dict[f"{p}attn.proj.bias"], np_dtype)
+
+            _save(f, state_dict[f"{p}norm2.weight"], np_dtype)
+            _save(f, state_dict[f"{p}norm2.bias"], np_dtype)
+
+            _save(f, state_dict[f"{p}mlp.fc1.weight"], np_dtype, transpose=True)
+            _save(f, state_dict[f"{p}mlp.fc1.bias"], np_dtype)
+            _save(f, state_dict[f"{p}mlp.fc2.weight"], np_dtype, transpose=True)
+            _save(f, state_dict[f"{p}mlp.fc2.bias"], np_dtype)
+
+        # 4. Final normalization
+        _save(f, state_dict["norm.weight"], np_dtype)
+        _save(f, state_dict["norm.bias"], np_dtype)
+
+        # 5. Attention pool (optional — present when global_pool="map")
+        if "attn_pool.latent" in state_dict:
+            _save(f, state_dict["attn_pool.latent"], np_dtype, transpose=False)
+            _save(f, state_dict["attn_pool.q.weight"], np_dtype, transpose=True)
+            _save(f, state_dict["attn_pool.q.bias"], np_dtype)
+            _save(f, state_dict["attn_pool.kv.weight"], np_dtype, transpose=True)
+            _save(f, state_dict["attn_pool.kv.bias"], np_dtype)
+            _save(f, state_dict["attn_pool.proj.weight"], np_dtype, transpose=True)
+            _save(f, state_dict["attn_pool.proj.bias"], np_dtype)
+            _save(f, state_dict["attn_pool.norm.weight"], np_dtype)
+            _save(f, state_dict["attn_pool.norm.bias"], np_dtype)
+            _save(f, state_dict["attn_pool.mlp.fc1.weight"], np_dtype, transpose=True)
+            _save(f, state_dict["attn_pool.mlp.fc1.bias"], np_dtype)
+            _save(f, state_dict["attn_pool.mlp.fc2.weight"], np_dtype, transpose=True)
+            _save(f, state_dict["attn_pool.mlp.fc2.bias"], np_dtype)
+
+    print(f"Saved binary: {output_name}")
+
+    patch_size = kwargs.get("patch_size", 16)
+    img_size = kwargs.get("img_size", 224)
+    num_patches = (img_size // patch_size) ** 2
+    nntr_extra = {
+        "model_type": "Model",
+        "patch_size": patch_size,
+        "img_size": img_size,
+        "num_patches": num_patches,
+        "num_classes": 0,
+        "num_to_generate": 0,
+        "init_seq_len": num_patches,
+        "max_seq_len": num_patches * 5,
+        "skip_tokenizer": True,
+        "sample_input": SAMPLE_INPUT,
+    }
+    # ViT loads from a checkpoint file, not an HF model directory — skip config.json / generation_config.json.
+    save_configs(output_name, dtype, hf_config=None, model_path=None, nntr_extra=nntr_extra)

--- a/Applications/CausalLM/converter/weight_converter.py
+++ b/Applications/CausalLM/converter/weight_converter.py
@@ -12,7 +12,7 @@
 #   qwen2         Qwen2 (e.g. Qwen/Qwen2-0.5B)
 #   qwen3         Qwen3 dense (e.g. Qwen/Qwen3-0.6B, Qwen3-4B)
 #   qwen3_moe     Qwen3 MoE (e.g. Qwen/Qwen3-30B-A3B)
-#   gemma3        Gemma3 causal LM
+#   gemma3        Gemma3 causal LM (config model_type "gemma3" or "gemma3_text")
 #   gemma3_emb    Gemma3 SentenceTransformer embedding model
 #   gpt_oss       GPT-OSS 20B MoE  (HF model_type may differ; use --model_type)
 #   kalm          KaLM-embedding (SentenceTransformer, Qwen2 backbone)
@@ -58,8 +58,9 @@ _MODULE_MAP = {
     "qwen2":      "qwen2",
     "qwen3":      "qwen3",
     "qwen3_moe":  "qwen3_moe",
-    "gemma3":     "gemma3",
-    "gemma3_emb": "gemma3",
+    "gemma3":      "gemma3",
+    "gemma3_text": "gemma3",  # text-only Gemma3 (Gemma3ForCausalLM) reports this
+    "gemma3_emb":  "gemma3",
     "gpt_oss":    "gpt_oss",
     "kalm":       "qwen2",
     "deberta-v2": "deberta_v2",

--- a/Applications/CausalLM/converter/weight_converter.py
+++ b/Applications/CausalLM/converter/weight_converter.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file weight_converter.py
+# @brief Unified weight conversion script for all CausalLM models.
+# @author  Jungwon-Lee <jungone.lee@samsung.com>
+#
+# This script lives in Applications/CausalLM/converter/.
+# Converted weights and config JSON files default to the sibling res/ directory.
+#
+# Supported models (--model_type):
+#   qwen2         Qwen2 (e.g. Qwen/Qwen2-0.5B)
+#   qwen3         Qwen3 dense (e.g. Qwen/Qwen3-0.6B, Qwen3-4B)
+#   qwen3_moe     Qwen3 MoE (e.g. Qwen/Qwen3-30B-A3B)
+#   gemma3        Gemma3 causal LM
+#   gemma3_emb    Gemma3 SentenceTransformer embedding model
+#   gpt_oss       GPT-OSS 20B MoE  (HF model_type may differ; use --model_type)
+#   kalm          KaLM-embedding (SentenceTransformer, Qwen2 backbone)
+#   deberta_v2    DeBERTa V2 encoder / SentenceTransformer
+#   vit           timm ViT  (--model_path is a .safetensors/.bin file, not an HF id)
+#
+# Outputs are saved to the same directory as --output_name.
+# Default output directory is the sibling res/ directory.
+# Along with the weight binary, three JSON files are always written:
+#   config.json            HuggingFace model config (HF models only)
+#   generation_config.json HuggingFace generation config (if available)
+#   nntr_config.json       nntrainer runtime config
+#
+# Usage:
+#   # output_name defaults to res/nntr_<model>_<dtype>.bin
+#   python weight_converter.py --model_path Qwen/Qwen3-0.6B
+#
+#   # explicit output path
+#   python weight_converter.py --model_path Qwen/Qwen3-0.6B --output_name /tmp/out.bin
+#
+#   # safetensors output (Qwen3 only)
+#   python weight_converter.py --model_path Qwen/Qwen3-0.6B --safetensors
+#
+#   # timm ViT (model_path is a checkpoint file, not an HF hub id)
+#   python weight_converter.py --model_path ./model.safetensors --model_type vit
+
+import argparse
+import importlib
+import os
+import re
+import sys
+
+# This script lives in Applications/CausalLM/converter/.
+# Make the sibling converter modules importable when run directly as a script.
+_CONVERTER_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _CONVERTER_DIR)
+
+# Default output directory: the sibling res/ directory.
+_DEFAULT_OUTPUT_DIR = os.path.normpath(os.path.join(_CONVERTER_DIR, os.pardir, "res"))
+
+# model_type string -> converter module name
+_MODULE_MAP = {
+    "qwen2":      "qwen2",
+    "qwen3":      "qwen3",
+    "qwen3_moe":  "qwen3_moe",
+    "gemma3":     "gemma3",
+    "gemma3_emb": "gemma3",
+    "gpt_oss":    "gpt_oss",
+    "kalm":       "qwen2",
+    "deberta-v2": "deberta_v2",
+    "deberta_v2": "deberta_v2",
+    "vit":        "vit",
+}
+
+# Extra kwargs forwarded to converter.convert() depending on model_type
+_EXTRA_KWARGS = {
+    "gemma3_emb": {"is_embedding": True},
+    "kalm":       {"is_kalm": True},
+}
+
+
+def _detect_model_type(model_path):
+    """Try to read model_type from HuggingFace config."""
+    try:
+        from transformers import AutoConfig
+        config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        return config.model_type
+    except Exception:
+        return None
+
+
+def _default_output_name(model_path, model_type, dtype, safetensors=False):
+    """Derive a default output path under res/<model_name>/."""
+    # Use the last path component of model_path and sanitize it.
+    basename = os.path.basename(model_path.rstrip("/\\"))
+    if not basename:
+        basename = model_type
+    # lowercase, replace spaces and slashes with hyphens
+    basename = re.sub(r"[^a-zA-Z0-9.\-_]", "-", basename).lower()
+    dtype_tag = "fp32" if dtype == "float32" else "fp16"
+    ext = ".safetensors" if safetensors else ".bin"
+    filename = f"nntr_{basename}_{dtype_tag}{ext}"
+    # Place each model's outputs in its own res/<model_name>/ subdirectory.
+    return os.path.join(_DEFAULT_OUTPUT_DIR, basename, filename)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Unified nntrainer weight converter for CausalLM/res models.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        required=True,
+        help="HuggingFace model id, local model directory, or checkpoint file (ViT).",
+    )
+    parser.add_argument(
+        "--output_name",
+        type=str,
+        default=None,
+        help=(
+            "Output file path (.bin or .safetensors). "
+            "Defaults to res/nntr_<model>_<dtype>.bin. "
+            "config.json, generation_config.json, and nntr_config.json are "
+            "always written to the same directory."
+        ),
+    )
+    parser.add_argument(
+        "--data_type",
+        type=str,
+        default="float32",
+        choices=["float32", "float16"],
+        help="Weight dtype written to the output file.",
+    )
+    parser.add_argument(
+        "--model_type",
+        type=str,
+        default=None,
+        help=(
+            "Override model type detection. "
+            "Choices: " + ", ".join(sorted(_MODULE_MAP)) + ". "
+            "Required for gpt_oss and vit."
+        ),
+    )
+    parser.add_argument(
+        "--safetensors",
+        action="store_true",
+        help="Save in safetensors format (Qwen3 only).",
+    )
+    # ViT-specific geometry (used for nntr_config.json)
+    parser.add_argument(
+        "--patch_size",
+        type=int,
+        default=16,
+        help="(ViT only) Patch size in pixels.",
+    )
+    parser.add_argument(
+        "--img_size",
+        type=int,
+        default=224,
+        help="(ViT only) Input image size in pixels.",
+    )
+    args = parser.parse_args()
+
+    # Resolve model_type
+    model_type = args.model_type
+    if model_type is None:
+        model_type = _detect_model_type(args.model_path)
+        if model_type is None:
+            parser.error(
+                "Could not detect model_type automatically. "
+                "Please specify --model_type explicitly."
+            )
+        print(f"Detected model_type: {model_type}")
+
+    model_type = model_type.lower()
+    module_name = _MODULE_MAP.get(model_type)
+    if module_name is None:
+        parser.error(
+            f"Unsupported model_type '{model_type}'. "
+            "Supported: " + ", ".join(sorted(_MODULE_MAP))
+        )
+
+    # Resolve output path
+    output_name = args.output_name
+    if output_name is None:
+        output_name = _default_output_name(
+            args.model_path, model_type, args.data_type, safetensors=args.safetensors
+        )
+        print(f"Output: {output_name}")
+
+    # Ensure output directory exists
+    output_dir = os.path.dirname(os.path.abspath(output_name))
+    os.makedirs(output_dir, exist_ok=True)
+
+    module = importlib.import_module(module_name)
+    extra = dict(_EXTRA_KWARGS.get(model_type, {}))
+    extra["safetensors"] = args.safetensors
+    if model_type == "vit":
+        extra["patch_size"] = args.patch_size
+        extra["img_size"] = args.img_size
+
+    module.convert(
+        model_path=args.model_path,
+        output_name=output_name,
+        dtype=args.data_type,
+        **extra,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Applications/CausalLM/converter/weight_converter.py
+++ b/Applications/CausalLM/converter/weight_converter.py
@@ -34,7 +34,7 @@
 #   # explicit output path
 #   python weight_converter.py --model_path Qwen/Qwen3-0.6B --output_name /tmp/out.bin
 #
-#   # safetensors output (Qwen3 only)
+#   # safetensors output (qwen2/qwen3/kalm/deberta_v2/bert)
 #   python weight_converter.py --model_path Qwen/Qwen3-0.6B --safetensors
 #
 #   # timm ViT (model_path is a checkpoint file, not an HF hub id)
@@ -144,7 +144,7 @@ def main():
     parser.add_argument(
         "--safetensors",
         action="store_true",
-        help="Save in safetensors format (Qwen3 only).",
+        help="Save in safetensors format (qwen2/qwen3/kalm/deberta_v2/bert).",
     )
     # ViT-specific geometry (used for nntr_config.json)
     parser.add_argument(

--- a/Applications/CausalLM/converter/weight_converter.py
+++ b/Applications/CausalLM/converter/weight_converter.py
@@ -17,6 +17,7 @@
 #   gpt_oss       GPT-OSS 20B MoE  (HF model_type may differ; use --model_type)
 #   kalm          KaLM-embedding (SentenceTransformer, Qwen2 backbone)
 #   deberta_v2    DeBERTa V2 encoder / SentenceTransformer
+#   bert          (multilingual tiny) BERT encoder
 #   vit           timm ViT  (--model_path is a .safetensors/.bin file, not an HF id)
 #
 # Outputs are saved to the same directory as --output_name.
@@ -65,6 +66,7 @@ _MODULE_MAP = {
     "kalm":       "qwen2",
     "deberta-v2": "deberta_v2",
     "deberta_v2": "deberta_v2",
+    "bert":       "tiny_bert",
     "vit":        "vit",
 }
 


### PR DESCRIPTION
## Summary

Adds a single unified weight converter for the CausalLM application that replaces the duplicated per-model `weight_converter.py` scripts scattered under `Applications/CausalLM/res/`.

A single entry point (`converter/weight_converter.py`) dispatches to per-model modules based on the model type, which is auto-detected from the HuggingFace config (and can be overridden with `--model_type`).

## What's included

- **Entry point**: `converter/weight_converter.py`
- **Per-model modules**: `qwen2`, `qwen3`, `qwen3_moe`, `gemma3` (causal/embedding), `gpt_oss`, `kalm`, `deberta_v2`, `vit`
- **Shared helpers** (`converter/utils.py`):
  - tensor I/O (`save_tensor` with `transpose` / `add_one`), LoRA-aware projection saving
  - safetensors export
  - `save_configs`: writes `config.json`, `generation_config.json`, tokenizer files (incl. **chat_template**), and a generated `nntr_config.json`
- **README** documenting usage, supported models, output layout, and how to add a new model

## Output layout

Outputs default to `res/<model_name>/`, keeping each model's weights and config artifacts grouped together and self-contained. The tokenizer (including the chat template) is re-emitted via `save_pretrained`, so it follows the model automatically.

## Notes

- Existing per-model scripts under `res/` are intentionally **left in place** for now (including the separate `gguf_to_nntrainer.py`, which is not covered by this unification).
- **Verification pending**: byte-level output comparison against the existing per-model scripts has not been run yet. Opening as Draft until verified.

## Checking List

- [x] Qwen2.5
- [x] Qwen3
- [ ] Qwen3-MoE
- [x] Gemma3
- [ ] GPT-OSS
- [x] TinyBert
- [x] Kalm-Embedding
- [x] deberta_v2