### PR TITLE
[kv_cache_manager] reduce peak memory

### DIFF
--- a/Applications/CausalLM/kv_cache_manager.cpp
+++ b/Applications/CausalLM/kv_cache_manager.cpp
@@ -68,8 +68,6 @@ void KVCacheManager::allocate(unsigned int num_layers, unsigned int batch_size,
                                    {format, dtype});
     layer_caches_[i].key_cache = nntrainer::Tensor(cache_dim, true);
     layer_caches_[i].value_cache = nntrainer::Tensor(cache_dim, true);
-    layer_caches_[i].key_cache.setZero();
-    layer_caches_[i].value_cache.setZero();
   }
 }
 


### PR DESCRIPTION
This commit removes redundant initialization which results peak memory explosion.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

---
With this PR we can reduce peak mem from 3.3 GB to 1.4GB for qwen3-0.6B model.