### PR TITLE
[CausalLM] Fix BERT and DeBERTa V2 encoder attention

### DIFF
--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -740,8 +740,11 @@ void DebertaAttentionLayer::add_relative_attn_score(
         if (p2c) {
           const int rel = static_cast<int>(q + from) - static_cast<int>(k);
           const int bucketed = lookup_bucket(rel);
+          // HF gathers key·pos_query with clamp(-r_pos+span) and then
+          // transposes (q<->k); the net effective index for score[q,k] is
+          // clamp(bucketed(q-k)+span), matching the c2p index.
           rel_idx_local.p2c_idx[static_cast<size_t>(q) * S_k + k] =
-            clampv(-bucketed + static_cast<int>(att_span), 0,
+            clampv(bucketed + static_cast<int>(att_span), 0,
                    static_cast<int>(rel_len_q) - 1);
         }
       }

--- a/Applications/CausalLM/models/bert/bert_transformer.cpp
+++ b/Applications/CausalLM/models/bert/bert_transformer.cpp
@@ -210,6 +210,7 @@ Tensor BertTransformer::createAttention(const int layer_id, int seq_len,
     withKey("num_heads_kv", n_heads / GQA_SIZE),
     withKey("max_timestep", std::to_string(INIT_SEQ_LEN)),
     withKey("rope_theta", ROPE_THETA),
+    withKey("use_rope", "false"),
     withKey("is_causal", "false")};
   LayerHandle mha(createLayer("mha_core", a_params));
   Tensor a = mha({q, k, v});


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR

<details><summary>[CausalLM] Disable RoPE in BERT attention layer</summary><br />

`BertTransformer::createAttention` created the `mha_core` layer without setting
`use_rope`, so the default (`true`) applied rotary embeddings with
`rope_theta=0`, yielding `1/pow(0, x)=inf` and `cos(inf)=nan` for every BERT
encoder output. Pass `use_rope=false` to match the bidirectional, non-rotary
BERT attention.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[CausalLM] Fix DeBERTa V2 p2c relative position index</summary><br />

The p2c branch of `add_relative_attn_score` indexed `pos_query` with
`clamp(-bucket(q-k) + att_span)`, copied from HuggingFace's pre-transpose
formula. HuggingFace gathers `key * pos_query^T` with `clamp(-r_pos + span)` and
then transposes (`q<->k`), so the effective index is
`clamp(bucket(q-k) + att_span)` (identical to c2p). The missing transpose
flipped the sign and corrupted every off-diagonal score. Corrected the sign so
the encoder output matches the reference.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

Two independent correctness fixes in the CausalLM encoder attention paths, found
while validating embedding models against HuggingFace `transformers`:

- **BERT**: `mha_core` was run with the default `use_rope=true` and
  `rope_theta=0`, producing `nan` for the entire BERT encoder output. Disabled
  RoPE for the bidirectional BERT attention. After the fix, tiny-BERT CLS output
  matches HuggingFace (cosine 0.99999999).
- **DeBERTa V2**: the p2c disentangled-attention gather index had the wrong sign
  (missing the HuggingFace post-gather transpose), corrupting every off-diagonal
  score. After the fix, the DeBERTa encoder output matches HuggingFace
  (mean-pooled embedding cosine 0.99999997).

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>