### PR TITLE
[CausalLM] Unify weight converters with safetensors export

### DIFF
--- a/Applications/CausalLM/res/deberta_v2/weight_converter.py
+++ b/Applications/CausalLM/res/deberta_v2/weight_converter.py
@@ -6,86 +6,54 @@
 # @author Samsung Electronics Co., Ltd.
 
 import argparse
-from pathlib import Path
+import json
+import struct
 
 import numpy as np
 import torch
-from transformers import DebertaV2Model
+from transformers import AutoConfig, AutoModel
 
 
-def _to_numpy(weight, dtype):
-    return weight.detach().cpu().numpy().astype(dtype, copy=False)
+SAFETENSORS_DTYPE_MAP = {
+    "float32": "F32",
+}
 
 
-def _save_weight(file, weight, dtype):
-    _to_numpy(weight, dtype).tofile(file)
+def tensor_to_numpy(tensor, dtype, transpose=False):
+    """Convert torch tensor to contiguous numpy array."""
+    if transpose:
+        tensor = tensor.transpose(0, 1)
+
+    return np.ascontiguousarray(tensor.detach().cpu().numpy().astype(dtype))
 
 
-def _save_linear(file, params, prefix, dtype):
-    _save_weight(file, params[f"{prefix}.weight"].transpose(0, 1), dtype)
-    _save_weight(file, params[f"{prefix}.bias"], dtype)
+def get_safetensors_output_name(output_name):
+    """Return safetensors output path based on the given output name."""
+    if output_name.endswith(".bin"):
+        return output_name[:-4] + ".safetensors"
+
+    if output_name.endswith(".safetensors"):
+        return output_name
+
+    return output_name + ".safetensors"
 
 
-def save_deberta_v2_for_nntrainer(params, config, dtype, file):
-    """Save DeBERTa V2 encoder weights in nntrainer layer order."""
-    _save_weight(file, params["embeddings.word_embeddings.weight"], dtype)
-    _save_weight(file, params["embeddings.LayerNorm.weight"], dtype)
-    _save_weight(file, params["embeddings.LayerNorm.bias"], dtype)
-
-    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none").lower().split("|")
-    norm_rel_ebd = [item.strip() for item in norm_rel_ebd]
-    pos_att_type = getattr(config, "pos_att_type", None) or []
-    uses_relative_bias = getattr(config, "relative_attention", False) and (
-        "c2p" in pos_att_type or "p2c" in pos_att_type
-    )
-    saved_relative_embeddings = False
-
-    for layer_idx in range(config.num_hidden_layers):
-        layer_prefix = f"encoder.layer.{layer_idx}"
-        attn_prefix = f"{layer_prefix}.attention"
-        self_prefix = f"{attn_prefix}.self"
-
-        _save_linear(file, params, f"{self_prefix}.query_proj", dtype)
-        _save_linear(file, params, f"{self_prefix}.key_proj", dtype)
-        _save_linear(file, params, f"{self_prefix}.value_proj", dtype)
-        if uses_relative_bias and not saved_relative_embeddings:
-            _save_weight(file, params["encoder.rel_embeddings.weight"], dtype)
-            if "layer_norm" in norm_rel_ebd:
-                _save_weight(file, params["encoder.LayerNorm.weight"], dtype)
-                _save_weight(file, params["encoder.LayerNorm.bias"], dtype)
-            saved_relative_embeddings = True
-
-        _save_linear(file, params, f"{attn_prefix}.output.dense", dtype)
-        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.weight"], dtype)
-        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.bias"], dtype)
-        _save_linear(file, params, f"{layer_prefix}.intermediate.dense", dtype)
-        _save_linear(file, params, f"{layer_prefix}.output.dense", dtype)
-        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.weight"], dtype)
-        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.bias"], dtype)
-
-
-def _encoder_state_dict(model):
-    if hasattr(model, "deberta"):
-        return model.deberta.state_dict()
-    return model.state_dict()
-
-
-def _strip_encoder_prefix(params):
+def strip_encoder_prefix(params):
+    """Return a state dict keyed from the DeBERTa encoder root."""
     if "embeddings.word_embeddings.weight" in params:
         return params
 
     prefixes = (
+        "deberta.",
         "0.auto_model.",
         "0.auto_model.deberta.",
         "auto_model.",
         "auto_model.deberta.",
-        "deberta.",
     )
     for prefix in prefixes:
-        key = prefix + "embeddings.word_embeddings.weight"
-        if key in params:
+        if prefix + "embeddings.word_embeddings.weight" in params:
             return {
-                name[len(prefix) :]: value
+                name[len(prefix):]: value
                 for name, value in params.items()
                 if name.startswith(prefix)
             }
@@ -93,28 +61,144 @@ def _strip_encoder_prefix(params):
     raise KeyError("Cannot find DeBERTa V2 encoder weights in state_dict")
 
 
-def _load_model_config_and_params(model_path):
-    try:
-        model = DebertaV2Model.from_pretrained(model_path)
-        return model.config, _strip_encoder_prefix(_encoder_state_dict(model))
-    except Exception as deberta_error:
-        try:
-            from sentence_transformers import SentenceTransformer
-
-            st_model = SentenceTransformer(model_path, trust_remote_code=True)
-            auto_model = getattr(st_model[0], "auto_model", None)
-            if auto_model is None:
-                raise AttributeError(
-                    "first SentenceTransformer module has no auto_model"
-                )
-            return auto_model.config, _strip_encoder_prefix(st_model.state_dict())
-        except Exception as st_error:
-            raise RuntimeError(
-                "Failed to load as DebertaV2Model or SentenceTransformer"
-            ) from st_error
+def _uses_relative_bias(config):
+    pos_att_type = getattr(config, "pos_att_type", None) or []
+    if isinstance(pos_att_type, str):
+        pos_att_type = pos_att_type.lower().replace("|", " ").split()
+    return getattr(config, "relative_attention", False) and (
+        "c2p" in pos_att_type or "p2c" in pos_att_type
+    )
 
 
-def main():
+def _norm_rel_ebd(config):
+    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none") or "none"
+    return "layer_norm" in norm_rel_ebd.lower()
+
+
+def _entries(params, config):
+    """Yield (nntrainer_name, hf_key, transpose) in nntrainer weight order.
+
+    Mirrors DebertaV2::constructTransformerModule / createDebertaLayer in
+    models/deberta_v2/deberta_v2.cpp. Note that rel_embeddings (and its
+    optional LayerNorm) are emitted *before* the encoder layers, matching the
+    nntrainer graph construction order. Linear weights are transposed; biases
+    and LayerNorm gamma/beta are stored as-is.
+    """
+    params = strip_encoder_prefix(params)
+
+    uses_rel = _uses_relative_bias(config)
+    norm_rel = _norm_rel_ebd(config)
+
+    # --- Embeddings ---
+    yield "embedding0:Embedding", "embeddings.word_embeddings.weight", False
+    yield "embeddings_norm:gamma", "embeddings.LayerNorm.weight", False
+    yield "embeddings_norm:beta", "embeddings.LayerNorm.bias", False
+
+    # --- Encoder layers ---
+    for i in range(config.num_hidden_layers):
+        hf = f"encoder.layer.{i}."
+        nn = f"layer{i}"
+        self_attn = f"{hf}attention.self."
+
+        yield f"{nn}_wq:weight", f"{self_attn}query_proj.weight", True
+        yield f"{nn}_wq:bias", f"{self_attn}query_proj.bias", False
+        yield f"{nn}_wk:weight", f"{self_attn}key_proj.weight", True
+        yield f"{nn}_wk:bias", f"{self_attn}key_proj.bias", False
+        yield f"{nn}_wv:weight", f"{self_attn}value_proj.weight", True
+        yield f"{nn}_wv:bias", f"{self_attn}value_proj.bias", False
+
+        # nntrainer's graph emits the shared relative-position embeddings (and
+        # their optional LayerNorm) right after the first layer's Q/K/V, since
+        # the deberta_attention layer that consumes them is created there.
+        if i == 0 and uses_rel:
+            yield "rel_embeddings:weight", "encoder.rel_embeddings.weight", False
+            if norm_rel:
+                yield "rel_embeddings_norm:gamma", "encoder.LayerNorm.weight", False
+                yield "rel_embeddings_norm:beta", "encoder.LayerNorm.bias", False
+
+        yield f"{nn}_attention_out:weight", f"{hf}attention.output.dense.weight", True
+        yield f"{nn}_attention_out:bias", f"{hf}attention.output.dense.bias", False
+        yield f"{nn}_attention_norm:gamma", f"{hf}attention.output.LayerNorm.weight", False
+        yield f"{nn}_attention_norm:beta", f"{hf}attention.output.LayerNorm.bias", False
+
+        yield f"{nn}_intermediate:weight", f"{hf}intermediate.dense.weight", True
+        yield f"{nn}_intermediate:bias", f"{hf}intermediate.dense.bias", False
+        yield f"{nn}_output_dense:weight", f"{hf}output.dense.weight", True
+        yield f"{nn}_output_dense:bias", f"{hf}output.dense.bias", False
+        # nntrainer names the post-FFN LayerNorm "layer{i}_output".
+        yield f"{nn}_output:gamma", f"{hf}output.LayerNorm.weight", False
+        yield f"{nn}_output:beta", f"{hf}output.LayerNorm.bias", False
+
+
+def save_deberta_v2_for_nntrainer(params, config, dtype, file):
+    """Save DeBERTa V2 encoder weights in nntrainer binary layer order."""
+    for _, hf_key, transpose in _entries(params, config):
+        arr = tensor_to_numpy(params_view(params)[hf_key], dtype, transpose=transpose)
+        arr.tofile(file)
+
+
+def collect_deberta_v2_for_nntrainer(params, config, dtype):
+    """Collect weights as ordered (nntrainer_name, ndarray) pairs."""
+    view = params_view(params)
+    weights = []
+    for nntr_name, hf_key, transpose in _entries(params, config):
+        arr = tensor_to_numpy(view[hf_key], dtype, transpose=transpose)
+        weights.append((nntr_name, arr))
+
+    return weights
+
+
+def params_view(params):
+    """Memoize the prefix-stripped state dict view."""
+    return strip_encoder_prefix(params)
+
+
+def save_safetensors(weights, output_path, dtype):
+    """Write weights to a safetensors file."""
+    if dtype not in SAFETENSORS_DTYPE_MAP:
+        raise ValueError(f"Unsupported safetensors dtype: {dtype}")
+
+    safetensors_dtype = SAFETENSORS_DTYPE_MAP[dtype]
+    metadata = {"format": "pt"}
+
+    offset = 0
+    tensor_meta = {}
+    raw_buffers = []
+
+    for name, arr in weights:
+        if not arr.flags["C_CONTIGUOUS"]:
+            arr = np.ascontiguousarray(arr)
+
+        nbytes = arr.nbytes
+        tensor_meta[name] = {
+            "dtype": safetensors_dtype,
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+
+        raw_buffers.append(arr.tobytes(order="C"))
+        offset += nbytes
+
+    header = {"__metadata__": metadata}
+    header.update(tensor_meta)
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(struct.pack("<Q", len(header_bytes)))
+        output_file.write(header_bytes)
+
+        for buffer in raw_buffers:
+            output_file.write(buffer)
+
+    print(f"Saved safetensors: {output_path}")
+    print(f"Tensor data size: {offset / 1e9:.2f} GB")
+
+
+def parse_args():
+    """Parse command line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model_path",
@@ -126,25 +210,47 @@ def main():
         "--output_name",
         type=str,
         default="./nntr_deberta_v2_fp32.bin",
-        help="Output nntrainer binary weight path",
+        help="Output nntrainer weight path",
     )
     parser.add_argument(
         "--data_type",
         type=str,
         default="float32",
-        choices=["float32", "float16"],
-        help="Weight dtype written to the binary file",
+        choices=["float32"],
+        help="Output data type",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--safetensors",
+        action="store_true",
+        help="Save weights in safetensors format instead of binary format",
+    )
+    return parser.parse_args()
 
-    dtype = np.float16 if args.data_type == "float16" else np.float32
-    config, params = _load_model_config_and_params(args.model_path)
 
-    output_path = Path(args.output_name)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+def main():
+    """Convert DeBERTa V2 Hugging Face weights to nntrainer weight format."""
+    args = parse_args()
 
-    with torch.no_grad(), output_path.open("wb") as output_file:
-        save_deberta_v2_for_nntrainer(params, config, dtype, output_file)
+    config = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.float32,
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    params = model.state_dict()
+
+    if args.safetensors:
+        output_name = get_safetensors_output_name(args.output_name)
+        weights = collect_deberta_v2_for_nntrainer(params, config, args.data_type)
+        save_safetensors(weights, output_name, args.data_type)
+        return
+
+    with torch.no_grad(), open(args.output_name, "wb") as output_file:
+        save_deberta_v2_for_nntrainer(params, config, args.data_type, output_file)
+
+    print(f"Saved binary: {args.output_name}")
 
 
 if __name__ == "__main__":

--- a/Applications/CausalLM/res/kalm-embedding/weight_converter.py
+++ b/Applications/CausalLM/res/kalm-embedding/weight_converter.py
@@ -6,75 +6,276 @@
 # @author Seunghui Lee <shsh1004.lee@samsung.com>
 
 import argparse
-import torch
+import json
+import struct
+
 import numpy as np
-from transformers import AutoConfig, AutoTokenizer
-from sentence_transformers import SentenceTransformer
+import torch
+from transformers import AutoConfig, AutoModel
 
-def save_kalm_embedding_for_nntrainer(params, n_layers, dtype, file):  
-    """Convert and save weights as nntrainer format for multi-head attention model"""  
-      
-    def save_weight(weight):
-        np.array(weight, dtype=dtype).tofile(file)  
 
-    def save_projection(layer_name, proj_name):  
-        """Helper function to handle base/lora weight saving"""  
-        lora_key = f"{layer_name}{proj_name}.lora_A.default.weight"  
-        if lora_key in params:  
-            save_weight(params[f"{layer_name}{proj_name}.base_layer.weight"].permute(1, 0))  
-            save_weight(params[f"{layer_name}{proj_name}.lora_A.default.weight"].permute(1, 0))  
-            save_weight(params[f"{layer_name}{proj_name}.lora_B.default.weight"].permute(1, 0))  
-        else:  
-            save_weight(params[f"{layer_name}{proj_name}.weight"].permute(1, 0))  
+SAFETENSORS_DTYPE_MAP = {
+    "float32": "F32",
+}
 
-    def save_attention(layer_name):  
-        """Save attention layer weights"""  
-        save_weight(params[f"{layer_name}input_layernorm.weight"])  
-          
-        # Save Q/K/V/O projections using helper  
+
+def tensor_to_numpy(tensor, dtype, transpose=False):
+    """Convert torch tensor to contiguous numpy array."""
+    if transpose:
+        tensor = tensor.permute(1, 0)
+
+    return np.ascontiguousarray(tensor.detach().cpu().numpy().astype(dtype))
+
+
+def get_safetensors_output_name(output_name):
+    """Return safetensors output path based on the given output name."""
+    if output_name.endswith(".bin"):
+        return output_name[:-4] + ".safetensors"
+
+    if output_name.endswith(".safetensors"):
+        return output_name
+
+    return output_name + ".safetensors"
+
+
+def resolve_prefix(params):
+    """Resolve the Qwen2 backbone key prefix inside a (possibly wrapped) state dict.
+
+    Plain ``AutoModel`` (Qwen2Model) yields keys like ``embed_tokens.weight``;
+    a ``SentenceTransformer`` wrapper yields ``0.auto_model.embed_tokens.weight``.
+    """
+    candidates = ["", "model.", "0.auto_model.", "auto_model."]
+    for prefix in candidates:
+        if f"{prefix}embed_tokens.weight" in params:
+            return prefix
+
+    raise KeyError("Cannot find Qwen2 embedding backbone weights in state_dict")
+
+
+def save_kalm_embedding_for_nntrainer(params, n_layers, dtype, file):
+    """Convert and save weights as nntrainer binary format for KaLM embedding."""
+
+    prefix = resolve_prefix(params)
+
+    def save_weight(tensor, transpose=False):
+        arr = tensor_to_numpy(tensor, dtype, transpose=transpose)
+        arr.tofile(file)
+
+    def save_projection(layer_name, proj_name):
+        """Save projection weight, handling optional LoRA weights."""
+        base_key = f"{layer_name}{proj_name}.base_layer.weight"
+        weight_key = f"{layer_name}{proj_name}.weight"
+        lora_a_key = f"{layer_name}{proj_name}.lora_A.default.weight"
+        lora_b_key = f"{layer_name}{proj_name}.lora_B.default.weight"
+
+        if lora_a_key in params:
+            save_weight(params[base_key], transpose=True)
+            save_weight(params[lora_a_key], transpose=True)
+            save_weight(params[lora_b_key], transpose=True)
+            return
+
+        save_weight(params[weight_key], transpose=True)
+
+    def save_attention(layer_name):
+        """Save attention layer weights (Qwen2 backbone uses bias on Q/K/V)."""
+        save_weight(params[f"{layer_name}input_layernorm.weight"])
+
         for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
             save_projection(layer_name, f"self_attn.{proj}")
-            if proj != "o_proj":
-                save_weight(params[f"{layer_name}self_attn.{proj}.bias"])
+
+            bias_key = f"{layer_name}self_attn.{proj}.bias"
+            if bias_key in params:
+                save_weight(params[bias_key])
 
     def save_feed_forward(layer_name):
-        """Save feed forward layer weights"""  
-        save_weight(params[f"{layer_name}post_attention_layernorm.weight"])   
+        """Save feed-forward layer weights in nntrainer up, gate, down order."""
+        save_weight(params[f"{layer_name}post_attention_layernorm.weight"])
 
-        # Save MLP projections using helper  
-        for proj in ["up_proj", "gate_proj", "down_proj"]:  
-            save_projection(layer_name, f"mlp.{proj}")  
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
+            save_projection(layer_name, f"mlp.{proj}")
 
-    # Save embedding layer  
-    save_weight(params["0.auto_model.embed_tokens.weight"])  
+    save_weight(params[f"{prefix}embed_tokens.weight"])
 
-    # Process all layers  
-    for layer_idx in range(n_layers):  
-        layer_prefix = f"0.auto_model.layers.{layer_idx}."  
-        save_attention(layer_prefix)  
-        save_feed_forward(layer_prefix)  
+    for layer_idx in range(n_layers):
+        layer_prefix = f"{prefix}layers.{layer_idx}."
+        save_attention(layer_prefix)
+        save_feed_forward(layer_prefix)
 
-    # Save final layers  
-    save_weight(params["0.auto_model.norm.weight"])
+    save_weight(params[f"{prefix}norm.weight"])
+
+
+def collect_kalm_embedding_for_nntrainer(params, n_layers, dtype):
+    """Collect weights as ordered (nntrainer_name, ndarray) pairs."""
+    prefix = resolve_prefix(params)
+    weights = []
+
+    def add(name, tensor, transpose=False):
+        arr = tensor_to_numpy(tensor, dtype, transpose=transpose)
+        weights.append((name, arr))
+
+    def add_projection(nntr_name, layer_name, proj_name):
+        base_key = f"{layer_name}{proj_name}.base_layer.weight"
+        weight_key = f"{layer_name}{proj_name}.weight"
+        lora_a_key = f"{layer_name}{proj_name}.lora_A.default.weight"
+
+        if lora_a_key in params:
+            add(nntr_name, params[base_key], transpose=True)
+            return
+
+        add(nntr_name, params[weight_key], transpose=True)
+
+    add("embedding0:Embedding", params[f"{prefix}embed_tokens.weight"])
+
+    for layer_idx in range(n_layers):
+        hf_prefix = f"{prefix}layers.{layer_idx}."
+        nntr_prefix = f"layer{layer_idx}"
+
+        add(
+            f"{nntr_prefix}_attention_norm:gamma",
+            params[f"{hf_prefix}input_layernorm.weight"],
+        )
+
+        for proj, nntr in [("q_proj", "wq"), ("k_proj", "wk"), ("v_proj", "wv")]:
+            add_projection(
+                f"{nntr_prefix}_{nntr}:weight",
+                hf_prefix,
+                f"self_attn.{proj}",
+            )
+            bias_key = f"{hf_prefix}self_attn.{proj}.bias"
+            if bias_key in params:
+                add(f"{nntr_prefix}_{nntr}:bias", params[bias_key])
+
+        add_projection(
+            f"{nntr_prefix}_attention_out:weight",
+            hf_prefix,
+            "self_attn.o_proj",
+        )
+
+        add(
+            f"{nntr_prefix}_ffn_norm:gamma",
+            params[f"{hf_prefix}post_attention_layernorm.weight"],
+        )
+
+        add_projection(f"{nntr_prefix}_ffn_up:weight", hf_prefix, "mlp.up_proj")
+        add_projection(f"{nntr_prefix}_ffn_gate:weight", hf_prefix, "mlp.gate_proj")
+        add_projection(f"{nntr_prefix}_ffn_down:weight", hf_prefix, "mlp.down_proj")
+
+    add("output_norm:gamma", params[f"{prefix}norm.weight"])
+
+    return weights
+
+
+def save_safetensors(weights, output_path, dtype):
+    """Write weights to a safetensors file."""
+    if dtype not in SAFETENSORS_DTYPE_MAP:
+        raise ValueError(f"Unsupported safetensors dtype: {dtype}")
+
+    safetensors_dtype = SAFETENSORS_DTYPE_MAP[dtype]
+    metadata = {"format": "pt"}
+
+    offset = 0
+    tensor_meta = {}
+    raw_buffers = []
+
+    for name, arr in weights:
+        if not arr.flags["C_CONTIGUOUS"]:
+            arr = np.ascontiguousarray(arr)
+
+        nbytes = arr.nbytes
+        tensor_meta[name] = {
+            "dtype": safetensors_dtype,
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+
+        raw_buffers.append(arr.tobytes(order="C"))
+        offset += nbytes
+
+    header = {"__metadata__": metadata}
+    header.update(tensor_meta)
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(struct.pack("<Q", len(header_bytes)))
+        output_file.write(header_bytes)
+
+        for buffer in raw_buffers:
+            output_file.write(buffer)
+
+    print(f"Saved safetensors: {output_path}")
+    print(f"Tensor data size: {offset / 1e9:.2f} GB")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="KaLM-Embedding/KaLM-embedding-multilingual-mini-instruct-v2.5",
+        help="Hugging Face model path or local model directory",
+    )
+    parser.add_argument(
+        "--output_name",
+        type=str,
+        default="./nntr_kalm_embedding_fp32.bin",
+        help="Output weight file path",
+    )
+    parser.add_argument(
+        "--data_type",
+        type=str,
+        default="float32",
+        choices=["float32"],
+        help="Output data type",
+    )
+    parser.add_argument(
+        "--safetensors",
+        action="store_true",
+        help="Save weights in safetensors format instead of binary format",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """Convert KaLM embedding Hugging Face weights to nntrainer weight format."""
+    args = parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.float32,
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    params = model.state_dict()
+
+    if args.safetensors:
+        output_name = get_safetensors_output_name(args.output_name)
+
+        weights = collect_kalm_embedding_for_nntrainer(
+            params,
+            config.num_hidden_layers,
+            args.data_type,
+        )
+
+        save_safetensors(weights, output_name, args.data_type)
+        return
+
+    with open(args.output_name, "wb") as output_file:
+        save_kalm_embedding_for_nntrainer(
+            params,
+            config.num_hidden_layers,
+            args.data_type,
+            output_file,
+        )
+
+    print(f"Saved binary: {args.output_name}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_path", type=str, default="KaLM-Embedding/KaLM-embedding-multilingual-mini-instruct-v2.5")
-    parser.add_argument("--output_name", type=str, default="./nntr_kalm_embedding_fp32.bin")
-    parser.add_argument("--data_type", type=str, default="float32")
-    args = parser.parse_args()
-    
-    data_dtype = args.data_type
-    model_path = args.model_path
-    output_name = args.output_name
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
-    config = AutoConfig.from_pretrained(model_path)
-    
-    model = SentenceTransformer(model_path, trust_remote_code=True, model_kwargs={"torch_dtype": data_dtype})
-    model.eval()
-
-    with open(output_name, "wb") as f_model :
-        save_kalm_embedding_for_nntrainer(model.state_dict(), config.num_hidden_layers, data_dtype, f_model)
+    main()

--- a/Applications/CausalLM/res/qwen2/qwen2-0.5b/weight_converter.py
+++ b/Applications/CausalLM/res/qwen2/qwen2-0.5b/weight_converter.py
@@ -6,76 +6,313 @@
 # @author Seunghui Lee <shsh1004.lee@samsung.com>
 
 import argparse
-import torch
+import json
+import struct
+
 import numpy as np
-from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
 
-def save_qwen2_for_nntrainer(params, n_layers, dtype, file):  
-    """Convert and save weights as nntrainer format for multi-head attention model"""  
-      
-    def save_weight(weight):
-        np.array(weight, dtype=dtype).tofile(file)  
 
-    def save_projection(layer_name, proj_name):  
-        """Helper function to handle base/lora weight saving"""  
-        lora_key = f"{layer_name}{proj_name}.lora_A.default.weight"  
-        if lora_key in params:  
-            save_weight(params[f"{layer_name}{proj_name}.base_layer.weight"].permute(1, 0))  
-            save_weight(params[f"{layer_name}{proj_name}.lora_A.default.weight"].permute(1, 0))  
-            save_weight(params[f"{layer_name}{proj_name}.lora_B.default.weight"].permute(1, 0))  
-        else:  
-            save_weight(params[f"{layer_name}{proj_name}.weight"].permute(1, 0))  
+SAFETENSORS_DTYPE_MAP = {
+    "float32": "F32",
+}
 
-    def save_attention(layer_name):  
-        """Save attention layer weights"""  
-        save_weight(params[f"{layer_name}input_layernorm.weight"])  
-          
-        # Save Q/K/V/O projections using helper  
+
+def tensor_to_numpy(tensor, dtype, transpose=False):
+    """Convert torch tensor to contiguous numpy array."""
+    if transpose:
+        tensor = tensor.permute(1, 0)
+
+    return np.ascontiguousarray(tensor.detach().cpu().numpy().astype(dtype))
+
+
+def get_tie_word_embeddings(config):
+    """Return whether the model uses tied word embeddings."""
+    return getattr(config, "tie_word_embeddings", True)
+
+
+def get_safetensors_output_name(output_name):
+    """Return safetensors output path based on the given output name."""
+    if output_name.endswith(".bin"):
+        return output_name[:-4] + ".safetensors"
+
+    if output_name.endswith(".safetensors"):
+        return output_name
+
+    return output_name + ".safetensors"
+
+
+def save_qwen2_for_nntrainer(
+    params,
+    n_layers,
+    dtype,
+    file,
+    tie_word_embeddings=True,
+):
+    """Convert and save weights as nntrainer binary format for Qwen2 model."""
+
+    def save_weight(tensor, transpose=False):
+        arr = tensor_to_numpy(tensor, dtype, transpose=transpose)
+        arr.tofile(file)
+
+    def save_projection(layer_name, proj_name):
+        """Save projection weight.
+
+        If LoRA weights exist, save base, LoRA A, and LoRA B weights in order.
+        """
+        base_key = f"{layer_name}{proj_name}.base_layer.weight"
+        weight_key = f"{layer_name}{proj_name}.weight"
+        lora_a_key = f"{layer_name}{proj_name}.lora_A.default.weight"
+        lora_b_key = f"{layer_name}{proj_name}.lora_B.default.weight"
+
+        if lora_a_key in params:
+            save_weight(params[base_key], transpose=True)
+            save_weight(params[lora_a_key], transpose=True)
+            save_weight(params[lora_b_key], transpose=True)
+            return
+
+        save_weight(params[weight_key], transpose=True)
+
+    def save_attention(layer_name):
+        """Save attention layer weights (Qwen2 uses bias on Q/K/V)."""
+        save_weight(params[f"{layer_name}input_layernorm.weight"])
+
         for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
             save_projection(layer_name, f"self_attn.{proj}")
-            if proj != "o_proj":
-                save_weight(params[f"{layer_name}self_attn.{proj}.bias"])
+
+            bias_key = f"{layer_name}self_attn.{proj}.bias"
+            if bias_key in params:
+                save_weight(params[bias_key])
 
     def save_feed_forward(layer_name):
-        """Save feed forward layer weights"""
+        """Save feed-forward layer weights."""
         save_weight(params[f"{layer_name}post_attention_layernorm.weight"])
 
-        # Save MLP projections using helper
-        for proj in ["gate_proj", "up_proj", "down_proj"]:
+        # nntrainer stores MLP weights in up, gate, down order (see
+        # Transformer::createMlp in models/transformer.cpp).
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
             save_projection(layer_name, f"mlp.{proj}")
 
-    # Save embedding layer  
-    save_weight(params["model.embed_tokens.weight"])  
+    save_weight(params["model.embed_tokens.weight"])
 
-    # Process all layers  
-    for layer_idx in range(n_layers):  
-        layer_prefix = f"model.layers.{layer_idx}."  
-        save_attention(layer_prefix)  
-        save_feed_forward(layer_prefix)  
+    for layer_idx in range(n_layers):
+        layer_prefix = f"model.layers.{layer_idx}."
+        save_attention(layer_prefix)
+        save_feed_forward(layer_prefix)
 
-    # Save final layers  
-    save_weight(params["model.norm.weight"])  
-    
-    # Qwen2 model uses tie_word_embedding.
-    # embed_token shares weights with lm_head.
-    # so lm_head weights don't need to be saved separately.
+    save_weight(params["model.norm.weight"])
 
-if __name__ == "__main__":
+    # Qwen2 uses tied word embeddings; lm_head shares model.embed_tokens.weight,
+    # so no separate lm_head weight is written.
+    if not tie_word_embeddings:
+        save_weight(params["lm_head.weight"], transpose=True)
+
+
+def collect_qwen2_for_nntrainer(
+    params,
+    n_layers,
+    dtype,
+    tie_word_embeddings=True,
+):
+    """Collect weights as ordered (nntrainer_name, ndarray) pairs."""
+    weights = []
+
+    def add(name, tensor, transpose=False):
+        arr = tensor_to_numpy(tensor, dtype, transpose=transpose)
+        weights.append((name, arr))
+
+    def add_projection(nntr_name, layer_name, proj_name):
+        """Add projection weight for safetensors export.
+
+        Note: this safetensors path exports the main projection weight only.
+        """
+        base_key = f"{layer_name}{proj_name}.base_layer.weight"
+        weight_key = f"{layer_name}{proj_name}.weight"
+        lora_a_key = f"{layer_name}{proj_name}.lora_A.default.weight"
+
+        if lora_a_key in params:
+            add(nntr_name, params[base_key], transpose=True)
+            return
+
+        add(nntr_name, params[weight_key], transpose=True)
+
+    add("embedding0:Embedding", params["model.embed_tokens.weight"])
+
+    for layer_idx in range(n_layers):
+        hf_prefix = f"model.layers.{layer_idx}."
+        nntr_prefix = f"layer{layer_idx}"
+
+        add(
+            f"{nntr_prefix}_attention_norm:gamma",
+            params[f"{hf_prefix}input_layernorm.weight"],
+        )
+
+        for proj, nntr in [("q_proj", "wq"), ("k_proj", "wk"), ("v_proj", "wv")]:
+            add_projection(
+                f"{nntr_prefix}_{nntr}:weight",
+                hf_prefix,
+                f"self_attn.{proj}",
+            )
+            bias_key = f"{hf_prefix}self_attn.{proj}.bias"
+            if bias_key in params:
+                add(f"{nntr_prefix}_{nntr}:bias", params[bias_key])
+
+        add_projection(
+            f"{nntr_prefix}_attention_out:weight",
+            hf_prefix,
+            "self_attn.o_proj",
+        )
+
+        add(
+            f"{nntr_prefix}_ffn_norm:gamma",
+            params[f"{hf_prefix}post_attention_layernorm.weight"],
+        )
+
+        add_projection(
+            f"{nntr_prefix}_ffn_up:weight",
+            hf_prefix,
+            "mlp.up_proj",
+        )
+        add_projection(
+            f"{nntr_prefix}_ffn_gate:weight",
+            hf_prefix,
+            "mlp.gate_proj",
+        )
+        add_projection(
+            f"{nntr_prefix}_ffn_down:weight",
+            hf_prefix,
+            "mlp.down_proj",
+        )
+
+    add("output_norm:gamma", params["model.norm.weight"])
+
+    if not tie_word_embeddings:
+        add(
+            "output_of_causallm:weight",
+            params["lm_head.weight"],
+            transpose=True,
+        )
+
+    return weights
+
+
+def save_safetensors(weights, output_path, dtype):
+    """Write weights to a safetensors file."""
+    if dtype not in SAFETENSORS_DTYPE_MAP:
+        raise ValueError(f"Unsupported safetensors dtype: {dtype}")
+
+    safetensors_dtype = SAFETENSORS_DTYPE_MAP[dtype]
+    metadata = {"format": "pt"}
+
+    offset = 0
+    tensor_meta = {}
+    raw_buffers = []
+
+    for name, arr in weights:
+        if not arr.flags["C_CONTIGUOUS"]:
+            arr = np.ascontiguousarray(arr)
+
+        nbytes = arr.nbytes
+        tensor_meta[name] = {
+            "dtype": safetensors_dtype,
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+
+        raw_buffers.append(arr.tobytes(order="C"))
+        offset += nbytes
+
+    header = {"__metadata__": metadata}
+    header.update(tensor_meta)
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(struct.pack("<Q", len(header_bytes)))
+        output_file.write(header_bytes)
+
+        for buffer in raw_buffers:
+            output_file.write(buffer)
+
+    print(f"Saved safetensors: {output_path}")
+    print(f"Tensor data size: {offset / 1e9:.2f} GB")
+
+
+def parse_args():
+    """Parse command line arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_path", type=str, default="Qwen/Qwen2-0.5B")
-    parser.add_argument("--output_name", type=str, default="./nntr_qwen2_0.5b_fp32.bin")
-    parser.add_argument("--data_type", type=str, default="float32")
-    args = parser.parse_args()
-    
-    data_dtype = args.data_type
-    model_path = args.model_path
-    output_name = args.output_name
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
-    config = AutoConfig.from_pretrained(model_path)
-    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=data_dtype, trust_remote_code=True)
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="Qwen/Qwen2-0.5B",
+        help="Hugging Face model path or local model directory",
+    )
+    parser.add_argument(
+        "--output_name",
+        type=str,
+        default="./nntr_qwen2_0.5b_fp32.bin",
+        help="Output weight file path",
+    )
+    parser.add_argument(
+        "--data_type",
+        type=str,
+        default="float32",
+        choices=["float32"],
+        help="Output data type",
+    )
+    parser.add_argument(
+        "--safetensors",
+        action="store_true",
+        help="Save weights in safetensors format instead of binary format",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """Convert Qwen2 Hugging Face weights to nntrainer weight format."""
+    args = parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_path)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.float32,
+        trust_remote_code=True,
+    )
     model.eval()
 
-    with open(output_name, "wb") as f_model :
-        save_qwen2_for_nntrainer(model.state_dict(), config.num_hidden_layers, data_dtype, f_model)
+    tie_word_embeddings = get_tie_word_embeddings(config)
+    print(f"tie_word_embeddings: {tie_word_embeddings}")
+
+    params = model.state_dict()
+
+    if args.safetensors:
+        output_name = get_safetensors_output_name(args.output_name)
+
+        weights = collect_qwen2_for_nntrainer(
+            params,
+            config.num_hidden_layers,
+            args.data_type,
+            tie_word_embeddings=tie_word_embeddings,
+        )
+
+        save_safetensors(weights, output_name, args.data_type)
+        return
+
+    with open(args.output_name, "wb") as output_file:
+        save_qwen2_for_nntrainer(
+            params,
+            config.num_hidden_layers,
+            args.data_type,
+            output_file,
+            tie_word_embeddings=tie_word_embeddings,
+        )
+
+    print(f"Saved binary: {args.output_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Applications/CausalLM/res/tiny-bert/weight_converter.py
+++ b/Applications/CausalLM/res/tiny-bert/weight_converter.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+
+## @file weight_converter.py
+## @brief weight conversion script for multilingual tiny-BERT embedding model
+## @author Seunghui Lee <shsh1004.lee@samsung.com>
+
+import argparse
+import json
+import struct
+
+import numpy as np
+import torch
+from transformers import AutoConfig, AutoModel
+
+
+SAFETENSORS_DTYPE_MAP = {
+    "float32": "F32",
+}
+
+
+def tensor_to_numpy(tensor, dtype, transpose=False):
+    """Convert torch tensor to contiguous numpy array."""
+    if transpose:
+        tensor = tensor.permute(1, 0)
+
+    return np.ascontiguousarray(tensor.detach().cpu().numpy().astype(dtype))
+
+
+def get_safetensors_output_name(output_name):
+    """Return safetensors output path based on the given output name."""
+    if output_name.endswith(".bin"):
+        return output_name[:-4] + ".safetensors"
+
+    if output_name.endswith(".safetensors"):
+        return output_name
+
+    return output_name + ".safetensors"
+
+
+def resolve_prefix(params):
+    """Resolve the BERT encoder key prefix inside the state dict.
+
+    ``AutoModel`` (BertModel) yields ``embeddings.word_embeddings.weight``;
+    ``BertForMaskedLM`` yields ``bert.embeddings.word_embeddings.weight``.
+    """
+    for prefix in ["", "bert."]:
+        if f"{prefix}embeddings.word_embeddings.weight" in params:
+            return prefix
+
+    raise KeyError("Cannot find BERT encoder weights in state_dict")
+
+
+def _entries(params, n_layers):
+    """Yield (nntrainer_name, hf_key, transpose) in nntrainer weight order.
+
+    Mirrors BertTransformer in models/bert/bert_transformer.cpp:
+      embeddings -> per encoder layer [attn q/k/v, attn out, attn norm,
+      ffn fc1, ffn down, ffn norm]. FC weights are transposed; biases and
+      LayerNorm gamma/beta are stored as-is.
+    """
+    p = resolve_prefix(params)
+
+    # --- Embeddings (embedding_layer weight name suffix is "Embedding") ---
+    yield "embedding0:Embedding", f"{p}embeddings.word_embeddings.weight", False
+    yield "position_embedding:Embedding", f"{p}embeddings.position_embeddings.weight", False
+    yield "token_type_embedding:Embedding", f"{p}embeddings.token_type_embeddings.weight", False
+    yield "embedding_norm:gamma", f"{p}embeddings.LayerNorm.weight", False
+    yield "embedding_norm:beta", f"{p}embeddings.LayerNorm.bias", False
+
+    # --- Encoder layers ---
+    for i in range(n_layers):
+        hf = f"{p}encoder.layer.{i}."
+        nn = f"layer{i}"
+        self_attn = f"{hf}attention.self."
+
+        yield f"{nn}_wq:weight", f"{self_attn}query.weight", True
+        yield f"{nn}_wq:bias", f"{self_attn}query.bias", False
+        yield f"{nn}_wk:weight", f"{self_attn}key.weight", True
+        yield f"{nn}_wk:bias", f"{self_attn}key.bias", False
+        yield f"{nn}_wv:weight", f"{self_attn}value.weight", True
+        yield f"{nn}_wv:bias", f"{self_attn}value.bias", False
+
+        yield f"{nn}_attention_out:weight", f"{hf}attention.output.dense.weight", True
+        yield f"{nn}_attention_out:bias", f"{hf}attention.output.dense.bias", False
+        yield f"{nn}_attention_norm:gamma", f"{hf}attention.output.LayerNorm.weight", False
+        yield f"{nn}_attention_norm:beta", f"{hf}attention.output.LayerNorm.bias", False
+
+        yield f"{nn}_ffn_fc1:weight", f"{hf}intermediate.dense.weight", True
+        yield f"{nn}_ffn_fc1:bias", f"{hf}intermediate.dense.bias", False
+        yield f"{nn}_ffn_down:weight", f"{hf}output.dense.weight", True
+        yield f"{nn}_ffn_down:bias", f"{hf}output.dense.bias", False
+        yield f"{nn}_ffn_norm:gamma", f"{hf}output.LayerNorm.weight", False
+        yield f"{nn}_ffn_norm:beta", f"{hf}output.LayerNorm.bias", False
+
+
+def save_tinybert_for_nntrainer(params, n_layers, dtype, file):
+    """Convert and save weights as nntrainer binary format for tiny-BERT."""
+    for _, hf_key, transpose in _entries(params, n_layers):
+        arr = tensor_to_numpy(params[hf_key], dtype, transpose=transpose)
+        arr.tofile(file)
+
+
+def collect_tinybert_for_nntrainer(params, n_layers, dtype):
+    """Collect weights as ordered (nntrainer_name, ndarray) pairs."""
+    weights = []
+    for nntr_name, hf_key, transpose in _entries(params, n_layers):
+        arr = tensor_to_numpy(params[hf_key], dtype, transpose=transpose)
+        weights.append((nntr_name, arr))
+
+    return weights
+
+
+def save_safetensors(weights, output_path, dtype):
+    """Write weights to a safetensors file."""
+    if dtype not in SAFETENSORS_DTYPE_MAP:
+        raise ValueError(f"Unsupported safetensors dtype: {dtype}")
+
+    safetensors_dtype = SAFETENSORS_DTYPE_MAP[dtype]
+    metadata = {"format": "pt"}
+
+    offset = 0
+    tensor_meta = {}
+    raw_buffers = []
+
+    for name, arr in weights:
+        if not arr.flags["C_CONTIGUOUS"]:
+            arr = np.ascontiguousarray(arr)
+
+        nbytes = arr.nbytes
+        tensor_meta[name] = {
+            "dtype": safetensors_dtype,
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+
+        raw_buffers.append(arr.tobytes(order="C"))
+        offset += nbytes
+
+    header = {"__metadata__": metadata}
+    header.update(tensor_meta)
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(struct.pack("<Q", len(header_bytes)))
+        output_file.write(header_bytes)
+
+        for buffer in raw_buffers:
+            output_file.write(buffer)
+
+    print(f"Saved safetensors: {output_path}")
+    print(f"Tensor data size: {offset / 1e9:.2f} GB")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="zl369/multilingual-tinyBERT-16MB",
+        help="Hugging Face model path or local model directory",
+    )
+    parser.add_argument(
+        "--output_name",
+        type=str,
+        default="./tinybert_fp32.bin",
+        help="Output weight file path",
+    )
+    parser.add_argument(
+        "--data_type",
+        type=str,
+        default="float32",
+        choices=["float32"],
+        help="Output data type",
+    )
+    parser.add_argument(
+        "--safetensors",
+        action="store_true",
+        help="Save weights in safetensors format instead of binary format",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """Convert tiny-BERT Hugging Face weights to nntrainer weight format."""
+    args = parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.float32,
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    params = model.state_dict()
+
+    if args.safetensors:
+        output_name = get_safetensors_output_name(args.output_name)
+        weights = collect_tinybert_for_nntrainer(
+            params, config.num_hidden_layers, args.data_type
+        )
+        save_safetensors(weights, output_name, args.data_type)
+        return
+
+    with open(args.output_name, "wb") as output_file:
+        save_tinybert_for_nntrainer(
+            params, config.num_hidden_layers, args.data_type, output_file
+        )
+
+    print(f"Saved binary: {args.output_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Dependency of the PR

End-to-end validation of the tiny-bert and deberta_v2 converters depends on the
encoder attention fixes in **[CausalLM] Fix BERT and DeBERTa V2 encoder
attention** (branch `fix/causallm-encoder-attention`). 
-> https://github.com/nntrainer/nntrainer/pull/3982

## Commits to be reviewed in this PR

<details><summary>[CausalLM] Fix qwen2-0.5b weight_converter and add safetensors output</summary><br />

Align `res/qwen2/qwen2-0.5b/weight_converter.py` with the qwen3-0.6b reference.
Correct the MLP binary order from `gate,up,down` to `up,gate,down` to match
`Transformer::createMlp`, keep Q/K/V bias and tied-embedding handling, and add a
`--safetensors` export path that writes nntrainer weight names directly.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[CausalLM] Rework kalm-embedding weight_converter</summary><br />

Load the Qwen2 backbone with plain `transformers` `AutoModel` instead of
`sentence-transformers`, resolve the state-dict prefix automatically, and add a
`--safetensors` export path following the qwen3-0.6b reference.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[CausalLM] Add safetensors output to deberta_v2 weight_converter</summary><br />

Restructure `res/deberta_v2/weight_converter.py` around the qwen3-0.6b reference.
Load with plain `transformers`, keep the nntrainer binary order (rel_embeddings
emitted after the first layer's Q/K/V), and add a `--safetensors` export path
using the correct nntrainer weight names.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[CausalLM] Add weight_converter for tiny-bert</summary><br />

Add `res/tiny-bert/weight_converter.py` to convert multilingual-tinyBERT encoder
weights into the nntrainer BERT layout, supporting both binary and safetensors
(`--safetensors`) output.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

Unifies the qwen2-0.5b, kalm-embedding, tiny-bert, and deberta_v2 weight
converters with the qwen3-0.6b reference: shared structure, a `--safetensors`
export flag in addition to the nntrainer binary format, and plain `transformers`
loading (drops the `sentence-transformers` dependency). Also fixes the qwen2 MLP
binary order (`gate,up,down` -> `up,gate,down`) and adds a new tiny-bert
converter.

Verification (build with `-Denable-transformer=true`, run `nntr_causallm`,
compare against HuggingFace `transformers` for the same input):

| Model | bin | safetensors | vs HuggingFace |
|-------|-----|-------------|----------------|
| qwen2-0.5b | ✅ | ✅ | greedy generation token-exact |
| kalm-embedding | ✅ | ✅ | mean-pooled embedding cos 0.9999994 |
| tiny-bert | ✅ | ✅ | CLS hidden state cos 0.99999999 |
| deberta_v2 | ✅ | ✅ | mean-pooled embedding cos 0.99999997 |

### How to use?

### Weight converter usage

```console
python3 weight_converter.py \
    --model_path  <HF hub id or local dir>   # source model
    --output_name <path/to/output.bin>       # output file
    [--safetensors]                          # write .safetensors instead of .bin
    [--data_type float32]                    # weight dtype (default: float32)
```

### Per-model examples

```console
# qwen2-0.5b (CausalLM)
python3 res/qwen2/qwen2-0.5b/weight_converter.py \
    --model_path Qwen/Qwen2-0.5B --output_name ./nntr_qwen2_0.5b_fp32.bin

# kalm-embedding
python3 res/kalm-embedding/weight_converter.py \
    --model_path KaLM-Embedding/KaLM-embedding-multilingual-mini-instruct-v2.5 \
    --output_name ./nntr_kalm_embedding_fp32.bin

# tiny-bert
python3 res/tiny-bert/weight_converter.py \
    --model_path zl369/multilingual-tinyBERT-16MB --output_name ./tinybert_fp32.bin

# deberta_v2
python3 res/deberta_v2/weight_converter.py \
    --model_path microsoft/mdeberta-v3-base --output_name ./nntr_deberta_v2_fp32.bin

# add --safetensors to any of the above to emit a .safetensors file instead
```

### Test
#### qwen2-0.5b
```console
$ ./nntr_causallm res/qwen2/qwen2-0.5b "The capital of France is"
 Paris. It is the largest city in France and the second largest in Europe. It is the capital of the Fifth Republic

# HuggingFace (transformers, do_sample=False)
 Paris. It is the largest city in France and the second largest in Europe. It is the capital of the Fifth Republic
```

#### kalm-embedding
```console
input: "This is an example sentence"   (DIM 896, first 10 dims)
nntrainer : [-0.010545, -0.021121,  0.009904, -0.008533, -0.004788,  0.010610, ...]
HuggingFace: [-0.010558, -0.021153,  0.009946, -0.008567, -0.004736,  0.010625, ...]
max abs diff = 5.7e-05   cosine = 0.9999994
```
#### tiny-bert
```console
input: "This is a sentence"   (DIM 32, first 10 dims of CLS token)
nntrainer : [-2.13659, 1.01522, -0.972241, -0.806628, -0.914149, -0.082743, ...]
HuggingFace: [-2.13650, 1.01512, -0.972210, -0.806590, -0.913830, -0.082860, ...]
max abs diff = 3.2e-04   cosine = 0.99999999
```
#### deberta_v2 
```console
input: "This is an example sentence"   (DIM 768, first 10 dims)
nntrainer : [-0.000477, -0.004533, -0.000528,  0.008642, -0.011086, -0.004126, ...]
HuggingFace: [-0.000477, -0.004534, -0.000527,  0.008642, -0.011086, -0.004125, ...]
max abs diff = 1.0e-06   cosine = 0.99999997
```