### PR TITLE
[Wait 4 #3967] [x86] feat: Enable FP16 attention (kcache/vcache/softmax) on x86 CPU Backend

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -33,6 +33,8 @@
 /usr/include/nntrainer/weight.h
 /usr/include/nntrainer/quantizer.h
 /usr/include/nntrainer/avx2_impl.h
+/usr/include/nntrainer/avx2_mathfun.h
+/usr/include/nntrainer/avx2_mathfun.hxx
 # todo: update dataset headers
 /usr/include/nntrainer/databuffer.h
 /usr/include/nntrainer/databuffer_factory.h

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -409,9 +409,18 @@ void __fallback_calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                             float *cos_, float *sin_,
                                             unsigned int from,
                                             float attention_scaling) {
-  throw std::runtime_error(
-    "Error: No implementation of rotary embedding layer incremental_forwarding "
-    "with SIMD acceleration except for NEON!");
+  const float from_f = static_cast<float>(from);
+  for (unsigned int i = 0; i < N_half; ++i) {
+    const float a = from_f * angle[i];
+    cos_[i] = std::cos(a) * attention_scaling;
+    sin_[i] = std::sin(a) * attention_scaling;
+  }
+  const unsigned int N = 2 * N_half;
+  for (unsigned int j = N_half, j_half = 0; j < N && j_half < N_half;
+       ++j, ++j_half) {
+    cos_[j] = cos_[j_half];
+    sin_[j] = sin_[j_half];
+  }
 }
 
 void __fallback_swiglu(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -1687,10 +1687,12 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
             accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
         }
 
-        float *remPtr = &sumRem.data()[h * rem];
-        int base = num_blocks * 8;
-        for (int r = 0; r < rem; ++r) {
-          remPtr[r] += a_val * tmp_fp32[base + r];
+        if (rem > 0) {
+          float *remPtr = &sumRem[(size_t)h * rem];
+          int base = num_blocks * 8;
+          for (int r = 0; r < rem; ++r) {
+            remPtr[r] += a_val * tmp_fp32[base + r];
+          }
         }
       }
     }
@@ -1703,11 +1705,13 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
           _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
       }
 
-      float *remPtr = &sumRem.data()[h * rem];
-      int base = num_blocks * 8;
-      for (int r = 0; r < rem; ++r) {
-        int out_idx = (n * gqa_size + h) * head_dim + base + r;
-        output[out_idx] = remPtr[r];
+      if (rem > 0) {
+        float *remPtr = &sumRem[(size_t)h * rem];
+        int base = num_blocks * 8;
+        for (int r = 0; r < rem; ++r) {
+          int out_idx = (n * gqa_size + h) * head_dim + base + r;
+          output[out_idx] = remPtr[r];
+        }
       }
     }
   }
@@ -1731,6 +1735,8 @@ void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
     num_rows < local_window_size ? 0 : num_rows - local_window_size;
   int row_cnt = num_rows < local_window_size ? num_rows : local_window_size;
   const int tile_count = (row_cnt + tile_size - 1) / tile_size;
+  const float inv_sqrt_head_dim =
+    1.0f / std::sqrt(static_cast<float>(head_dim));
 
   for (int n = head_start; n < actual_head_end; ++n) {
     for (int t = 0; t < tile_count; ++t) {
@@ -1772,7 +1778,7 @@ void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
             sum += in_ptr[i] * nntrainer::compute_fp16_to_fp32(kptr[i]);
 
           output[(row - start_row) * num_cache_head * gqa_size + n * gqa_size +
-                 g] = sum / sqrt((float)head_dim);
+                 g] = sum * inv_sqrt_head_dim;
         }
       }
     }

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -1651,16 +1651,21 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
   // its own thread_local copy). sumVec holds num_blocks*gqa_size accumulator
   // vectors as a flat float buffer (8 floats each) to avoid the
   // -Wignored-attributes warning that a std::vector<__m256> would raise.
+  // Resolve each thread_local data pointer once into a local so the hot loops
+  // do plain pointer arithmetic (no per-access TLS/vector indirection).
   static thread_local std::vector<float> tmp_fp32;
   static thread_local std::vector<float> sumVec;
   static thread_local std::vector<float> sumRem;
   tmp_fp32.resize(head_dim);
   sumVec.resize((size_t)std::max(1, num_blocks * gqa_size) * 8);
   sumRem.resize((size_t)gqa_size * rem);
+  float *tmp = tmp_fp32.data();
+  float *sv = sumVec.data();
+  float *rem_buf = sumRem.data();
 
   for (int n = head_start; n < actual_head_end; ++n) {
     for (int i = 0; i < num_blocks * gqa_size; i++) {
-      _mm256_storeu_ps(&sumVec[(size_t)i * 8], _mm256_setzero_ps());
+      _mm256_storeu_ps(&sv[(size_t)i * 8], _mm256_setzero_ps());
     }
     std::fill(sumRem.begin(), sumRem.end(), 0.0f);
 
@@ -1668,7 +1673,7 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
                                              : row_num + 1 - local_window_size;
          j <= row_num; ++j) {
       const uint16_t *vptr = vcache + (j * num_cache_head + n) * head_dim;
-      load_fp16_8_to_chunk(vptr, tmp_fp32.data(), head_dim);
+      load_fp16_8_to_chunk(vptr, tmp, head_dim);
 
       for (int h = 0; h < gqa_size; ++h) {
         float a_val =
@@ -1681,17 +1686,17 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
         __m256 inVec = _mm256_set1_ps(a_val);
 
         for (int b = 0; b < num_blocks; ++b) {
-          __m256 bVec = _mm256_loadu_ps(&tmp_fp32[b * 8]);
-          float *accPtr = &sumVec[(size_t)(h * num_blocks + b) * 8];
+          __m256 bVec = _mm256_loadu_ps(&tmp[b * 8]);
+          float *accPtr = &sv[(size_t)(h * num_blocks + b) * 8];
           _mm256_storeu_ps(
             accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
         }
 
         if (rem > 0) {
-          float *remPtr = &sumRem[(size_t)h * rem];
+          float *remPtr = &rem_buf[(size_t)h * rem];
           int base = num_blocks * 8;
           for (int r = 0; r < rem; ++r) {
-            remPtr[r] += a_val * tmp_fp32[base + r];
+            remPtr[r] += a_val * tmp[base + r];
           }
         }
       }
@@ -1702,11 +1707,11 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
         int out_base = (n * gqa_size + h) * head_dim + b * 8;
         _mm256_storeu_ps(
           &output[out_base],
-          _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
+          _mm256_loadu_ps(&sv[(size_t)(h * num_blocks + b) * 8]));
       }
 
       if (rem > 0) {
-        float *remPtr = &sumRem[(size_t)h * rem];
+        float *remPtr = &rem_buf[(size_t)h * rem];
         int base = num_blocks * 8;
         for (int r = 0; r < rem; ++r) {
           int out_idx = (n * gqa_size + h) * head_dim + base + r;

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -19,13 +19,13 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <fallback_internal.h>
 #include <fp16.h>
 #include <immintrin.h>
 #include <limits>
-#include <type_traits>
-#include <fallback_internal.h>
 #include <nntrainer_error.h>
 #include <thread_manager.h>
+#include <type_traits>
 #include <util_func.h>
 #include <vector>
 
@@ -731,8 +731,8 @@ void swiglu(const unsigned int N, float *X, const float *Y, const float *Z,
 }
 
 // poly_gelu_tanh_avx2 / poly_gelu_erf_avx2 are defined in avx2_internal.h
-using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
 using nntrainer::avx2::internal::poly_gelu_erf_avx2;
+using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
 
 // exp256_ps, hsum_avx, rcp_ps are also in avx2_internal.h
 using nntrainer::avx2::internal::exp256_ps;

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -328,6 +328,10 @@ avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
 
 namespace nntrainer::avx2 {
 
+// Forward declarations for internal helpers used across the file
+static inline __m256 exp256_ps(__m256 x);
+static float hsum_avx(__m256 v);
+
 /**
  * @brief struct of q4_0x8 block
  */
@@ -701,16 +705,25 @@ static inline void convert_q4_0x8_noshuffle(const void *src,
 
 // ================== wrappers for your K,N combinations ==================
 // K = 3072 (UNIT = 768)
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=98304
+ */
 void convert_q4_0x8_shuffle_K3072_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = (N*8)/UNIT = 1024
   convert_q4_0x8_noshuffle<768, 1024>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=36864
+ */
 void convert_q4_0x8_shuffle_K3072_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<768, 384>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=3072
+ */
 void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 32
@@ -718,16 +731,25 @@ void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
 }
 
 // K = 8192 (UNIT = 2048)
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=98304
+ */
 void convert_q4_0x8_shuffle_K8192_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<2048, 384>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=36864
+ */
 void convert_q4_0x8_shuffle_K8192_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 144
   convert_q4_0x8_noshuffle<2048, 144>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=3072
+ */
 void convert_q4_0x8_shuffle_K8192_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 12
@@ -1140,6 +1162,223 @@ void gelu_v2(const unsigned int N, const float *X, float *Y) {
   }
 }
 
+void tanh_gelu(const unsigned int N, const float *X, float *Y) {
+  unsigned int i = 0;
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 y = poly_gelu_tanh_avx2(x);
+    _mm256_storeu_ps(&Y[i], y);
+  }
+
+  for (; i < N; ++i) {
+    const float x = X[i];
+    Y[i] = 0.5f * x *
+           (1.0f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+  }
+}
+
+void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z) {
+  unsigned int i = 0;
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 y = _mm256_loadu_ps(&Y[i]);
+    __m256 g = poly_gelu_tanh_avx2(y);
+    __m256 z = _mm256_loadu_ps(&Z[i]);
+    _mm256_storeu_ps(&X[i], _mm256_mul_ps(g, z));
+  }
+
+  for (; i < N; ++i) {
+    const float y = Y[i];
+    float gelu_y =
+      0.5f * y *
+      (1.0f + std::tanh(0.7978845608f * (y + 0.044715f * y * y * y)));
+    X[i] = gelu_y * Z[i];
+  }
+}
+
+void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z) {
+  tanh_gelu_mul(N, X, Y, Z);
+}
+
+float max_val(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  __m256 vmax = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    vmax = _mm256_max_ps(vmax, x);
+  }
+
+  // Horizontal max reduction
+  __m128 hi = _mm256_extractf128_ps(vmax, 1);
+  __m128 lo = _mm256_castps256_ps128(vmax);
+  lo = _mm_max_ps(lo, hi);
+  __m128 shuf = _mm_movehl_ps(lo, lo);
+  lo = _mm_max_ps(lo, shuf);
+  shuf = _mm_movehdup_ps(lo);
+  lo = _mm_max_ss(lo, shuf);
+  float result = _mm_cvtss_f32(lo);
+
+  for (; i < N; ++i) {
+    result = std::max(result, X[i]);
+  }
+  return result;
+}
+
+void softmax(const unsigned int N, float *X, float *Y) {
+  // Step 1: find max
+  float max_x = max_val(N, X);
+  __m256 vmax = _mm256_set1_ps(max_x);
+
+  // Step 2: exp(x - max) and accumulate sum
+  unsigned int i = 0;
+  unsigned int N8 = (N & ~(7));
+  __m256 vsum = _mm256_setzero_ps();
+
+  for (; i < N8; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 e = exp256_ps(_mm256_sub_ps(x, vmax));
+    _mm256_storeu_ps(&Y[i], e);
+    vsum = _mm256_add_ps(vsum, e);
+  }
+
+  float sum = hsum_avx(vsum);
+  for (; i < N; ++i) {
+    float e = std::exp(X[i] - max_x);
+    Y[i] = e;
+    sum += e;
+  }
+
+  // Step 3: normalize
+  float inv_sum = 1.0f / sum;
+  __m256 vinv = _mm256_set1_ps(inv_sum);
+
+  i = 0;
+  for (; i < N8; i += 8) {
+    __m256 y = _mm256_loadu_ps(&Y[i]);
+    _mm256_storeu_ps(&Y[i], _mm256_mul_ps(y, vinv));
+  }
+  for (; i < N; ++i) {
+    Y[i] *= inv_sum;
+  }
+}
+
+void inv_sqrt_inplace(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  const __m256 zero = _mm256_setzero_ps();
+  const __m256 inf_val = _mm256_set1_ps(INFINITY);
+  const __m256 three_half = _mm256_set1_ps(1.5f);
+  const __m256 half = _mm256_set1_ps(0.5f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 is_zero = _mm256_cmp_ps(x, zero, _CMP_EQ_OQ);
+    __m256 est = _mm256_rsqrt_ps(x);
+    // Newton-Raphson: y = y * (1.5 - 0.5 * x * y * y)
+    __m256 half_x = _mm256_mul_ps(half, x);
+    __m256 yy = _mm256_mul_ps(est, est);
+    __m256 refined =
+      _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    refined = _mm256_blendv_ps(refined, inf_val, is_zero);
+    _mm256_storeu_ps(&X[i], refined);
+  }
+
+  for (; i < N; ++i) {
+    X[i] = 1.0f / std::sqrt(X[i]);
+  }
+}
+
+void sine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
+  unsigned int i = 0;
+  const __m256 v_alpha = _mm256_set1_ps(alpha);
+  const __m256 v_beta = _mm256_set1_ps(beta);
+  const bool need_alpha = (alpha != 1.0f);
+  const bool need_beta = (beta != 1.0f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    if (need_alpha)
+      x = _mm256_mul_ps(x, v_alpha);
+    __m256 result = sin256_ps(x);
+    if (need_beta)
+      result = _mm256_mul_ps(result, v_beta);
+    _mm256_storeu_ps(&Y[i], result);
+  }
+
+  for (; i < N; ++i) {
+    Y[i] =
+      std::sin(static_cast<float>(alpha) * X[i]) * static_cast<float>(beta);
+  }
+}
+
+void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
+  unsigned int i = 0;
+  const __m256 v_alpha = _mm256_set1_ps(alpha);
+  const __m256 v_beta = _mm256_set1_ps(beta);
+  const bool need_alpha = (alpha != 1.0f);
+  const bool need_beta = (beta != 1.0f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    if (need_alpha)
+      x = _mm256_mul_ps(x, v_alpha);
+    __m256 result = cos256_ps(x);
+    if (need_beta)
+      result = _mm256_mul_ps(result, v_beta);
+    _mm256_storeu_ps(&Y[i], result);
+  }
+
+  for (; i < N; ++i) {
+    Y[i] =
+      std::cos(static_cast<float>(alpha) * X[i]) * static_cast<float>(beta);
+  }
+}
+
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int from,
+                                 float attention_scaling) {
+  unsigned int i = 0;
+  const __m256 v_from = _mm256_set1_ps(static_cast<float>(from));
+  const __m256 v_scale = _mm256_set1_ps(attention_scaling);
+  const bool need_scale = (attention_scaling != 1.0f);
+
+  for (; i + 8 <= N_half; i += 8) {
+    __m256 x = _mm256_loadu_ps(&angle[i]);
+    x = _mm256_mul_ps(x, v_from);
+    __m256 s, c;
+    sincos256_ps(x, &s, &c);
+    if (need_scale) {
+      s = _mm256_mul_ps(s, v_scale);
+      c = _mm256_mul_ps(c, v_scale);
+    }
+    _mm256_storeu_ps(&cos_[i], c);
+    _mm256_storeu_ps(&sin_[i], s);
+  }
+
+  for (; i < N_half; ++i) {
+    cos_[i] = std::cos(static_cast<float>(from) * angle[i]) * attention_scaling;
+    sin_[i] = std::sin(static_cast<float>(from) * angle[i]) * attention_scaling;
+  }
+
+  unsigned int N = 2 * N_half;
+
+  // Copy first half to second half (duplicate)
+  unsigned int j = N_half;
+  unsigned int j_half = 0;
+
+  for (; j + 8 <= N && j_half + 8 <= N_half; j += 8, j_half += 8) {
+    __m256 c = _mm256_loadu_ps(&cos_[j_half]);
+    __m256 s = _mm256_loadu_ps(&sin_[j_half]);
+    _mm256_storeu_ps(&cos_[j], c);
+    _mm256_storeu_ps(&sin_[j], s);
+  }
+  for (; j < N && j_half < N_half; ++j, ++j_half) {
+    cos_[j] = cos_[j_half];
+    sin_[j] = sin_[j_half];
+  }
+}
+
 void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
@@ -1174,12 +1413,53 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
       Z++;
     }
   } else {
-    // TODO: AVX2 implementation if used
-    for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
-      X += o_stride;
-      Y += i_stride;
-      Z += o_stride;
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
     }
   }
 }
@@ -1218,12 +1498,245 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
       Z++;
     }
   } else {
-    // TODO: AVX2 implementation if used
-    for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
-      X += o_stride;
-      Y += i_stride;
-      Z += o_stride;
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_fmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_fmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
+    }
+  }
+}
+
+void ele_sub(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int N8 = (N & ~(7));
+    if (i_stride == 0) {
+      auto y = _mm256_set1_ps(Y[0]);
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto z = _mm256_sub_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - Y[0];
+        X++;
+        Z++;
+      }
+    } else if (i_stride == 1) {
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto y = _mm256_loadu_ps(Y);
+        auto z = _mm256_sub_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Y += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - *Y;
+        X++;
+        Y++;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X - *Y;
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    }
+  } else {
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_fnmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_fnmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
+    }
+  }
+}
+
+void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int N8 = (N & ~(7));
+    if (i_stride == 0) {
+      auto y = _mm256_set1_ps(Y[0]);
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto z = _mm256_div_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / Y[0];
+        X++;
+        Z++;
+      }
+    } else if (i_stride == 1) {
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto y = _mm256_loadu_ps(Y);
+        auto z = _mm256_div_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Y += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / *Y;
+        X++;
+        Y++;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X / *Y;
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    }
+  } else {
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        auto denom = _mm256_mul_ps(alpha_v, y);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_div_ps(x, denom);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto denom = _mm256_mul_ps(alpha_v, y);
+          auto z = _mm256_div_ps(x, denom);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
     }
   }
 }
@@ -1791,10 +2304,8 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
         __m256 cos_v = _mm256_loadu_ps(&cos_[k]);
         __m256 sin_v = _mm256_loadu_ps(&sin_[k]);
 
-        __m256 out0 =
-          _mm256_sub_ps(_mm256_mul_ps(a, cos_v), _mm256_mul_ps(b, sin_v));
-        __m256 out1 =
-          _mm256_add_ps(_mm256_mul_ps(a, sin_v), _mm256_mul_ps(b, cos_v));
+        __m256 out0 = _mm256_fnmadd_ps(b, sin_v, _mm256_mul_ps(a, cos_v));
+        __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
 
         if (out_type == OutputType::FP16) {
           __m128i out0_fp16 = convert_vector_f32_to_f16(out0);

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -1355,8 +1355,12 @@ static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
   const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
-  // 1. find max for each head
-  float *max_vals = new float[num_heads];
+  // 1. find max for each head (reusable thread-local scratch: 0 per-call alloc)
+  static thread_local std::vector<float> max_vals_buf;
+  static thread_local std::vector<float> sum_vals_buf;
+  max_vals_buf.resize(num_heads);
+  sum_vals_buf.resize(num_heads);
+  float *max_vals = max_vals_buf.data();
 
   // initialize max_vals with first row of qk_out
   std::memcpy(max_vals, qk_out + start_row * num_heads,
@@ -1377,7 +1381,7 @@ static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
   }
 
   // 2. calc exp(x - max) and sum
-  float *sum_vals = new float[num_heads];
+  float *sum_vals = sum_vals_buf.data();
   std::memset(sum_vals, 0, num_heads * sizeof(float));
 
   for (size_t r = start_row; r < end_row; ++r) {
@@ -1424,9 +1428,6 @@ static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
       row[c] *= sum_vals[c];
     }
   }
-
-  delete[] max_vals;
-  delete[] sum_vals;
 }
 
 static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
@@ -1434,8 +1435,12 @@ static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
                                           float *sink) {
   const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
-  // 1. find max for each head
-  float *max_vals = new float[num_heads];
+  // 1. find max for each head (reusable thread-local scratch: 0 per-call alloc)
+  static thread_local std::vector<float> max_vals_buf;
+  static thread_local std::vector<float> sum_vals_buf;
+  max_vals_buf.resize(num_heads);
+  sum_vals_buf.resize(num_heads);
+  float *max_vals = max_vals_buf.data();
 
   // initialize max_vals with sink
   std::memcpy(max_vals, sink, num_heads * sizeof(float));
@@ -1455,7 +1460,7 @@ static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
   }
 
   // 2. calc exp(x - max) and sum
-  float *sum_vals = new float[num_heads];
+  float *sum_vals = sum_vals_buf.data();
   // init sum_vals with exp(sink - max)
   {
     for (size_t c = 0; c < vec_end; c += 8) {
@@ -1515,9 +1520,6 @@ static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
       row[c] *= sum_vals[c];
     }
   }
-
-  delete[] max_vals;
-  delete[] sum_vals;
 }
 
 template <>
@@ -1641,22 +1643,26 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
     << "head_start (" << head_start << ") must be less than head_end ("
     << actual_head_end << ")";
 
-  std::vector<float> tmp_fp32(head_dim);
-  int num_blocks = head_dim / 8;
-  __m256 *sumVec = new __m256[std::max(1, num_blocks * gqa_size)];
+  const int num_blocks = head_dim / 8;
+  const int rem = head_dim % 8;
+
+  // Reusable thread-local scratch so the kernel performs zero per-call
+  // allocations after warm-up (ThreadManager::parallel_for gives each worker
+  // its own thread_local copy). sumVec holds num_blocks*gqa_size accumulator
+  // vectors as a flat float buffer (8 floats each) to avoid the
+  // -Wignored-attributes warning that a std::vector<__m256> would raise.
+  static thread_local std::vector<float> tmp_fp32;
+  static thread_local std::vector<float> sumVec;
+  static thread_local std::vector<float> sumRem;
+  tmp_fp32.resize(head_dim);
+  sumVec.resize((size_t)std::max(1, num_blocks * gqa_size) * 8);
+  sumRem.resize((size_t)gqa_size * rem);
 
   for (int n = head_start; n < actual_head_end; ++n) {
-    int rem = head_dim % 8;
-
-    /* Declaration: std::vector<__m256> sumVec(num_blocks * gqa_size,
-     * _mm256_setzero_ps()); caused warning: ignoring attributes on template
-     * argument ‘__m256’ [-Wignored-attributes].
-     * So it is implemented that way.
-     */
     for (int i = 0; i < num_blocks * gqa_size; i++) {
-      sumVec[i] = _mm256_setzero_ps();
+      _mm256_storeu_ps(&sumVec[(size_t)i * 8], _mm256_setzero_ps());
     }
-    std::vector<float> sumRem((size_t)gqa_size * rem, 0.0f);
+    std::fill(sumRem.begin(), sumRem.end(), 0.0f);
 
     for (int j = row_num < local_window_size ? 0
                                              : row_num + 1 - local_window_size;
@@ -1676,8 +1682,9 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
 
         for (int b = 0; b < num_blocks; ++b) {
           __m256 bVec = _mm256_loadu_ps(&tmp_fp32[b * 8]);
-          sumVec[h * num_blocks + b] =
-            _mm256_fmadd_ps(inVec, bVec, sumVec[h * num_blocks + b]);
+          float *accPtr = &sumVec[(size_t)(h * num_blocks + b) * 8];
+          _mm256_storeu_ps(
+            accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
         }
 
         float *remPtr = &sumRem.data()[h * rem];
@@ -1691,11 +1698,12 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
     for (int h = 0; h < gqa_size; ++h) {
       for (int b = 0; b < num_blocks; ++b) {
         int out_base = (n * gqa_size + h) * head_dim + b * 8;
-        _mm256_storeu_ps(&output[out_base], sumVec[h * num_blocks + b]);
+        _mm256_storeu_ps(
+          &output[out_base],
+          _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
       }
 
       float *remPtr = &sumRem.data()[h * rem];
-      // float *remPtr = &sumRem[h * rem];
       int base = num_blocks * 8;
       for (int r = 0; r < rem; ++r) {
         int out_idx = (n * gqa_size + h) * head_dim + base + r;
@@ -1703,7 +1711,6 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
       }
     }
   }
-  delete[] sumVec;
 }
 
 template <>
@@ -1711,8 +1718,6 @@ void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
                      int num_rows, int num_cache_head, int head_dim,
                      int gqa_size, int tile_size, size_t local_window_size,
                      int head_start, int head_end) {
-  std::vector<float> tmp_fp32(head_dim);
-
   // If head_end is -1, process all heads from head_start to num_cache_head.
   // No other negative values are accepted for head_end.
   int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
@@ -1743,16 +1748,16 @@ void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
                          _MM_HINT_T0);
           }
           const uint16_t *kptr = kcache + (row * num_cache_head + n) * head_dim;
-          load_fp16_8_to_chunk(kptr, tmp_fp32.data(), head_dim);
 
-          const float *k_row = tmp_fp32.data();
-
+          // Convert the FP16 key row to FP32 on the fly inside the dot product
+          // (8 lanes via F16C) instead of staging it in a temporary buffer.
           float sum = 0.0f;
           int i = 0;
           __m256 acc = _mm256_setzero_ps();
           for (; i + 8 <= head_dim; i += 8) {
             __m256 va = _mm256_loadu_ps(in_ptr + i);
-            __m256 vb = _mm256_loadu_ps(k_row + i);
+            __m256 vb = convert_vector_f16_to_f32(
+              _mm_loadu_si128(reinterpret_cast<const __m128i *>(kptr + i)));
             acc = _mm256_fmadd_ps(va, vb, acc);
           }
 
@@ -1764,7 +1769,7 @@ void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
           sum += _mm_cvtss_f32(sum128);
 
           for (; i < head_dim; ++i)
-            sum += in_ptr[i] * k_row[i];
+            sum += in_ptr[i] * nntrainer::compute_fp16_to_fp32(kptr[i]);
 
           output[(row - start_row) * num_cache_head * gqa_size + n * gqa_size +
                  g] = sum / sqrt((float)head_dim);

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -13,10 +13,8 @@
  */
 
 #include "avx2_impl.h"
+#include "avx2_internal.h"
 #include <array>
-#if __has_include(<bit>)
-#include <bit>
-#endif
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -24,13 +22,7 @@
 #include <fp16.h>
 #include <immintrin.h>
 #include <limits>
-#if __has_include(<numbers>)
-#include <numbers>
-#endif
 #include <type_traits>
-#if __has_include(<version>)
-#include <version>
-#endif
 #include <fallback_internal.h>
 #include <nntrainer_error.h>
 #include <thread_manager.h>
@@ -39,298 +31,21 @@
 
 #include "nntr_ggml_impl_common.h"
 
-#if !defined(__has_constexpr_builtin)
-#define __has_constexpr_builtin(x) (0)
-#endif
-
-#if !defined(__has_cpp_attribute)
-#define __has_cpp_attribute(x) (0)
-#endif
-
-// VECTORCALL calling-conv (default for x86_64-linux-gnu)
-#if _MSC_VER >= 1700
-#define _nnt_CC_VECTORCALL __vectorcall
-#else
-#define _nnt_CC_VECTORCALL
-#endif
-
-// Flatten attribute
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
-#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
-#else
-#define _nnt_ATTR_FLATTEN
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::noinline)
-#define _nnt_ATTR_NOINLINE [[msvc::noinline]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_NOINLINE [[gnu::noinline]]
-#else
-#define _nnt_ATTR_NOINLINE
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
-#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
-#elif __has_cpp_attribute(gnu::always_inline)
-#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
-#endif
-
-#if __has_cpp_attribute(unikely)
-#define UNLIKELY [[unlikely]]
-#else
-#define UNLIKELY
-#endif
-
 #if !defined(_MSC_VER) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
 
+#if !defined(RESTRICT)
 #if defined(__clang__) || defined(__GNUC__)
 #define RESTRICT __restrict__
 #else
 #define RESTRICT
 #endif
-
-namespace {
-
-template <typename To_, typename From_>
-constexpr inline bool concept17_BinaryCastable =
-  sizeof(To_) == sizeof(From_) &&
-  std::is_trivially_copyable_v<From_> &&std::is_trivially_copyable_v<To_>;
-
-template <class To_, class From_>
-auto compat_bit_cast(const From_ &src) noexcept
-  -> std::enable_if_t<concept17_BinaryCastable<To_, From_>, To_> {
-#if __cpp_lib_bit_cast >= 201806L
-  return std::bit_cast<To_>(src);
-#else
-  To_ dst;
-  std::memcpy(&dst, &src, sizeof(To_));
-  return dst;
-#endif
-}
-
-[[nodiscard]] constexpr inline unsigned
-constexpr_popcount(uint32_t v) noexcept {
-#if __cpp_lib_bitops >= 201907L
-  return std::popcount(v);
-#else
-  // Popcount via bit-hack
-  v = v - ((v >> 1) & 0x55555555);                // reuse input as temporary
-  v = (v & 0x33333333) + ((v >> 2) & 0x33333333); // temp
-  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24; // count
-  return c;
-#endif
-}
-
-template <unsigned I_>
-constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
-
-namespace numbers {
-
-#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
-using std::numbers::ln2_v;
-using std::numbers::log2e_v;
-#else
-template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
-
-template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
-#endif
-} // namespace numbers
-
-constexpr inline float EXP_ARG_MIN = -87.0;
-constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
-
-// @brief Precalculated lookup table for 2^x calculation
-template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
-          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-struct Exp2Table {
-
-  constexpr static inline auto MANTISSA_BITS =
-    std::numeric_limits<Float_>::digits - 1;
-
-#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
-  [[nodiscard]] static consteval auto calculate() noexcept {
-    std::array<Ty_, N_> t;
-    for (unsigned i = 0; i < N_; ++i)
-      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
-             ((i << MANTISSA_BITS) / N_);
-    return t;
-  }
-#endif
-};
-
-#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
-
-// @brief Precalculated lookup table for 2^x calculation when we don't have
-// constexpr math functions
-template <> struct Exp2Table<8, uint32_t, float> {
-  [[nodiscard]] static constexpr auto calculate() noexcept {
-    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
-                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
-                                 0x3f7744fdU, 0x3f7ac0c7U};
-    return t;
-  }
-};
-
 #endif
 
-template <unsigned N_> // requires PowerOfTwo<N_>
-alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
-
-// Scalar version of expf() approximation with 3-th deg polynominal of
-// fractional part
-//
-// The error with regards to std::expf less than 5e-6
-// It is valid in range [-87, +88.37) - not handling +INF, NaN etc.
-// The function domain is clamped to valid function range.
-//
-// The strategy picked is to approximate exp as 2^K*2^F
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-[[nodiscard]] _nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline float
-approx_exp_exp2_lookup(float x) noexcept {
-  constexpr static unsigned N_MASK = uint32_t(N_ - 1U);
-  constexpr static unsigned FLT_MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1U;
-
-  x = std::max(x, EXP_ARG_MIN);
-  x *= float(0x1.0p1 / numbers::ln2_v<double> * N_);
-  x = std::min(x, float(EXP_ARG_MAX / numbers::ln2_v<double> * N_));
-
-  // Round nearest and convert integer part to an int (std::modf)
-  // NB: This way doesn't handle ties even.
-  auto x_int = x + 0x1.8p23f;
-  auto x_uint = compat_bit_cast<uint32_t>(x_int);
-  x_int -= 0x1.8p23f;
-  auto x_frac = x - x_int;
-
-  auto s_int = exp2_table_v<N_>[x_uint & N_MASK];
-  auto x_uint_shifted = x_uint
-                        << (FLT_MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_int_2 = s_int + x_uint_shifted;
-  auto s = compat_bit_cast<float>(s_int_2);
-
-  // Polynominal of form C0*x^3 + C1*x^2 + C2*x^1 + 1.0
-  static constexpr float poly_4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                     0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                     0x1.62e42ff0c52d6p-1f / N_};
-
-  auto q0 = std::fma(x_frac, poly_4[0], poly_4[1]);
-  auto x_frac_pow2 = x_frac * x_frac;
-  auto q2 = x_frac * poly_4[2]; // not adding +1.0
-
-  x = std::fma(q0, x_frac_pow2, q2);
-
-  return std::fma(x, s, s); // NB: (handles (x+1) by addition of s)
-}
-
-// Vectorized version of above
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
-avx2_approx_exp_e2lookup(__m256 xs) noexcept {
-
-  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
-  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
-  constexpr static unsigned MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1;
-
-  // Ensure arg in range [exp_arg_min, exp_arg_max]
-  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
-  // Would clamp to EXP_ARG_MAX but we move it after multiplication for IPC:
-  // xs = _mm256_min_ps(xs, _mm256_set1_ps(EXP_ARG_MAX));
-
-  xs =
-    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
-  // Clamp EXP_ARG_MAX after multiply
-  xs = _mm256_min_ps(
-    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
-
-  // Mostly equivalent to, doesn't round ties to even
-  // auto xs_int = _mm256_round_ps(xs, _MM_FROUND_TO_NEAREST_INT |
-  // _MM_FROUND_NO_EXC); auto xs_int_as_u32 = _mm256_cvtps_epi32(xs_int);
-  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
-  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
-  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
-
-  // Calculate fractional part
-  auto xs_frac = _mm256_sub_ps(xs, xs_int);
-  // Indices for lookup (modulo N_)
-  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
-
-  __m256i s_ints;
-
-  // Lookup e^xs_int s factor
-  if constexpr (N_ == 8) {
-    // Lookup by vector permute
-    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
-    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
-  } else {
-    // Falback for not fitting number of vector elements
-    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
-  }
-
-  auto xs_uint_shifted = _mm256_slli_epi32(
-    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
-  auto s_floats = _mm256_castsi256_ps(s_ints_2);
-
-  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                      0x1.62e42ff0c52d6p-1f / N_};
-
-  const auto C0 = _mm256_set1_ps(poly_d4[0]);
-  const auto C1 = _mm256_set1_ps(poly_d4[1]);
-  const auto C2 = _mm256_set1_ps(poly_d4[2]);
-
-  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
-  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
-  auto qs2 = _mm256_mul_ps(xs_frac, C2);
-
-  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
-
-  return _mm256_fmadd_ps(xs, s_floats, s_floats);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_negate_ps(__m256 x) noexcept -> __m256 {
-  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
-  const auto UNDEF = _mm256_undefined_si256();
-  const auto sign_bit =
-    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
-  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
-  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
-  return neg_x;
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
-  auto neg_x = avx2_negate_ps(x);
-  auto inv_sigmoid =
-    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
-  auto alpha_x = _mm256_mul_ps(alpha, x);
-  auto neg_alpha_x = avx2_negate_ps(alpha_x);
-  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
-                                   _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-} // namespace
+using namespace nntrainer::avx2::internal;
 
 namespace nntrainer::avx2 {
-
-// Forward declarations for internal helpers used across the file
-static inline __m256 exp256_ps(__m256 x);
-static float hsum_avx(__m256 v);
 
 /**
  * @brief struct of q4_0x8 block
@@ -1015,121 +730,14 @@ void swiglu(const unsigned int N, float *X, const float *Y, const float *Z,
   _mm_setcsr(oldcsr);
 }
 
-#define gelu_start_tanh -4.38086284326899f
-#define gelu_end_tanh 4.38086284326899f
+// poly_gelu_tanh_avx2 / poly_gelu_erf_avx2 are defined in avx2_internal.h
+using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
+using nntrainer::avx2::internal::poly_gelu_erf_avx2;
 
-#define tanh_c_gelu_p0 5.91303808e-6f
-#define tanh_c_gelu_p1 5.00000000e-1f
-#define tanh_c_gelu_p2 3.98865869e-1f
-#define tanh_c_gelu_p4 -6.66574676e-2f
-#define tanh_c_gelu_p6 1.00712610e-2f
-#define tanh_c_gelu_p8 -1.19336340e-3f
-#define tanh_c_gelu_p10 1.09543224e-4f
-#define tanh_c_gelu_p12 -7.55788500e-6f
-#define tanh_c_gelu_p14 3.73374142e-7f
-#define tanh_c_gelu_p16 -1.23162678e-8f
-#define tanh_c_gelu_p18 2.40940960e-10f
-#define tanh_c_gelu_p20 -2.10237709e-12f
-
-#define gelu_start_erf -4.59373833108583f
-#define gelu_end_erf 4.59373833108583f
-
-#define erf_c_gelu_p0 8.70757509e-06f
-#define erf_c_gelu_p1 5.00000000e-1f
-#define erf_c_gelu_p2 3.98833088e-01f
-#define erf_c_gelu_p4 -6.62633808e-02f
-#define erf_c_gelu_p6 9.78776282e-03f
-#define erf_c_gelu_p8 -1.10798998e-03f
-#define erf_c_gelu_p10 9.51056006e-05f
-#define erf_c_gelu_p12 -6.04633051e-06f
-#define erf_c_gelu_p14 2.73076070e-07f
-#define erf_c_gelu_p16 -8.20707325e-09f
-#define erf_c_gelu_p18 1.46115955e-10f
-#define erf_c_gelu_p20 -1.16009840e-12f
-
-static inline __m256 poly_gelu_tanh_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
-
-static inline __m256 poly_gelu_erf_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
+// exp256_ps, hsum_avx, rcp_ps are also in avx2_internal.h
+using nntrainer::avx2::internal::exp256_ps;
+using nntrainer::avx2::internal::hsum_avx;
+using nntrainer::avx2::internal::rcp_ps;
 
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
   unsigned int i = 0;
@@ -1741,109 +1349,7 @@ void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
   }
 }
 
-static inline __m256 exp256_ps(__m256 x) {
-  /*  Low-Precision Version I*/
-  // const __m256 c1 = _mm256_set1_ps(12102203.0f);
-  // const __m256 c2 = _mm256_set1_ps(1065353216.0f);
-  // __m256 fx = _mm256_add_ps(_mm256_mul_ps(x, c1),c2);
-  // return _mm256_castsi256_ps(_mm256_cvtps_epi32(fx));
-
-  /* Low-Precision Version II*/
-  /*    const __m256 ln2 = _mm256_set1_ps(0.69314718056f);
-    const __m256 inv_ln2 = _mm256_set1_ps(1.44269504089f); // 1 / ln(2)
-
-    // Range reduction: x = n * ln2 + r,  where n is integer and |r| <= ln2/2
-    __m256 fx = _mm256_mul_ps(x, inv_ln2);
-    fx = _mm256_round_ps(fx, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
-    __m256i emm0 = _mm256_cvtps_epi32(fx);
-
-    __m256 tmp = _mm256_mul_ps(fx, ln2);
-    __m256 r = _mm256_sub_ps(x, tmp);
-
-    // Compute polynomial approximation of exp(r)
-    const __m256 c1 = _mm256_set1_ps(1.9875691500E-4f);
-    const __m256 c2 = _mm256_set1_ps(1.3981999507E-3f);
-    const __m256 c3 = _mm256_set1_ps(8.3334519073E-3f);
-    const __m256 c4 = _mm256_set1_ps(4.1665795894E-2f);
-    const __m256 c5 = _mm256_set1_ps(1.6666665459E-1f);
-    const __m256 c6 = _mm256_set1_ps(5.0000001201E-1f);
-
-  //  __m256 r2 = _mm256_mul_ps(r, r);
-  //  __m256 r3 = _mm256_mul_ps(r2, r);
-  //  __m256 r4 = _mm256_mul_ps(r2, r2);
-
-    __m256 y = _mm256_fmadd_ps(c1, r, c2);
-    y = _mm256_fmadd_ps(y, r, c3);
-    y = _mm256_fmadd_ps(y, r, c4);
-    y = _mm256_fmadd_ps(y, r, c5);
-    y = _mm256_fmadd_ps(y, r, c6);
-    y = _mm256_fmadd_ps(y, r, _mm256_set1_ps(1.0f));
-
-    // Reconstruct exp(x) = 2^n * exp(r)
-    emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-    emm0 = _mm256_slli_epi32(emm0, 23);
-    __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-    return _mm256_mul_ps(y, pow2n);
-  */
-  /* Low-Precision Versino III */
-  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f); // 1 / ln(2)
-  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);     // ln(2)
-
-  // Clamp input to range to prevent overflow/underflow
-  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);  // log(FLT_MAX)
-  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f); // log(FLT_MIN)
-  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
-
-  // Range reduction: x = n * ln2 + r
-  __m256 fx = _mm256_mul_ps(x, LOG2EF); // x * (1/ln(2))
-  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
-
-  __m256 tmp = _mm256_mul_ps(fx, LN2); // n * ln(2)
-  __m256 r = _mm256_sub_ps(x, tmp);    // r = x - n * ln2
-
-  // Compute exp(r) using 10th-order polynomial (Horner's method)
-  const __m256 c0 = _mm256_set1_ps(1.0f);
-  const __m256 c1 = _mm256_set1_ps(1.0f);
-  const __m256 c2 = _mm256_set1_ps(0.5f);
-  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
-  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
-  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
-  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
-  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
-  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
-  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
-  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
-
-  __m256 y = c10;
-  y = _mm256_fmadd_ps(y, r, c9);
-  y = _mm256_fmadd_ps(y, r, c8);
-  y = _mm256_fmadd_ps(y, r, c7);
-  y = _mm256_fmadd_ps(y, r, c6);
-  y = _mm256_fmadd_ps(y, r, c5);
-  y = _mm256_fmadd_ps(y, r, c4);
-  y = _mm256_fmadd_ps(y, r, c3);
-  y = _mm256_fmadd_ps(y, r, c2);
-  y = _mm256_fmadd_ps(y, r, c1);
-  y = _mm256_fmadd_ps(y, r, c0); // final y = (((...r+...)*r+...)*r + 1)
-
-  // Reconstruct exp(x) = 2^n * exp(r)
-  __m256i emm0 = _mm256_cvtps_epi32(fx);
-  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-  emm0 = _mm256_slli_epi32(emm0, 23);
-  __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-  return _mm256_mul_ps(y, pow2n);
-}
-
-static inline __m256 rcp_ps(__m256 x) {
-  // Use Newton-Raphson method to enhance accuracy
-  // x_n+1 = x_n * (2 - x_0 * x_n)
-  __m256 rcp = _mm256_rcp_ps(x);
-  __m256 two = _mm256_set1_ps(2.0f);
-  // rcp * (2 - x * rcp)
-  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
-}
+// exp256_ps and rcp_ps are now in avx2_internal.h
 
 static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
@@ -2354,16 +1860,7 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
   }
 }
 
-static float hsum_avx(__m256 v) {
-  __m128 vlow = _mm256_castps256_ps128(v);
-  __m128 vhigh = _mm256_extractf128_ps(v, 1);
-  vlow = _mm_add_ps(vlow, vhigh);
-  __m128 shuf = _mm_movehdup_ps(vlow);
-  __m128 sums = _mm_add_ps(vlow, shuf);
-  shuf = _mm_movehl_ps(shuf, sums);
-  sums = _mm_add_ss(sums, shuf);
-  return _mm_cvtss_f32(sums);
-}
+// hsum_avx is now in avx2_internal.h
 
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -473,6 +473,44 @@ void compute_kcaches(const float *in, const BType *kcache, float *output,
                      size_t local_window_size = UINT_MAX, int head_start = 0,
                      int head_end = -1);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief FP16-input multi-head softmax (in-place). FP16 sink variant; sink may
+ * be nullptr. Math is done in FP32 internally.
+ */
+template <>
+void softmax_row_inplace(_Float16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, _Float16 *sink);
+
+/**
+ * @brief FP16-input multi-head softmax (in-place), mixed-precision FP32 sink.
+ */
+void softmax_row_inplace(_Float16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, float *sink);
+
+/**
+ * @brief FP16-input scaled dot product Q*K^T (kcache). See the FP32 overload
+ * for parameter semantics; all operands and the output are FP16.
+ */
+void compute_kcaches(const _Float16 *in, const _Float16 *kcache,
+                     _Float16 *output, int num_rows, int num_cache_head,
+                     int head_dim, int gqa_size, int tile_size,
+                     size_t local_window_size = UINT_MAX, int head_start = 0,
+                     int head_end = -1);
+
+/**
+ * @brief FP16-input attention-weighted value aggregation (softmax_out * V).
+ * See compute_fp16vcache_fp32_transposed for parameter semantics; all operands
+ * and the output are FP16.
+ */
+void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
+                                   const _Float16 *vcache, _Float16 *output,
+                                   int num_cache_head, int gqa_size,
+                                   int head_dim,
+                                   size_t local_window_size = UINT_MAX,
+                                   int head_start = 0, int head_end = -1);
+#endif
+
 /**
  * @brief Compute rotary embedding value
  * @param[in] width current w value from b, c, h, w

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -52,6 +52,57 @@ void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output);
  * @param[out] false if it has NaN or inf
  */
 bool is_valid(const unsigned int N, const _Float16 *X);
+
+void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+
+void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
+           const unsigned int incX, _Float16 *Y, const unsigned int incY);
+_Float16 sdot(const unsigned int N, const _Float16 *X, const unsigned int incX,
+              const _Float16 *Y, const unsigned int incY);
+_Float16 snrm2(const unsigned int N, const _Float16 *X,
+               const unsigned int incX);
+void sscal(const unsigned int N, const float alpha, _Float16 *X,
+           const unsigned int incX);
+void custom_scopy(const unsigned int N, const _Float16 *X,
+                  const unsigned int incX, _Float16 *Y,
+                  const unsigned int incY);
+
+_Float16 max_val(const unsigned int N, _Float16 *X);
+void softmax(const unsigned int N, _Float16 *X, _Float16 *Y);
+void inv_sqrt_inplace(const unsigned int N, _Float16 *X);
+void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z);
+void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
+                             _Float16 *__restrict Y, size_t H, size_t W,
+                             float epsilon);
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _Float16 *in, _Float16 *out,
+                                    float *cos_, float *sin_);
+
+unsigned int isamax(const unsigned int N, const _Float16 *X,
+                    const unsigned int incX);
+void transpose_matrix(const unsigned int M, const unsigned int N,
+                      const _Float16 *src, unsigned int ld_src, _Float16 *dst,
+                      unsigned int ld_dst);
+void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
+void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
+void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -15,6 +15,7 @@
 #define __AVX2_IMPL_H_
 #ifdef __cplusplus
 
+#include "avx2_mathfun.h"
 #include <cstdint>
 #include <limits.h>
 #include <limits>
@@ -102,6 +103,98 @@ void transpose_matrix(const unsigned int M, const unsigned int N,
                       unsigned int ld_dst);
 
 /**
+ * @brief tanh_gelu function with AVX2 polynomial approximation
+ *        Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X + 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X const float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
+ * @brief tanh_gelu_mul function with AVX2: X = GELU(Y) * Z
+ *
+ * @param N number of elements
+ * @param X float * for output
+ * @param Y float * for GELU input
+ * @param Z float * for multiply input
+ */
+void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z);
+
+/**
+ * @brief tanh_gelu_v2_mul function with AVX2: X = GELU(Y) * Z
+ *
+ * @param N number of elements
+ * @param X float * for output
+ * @param Y float * for GELU input
+ * @param Z float * for multiply input
+ */
+void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z);
+
+/**
+ * @brief returns maximum value of the vector X
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @return float maximum value of vector X
+ */
+float max_val(const unsigned int N, float *X);
+
+/**
+ * @brief softmax function y_i = exp(x_i) / sum( exp(x_i) )
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void softmax(const unsigned int N, float *X, float *Y);
+
+/**
+ * @brief inversed squared root transformation inplace : X[i] = 1 / sqrt(X[i])
+ *
+ * @param N size of X
+ * @param X float * for Vector X
+ */
+void inv_sqrt_inplace(const unsigned int N, float *X);
+
+/**
+ * @brief sine function : Y[i] = sin(alpha * X[i]) * beta
+ *
+ * @param N number of elements
+ * @param X float * input
+ * @param Y float * output
+ * @param alpha scaling for input
+ * @param beta scaling for output
+ */
+void sine(const unsigned int N, float *X, float *Y, float alpha, float beta);
+
+/**
+ * @brief cosine function : Y[i] = cos(alpha * X[i]) * beta
+ *
+ * @param N number of elements
+ * @param X float * input
+ * @param Y float * output
+ * @param alpha scaling for input
+ * @param beta scaling for output
+ */
+void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta);
+
+/**
+ * @brief compute cos and sin of angles, then duplicate to second half
+ *
+ * @param N_half half size of output arrays
+ * @param angle float * input angles
+ * @param cos_ float * output cosines (size 2*N_half)
+ * @param sin_ float * output sines (size 2*N_half)
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor for cos and sin values
+ */
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int from,
+                                 float attention_scaling);
+
+/**
  * @brief swiglu function with AVX : X = (Y / (1 + exp( -Y ))) * Z
  *
  * @param N number of elements in X
@@ -176,6 +269,37 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
              unsigned int o_stride);
 
 /**
+ * @brief     elementwise vector subtraction : Z = X - alpha * Y + beta * Z
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] alpha scalar multiplier for input
+ * @param[in] beta scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void ele_sub(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
+ * @brief     elementwise vector division : Z = X / (alpha * Y) + beta * Z
+ * @note ZeroDivisionError is not guaranteed in this function
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] alpha scalar multiplier for input
+ * @param[in] beta scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
  * @brief Multihead softmax, exp(x_i) / sum(exp(x_i)), inplace version
  * @param[in/out] qk_out float* input/output values
  * @param[in] start_row start row number
@@ -186,7 +310,7 @@ template <typename T = float>
 void softmax_row_inplace(T *qk_out, size_t start_row, size_t end_row,
                          size_t num_heads, T *sink = nullptr);
 
-/**f
+/**
  * @brief Multihead softmax, exp(x_i) / sum(exp(x_i))
  * @param[in/out] qk_out float* input/output values
  * @param[in] start_row start row number

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -78,6 +78,55 @@ void custom_scopy(const unsigned int N, const _Float16 *X,
                   const unsigned int incX, _Float16 *Y,
                   const unsigned int incY);
 
+/**
+ * @brief FP16 GEMV with FP32 accumulation (row-major A only).
+ *
+ * Computes Y := alpha * op(A) * X + beta * Y where op(A) is A or A^T.
+ *   TransA == false: A is (M x N), Y length M, X length N.
+ *   TransA == true : A is (M x N), Y length N, X length M.
+ *
+ * Internals: F16C convert + FP32 FMA. TransA=false uses dot-product per row
+ * with a horizontal reduction. TransA=true uses an AXPY-style accumulation
+ * into a temporary FP32 buffer so Y avoids repeated FP16<->FP32 round trips
+ * across the M iterations. Honors alpha/beta and the BLAS rule "do not read
+ * Y when beta == 0".
+ *
+ * @param[in] TransA whether to transpose A.
+ * @param[in] M number of rows of A.
+ * @param[in] N number of cols of A.
+ * @param[in] alpha scalar multiplier for op(A) * X.
+ * @param[in] A row-major matrix of shape (M, N) with row stride lda.
+ * @param[in] lda row stride of A in elements (>= N).
+ * @param[in] X input vector. Length is N if !TransA else M.
+ * @param[in] incX stride between consecutive X elements (>= 1).
+ * @param[in] beta scalar multiplier for the existing Y. When 0, Y is
+ *                 overwritten without being read first.
+ * @param[in,out] Y output vector. Length is M if !TransA else N.
+ * @param[in] incY stride between consecutive Y elements (>= 1).
+ */
+void hgemv(bool TransA, const unsigned int M, const unsigned int N,
+           const float alpha, const _Float16 *A, const unsigned int lda,
+           const _Float16 *X, const unsigned int incX, const float beta,
+           _Float16 *Y, const unsigned int incY);
+
+/**
+ * @brief Mixed-precision GEMV with FP32 matrix, FP16 vector and FP32 output
+ * (shgemv). Shares gemv_impl with hgemv; see hgemv for parameter semantics.
+ */
+void shgemv(bool TransA, const unsigned int M, const unsigned int N,
+            const float alpha, const float *A, const unsigned int lda,
+            const _Float16 *X, const unsigned int incX, const float beta,
+            float *Y, const unsigned int incY);
+
+/**
+ * @brief Mixed-precision GEMV with FP16 matrix, FP32 vector and FP32 output
+ * (hsgemv). Shares gemv_impl with hgemv; see hgemv for parameter semantics.
+ */
+void hsgemv(bool TransA, const unsigned int M, const unsigned int N,
+            const float alpha, const _Float16 *A, const unsigned int lda,
+            const float *X, const unsigned int incX, const float beta, float *Y,
+            const unsigned int incY);
+
 _Float16 max_val(const unsigned int N, _Float16 *X);
 void softmax(const unsigned int N, _Float16 *X, _Float16 *Y);
 void inv_sqrt_inplace(const unsigned int N, _Float16 *X);

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -20,7 +20,9 @@
 #include <cstring>
 #include <immintrin.h>
 #include <limits>
+#include <type_traits>
 #include <util_func.h>
+#include <vector>
 
 using namespace nntrainer::avx2::internal;
 
@@ -1006,6 +1008,243 @@ _Float16 snrm2(const unsigned int N, const _Float16 *X,
     }
     return static_cast<_Float16>(std::sqrt(sum));
   }
+}
+
+namespace {
+
+/// Load 8 contiguous elements and widen to FP32 (F16C for _Float16, plain load
+/// for float). Lets one GEMV body serve FP16 and mixed-precision operands.
+template <typename T> inline __m256 gemv_load8(const T *p) {
+  if constexpr (std::is_same_v<T, float>) {
+    return _mm256_loadu_ps(p);
+  } else {
+    return _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)p));
+  }
+}
+
+/// Load 16 contiguous elements into two FP32 vectors.
+template <typename T>
+inline void gemv_load16(const T *p, __m256 &lo, __m256 &hi) {
+  if constexpr (std::is_same_v<T, float>) {
+    lo = _mm256_loadu_ps(p);
+    hi = _mm256_loadu_ps(p + 8);
+  } else {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)p);
+    lo = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    hi = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+  }
+}
+
+/// Narrow an FP32 vector and store 8 elements (F16C for _Float16, plain store
+/// for float).
+template <typename T> inline void gemv_store8(T *p, __m256 v) {
+  if constexpr (std::is_same_v<T, float>) {
+    _mm256_storeu_ps(p, v);
+  } else {
+    _mm_storeu_si128((__m128i *)p,
+                     _mm256_cvtps_ph(v, _MM_FROUND_TO_NEAREST_INT));
+  }
+}
+
+template <typename OutT>
+void gemv_apply_beta(unsigned int out_len, float beta, OutT *Y,
+                     unsigned int incY) {
+  if (beta == 1.0f) {
+    return;
+  }
+
+  for (unsigned int i = 0; i < out_len; ++i) {
+    const std::size_t idx = static_cast<std::size_t>(i) * incY;
+    if (beta == 0.0f) {
+      Y[idx] = static_cast<OutT>(0.0f);
+    } else {
+      Y[idx] = static_cast<OutT>(beta * static_cast<float>(Y[idx]));
+    }
+  }
+}
+
+template <typename MatT, typename XContigT, typename OutT>
+void gemv_no_trans_contiguous_x(const unsigned int M, const unsigned int N,
+                                const float alpha, const MatT *A,
+                                const unsigned int lda, const XContigT *X,
+                                const float beta, OutT *Y,
+                                const unsigned int incY) {
+  const unsigned int N16 = N & ~15u;
+  for (unsigned int i = 0; i < M; ++i) {
+    const MatT *a_row = A + static_cast<std::size_t>(i) * lda;
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    unsigned int j = 0;
+    for (; j < N16; j += 16) {
+      __m256 af0, af1, xf0, xf1;
+      gemv_load16<MatT>(a_row + j, af0, af1);
+      gemv_load16<XContigT>(X + j, xf0, xf1);
+      acc0 = _mm256_fmadd_ps(af0, xf0, acc0);
+      acc1 = _mm256_fmadd_ps(af1, xf1, acc1);
+    }
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+    if (j + 8 <= N) {
+      __m256 a32 = gemv_load8<MatT>(a_row + j);
+      __m256 x32 = gemv_load8<XContigT>(X + j);
+      acc = _mm256_fmadd_ps(a32, x32, acc);
+      j += 8;
+    }
+    float sum = hsum_avx(acc);
+    for (; j < N; ++j) {
+      sum += static_cast<float>(a_row[j]) * static_cast<float>(X[j]);
+    }
+
+    const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
+    float y_new = alpha * sum;
+    if (beta != 0.0f) {
+      y_new += beta * static_cast<float>(Y[y_idx]);
+    }
+    Y[y_idx] = static_cast<OutT>(y_new);
+  }
+}
+
+/**
+ * @brief Shared row-major GEMV: Y = alpha * op(A) * X + beta * Y.
+ *
+ * @tparam MatT A element type (_Float16 or float)
+ * @tparam VecT X element type (_Float16 or float)
+ * @tparam OutT Y element type (_Float16 or float)
+ */
+template <typename MatT, typename VecT, typename OutT>
+void gemv_impl(bool TransA, const unsigned int M, const unsigned int N,
+               const float alpha, const MatT *A, const unsigned int lda,
+               const VecT *X, const unsigned int incX, const float beta,
+               OutT *Y, const unsigned int incY) {
+  assert(incX > 0 && incY > 0);
+  if (M == 0 || N == 0) {
+    return;
+  }
+
+  if (alpha == 0.0f) {
+    gemv_apply_beta<OutT>(TransA ? N : M, beta, Y, incY);
+    return;
+  }
+
+  if (TransA) {
+    // Y[0..N) = beta * Y + alpha * A^T * X.
+    // Stage the output in an FP32 scratch buffer so the row sweep over A
+    // does not pay a FP16<->FP32 round trip on Y every iteration.
+    const unsigned int out_len = N;
+    static thread_local std::vector<float> y32_scratch;
+    y32_scratch.resize(out_len);
+    float *Y32 = y32_scratch.data();
+
+    if (beta == 0.0f) {
+      std::memset(Y32, 0, out_len * sizeof(float));
+    } else if (incY == 1) {
+      const __m256 vbeta = _mm256_set1_ps(beta);
+      unsigned int j = 0;
+      for (; j + 8 <= out_len; j += 8) {
+        __m256 y32 = gemv_load8<OutT>(Y + j);
+        y32 = _mm256_mul_ps(y32, vbeta);
+        _mm256_storeu_ps(Y32 + j, y32);
+      }
+      for (; j < out_len; ++j) {
+        Y32[j] = beta * static_cast<float>(Y[j]);
+      }
+    } else {
+      for (unsigned int j = 0; j < out_len; ++j) {
+        Y32[j] = beta * static_cast<float>(Y[j * incY]);
+      }
+    }
+
+    // Per row i, Y32[0..N) += (alpha * X[i]) * A[i, 0..N).
+    for (unsigned int i = 0; i < M; ++i) {
+      const float scale = alpha * static_cast<float>(X[i * incX]);
+      if (scale == 0.0f) {
+        continue;
+      }
+      const __m256 vs = _mm256_set1_ps(scale);
+      const MatT *a_row = A + i * lda;
+      unsigned int j = 0;
+      for (; j + 8 <= out_len; j += 8) {
+        __m256 a32 = gemv_load8<MatT>(a_row + j);
+        __m256 y32 = _mm256_loadu_ps(Y32 + j);
+        y32 = _mm256_fmadd_ps(a32, vs, y32);
+        _mm256_storeu_ps(Y32 + j, y32);
+      }
+      for (; j < out_len; ++j) {
+        Y32[j] += scale * static_cast<float>(a_row[j]);
+      }
+    }
+
+    if (incY == 1) {
+      unsigned int j = 0;
+      for (; j + 8 <= out_len; j += 8) {
+        __m256 y32 = _mm256_loadu_ps(Y32 + j);
+        gemv_store8<OutT>(Y + j, y32);
+      }
+      for (; j < out_len; ++j) {
+        Y[j] = static_cast<OutT>(Y32[j]);
+      }
+    } else {
+      for (unsigned int j = 0; j < out_len; ++j) {
+        Y[j * incY] = static_cast<OutT>(Y32[j]);
+      }
+    }
+    return;
+  }
+
+  // TransA == false: per output row, dot product of A[i, :] with X[:].
+  // The dot length (N) is the contraction; A rows are unit-stride which
+  // matches the SIMD reduction pattern from sdot.
+  const unsigned int dot_len = N;
+  if (incX == 1) {
+    gemv_no_trans_contiguous_x<MatT, VecT, OutT>(M, dot_len, alpha, A, lda, X,
+                                                 beta, Y, incY);
+  } else if (dot_len >= 8) {
+    static thread_local std::vector<float> x32_scratch;
+    x32_scratch.resize(dot_len);
+    for (unsigned int j = 0; j < dot_len; ++j) {
+      x32_scratch[j] = static_cast<float>(X[j * incX]);
+    }
+    gemv_no_trans_contiguous_x<MatT, float, OutT>(
+      M, dot_len, alpha, A, lda, x32_scratch.data(), beta, Y, incY);
+  } else {
+    for (unsigned int i = 0; i < M; ++i) {
+      const MatT *a_row = A + i * lda;
+      float sum = 0.0f;
+      for (unsigned int j = 0; j < dot_len; ++j) {
+        sum += static_cast<float>(a_row[j]) * static_cast<float>(X[j * incX]);
+      }
+      float y_new = alpha * sum;
+      if (beta != 0.0f) {
+        y_new += beta * static_cast<float>(Y[i * incY]);
+      }
+      Y[i * incY] = static_cast<OutT>(y_new);
+    }
+  }
+}
+
+} // namespace
+
+void hgemv(bool TransA, const unsigned int M, const unsigned int N,
+           const float alpha, const _Float16 *A, const unsigned int lda,
+           const _Float16 *X, const unsigned int incX, const float beta,
+           _Float16 *Y, const unsigned int incY) {
+  gemv_impl<_Float16, _Float16, _Float16>(TransA, M, N, alpha, A, lda, X, incX,
+                                          beta, Y, incY);
+}
+
+void shgemv(bool TransA, const unsigned int M, const unsigned int N,
+            const float alpha, const float *A, const unsigned int lda,
+            const _Float16 *X, const unsigned int incX, const float beta,
+            float *Y, const unsigned int incY) {
+  gemv_impl<float, _Float16, float>(TransA, M, N, alpha, A, lda, X, incX, beta,
+                                    Y, incY);
+}
+
+void hsgemv(bool TransA, const unsigned int M, const unsigned int N,
+            const float alpha, const _Float16 *A, const unsigned int lda,
+            const float *X, const unsigned int incX, const float beta, float *Y,
+            const unsigned int incY) {
+  gemv_impl<_Float16, float, float>(TransA, M, N, alpha, A, lda, X, incX, beta,
+                                    Y, incY);
 }
 
 void sscal(const unsigned int N, const float alpha, _Float16 *X,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -13,11 +13,16 @@
  */
 
 #include <avx2_impl.h>
+#include "avx2_internal.h"
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <immintrin.h>
+#include <limits>
 #include <util_func.h>
+
+using namespace nntrainer::avx2::internal;
 
 namespace nntrainer::avx2 {
 
@@ -182,6 +187,1356 @@ bool is_valid(const unsigned int N, const _Float16 *input) {
   }
 
   return true;
+}
+
+// ============================================================
+// FP16 elementwise operations
+// ============================================================
+
+void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      float y0_f32 = static_cast<float>(Y[0]);
+      __m256 vy = _mm256_set1_ps(y0_f32);
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, vy);
+        __m256 z_hi = _mm256_mul_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) * y0_f32);
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_mul_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) *
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) *
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(_mm256_mul_ps(x_lo, vy), alpha_v);
+        __m256 z_hi = _mm256_mul_ps(_mm256_mul_ps(x_hi, vy), alpha_v);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(_mm256_mul_ps(x, vy), alpha_v);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_mul_ps(_mm256_mul_ps(x_lo, y_lo), alpha_v);
+        __m256 z_hi = _mm256_mul_ps(_mm256_mul_ps(x_hi, y_hi), alpha_v);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf * alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf = xf * alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_add_ps(x_lo, vy);
+        __m256 z_hi = _mm256_add_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_add_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_add_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_add_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_add_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_fmadd_ps(alpha_v, vy, x_lo);
+        __m256 z_hi = _mm256_fmadd_ps(alpha_v, vy, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_fmadd_ps(alpha_v, vy, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_fmadd_ps(alpha_v, y_lo, x_lo);
+        __m256 z_hi = _mm256_fmadd_ps(alpha_v, y_hi, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_fmadd_ps(alpha_v, y, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf + alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf =
+        xf + alpha * yf +
+        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_sub_ps(x_lo, vy);
+        __m256 z_hi = _mm256_sub_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_sub_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_sub_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_sub_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_sub_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_fnmadd_ps(alpha_v, vy, x_lo);
+        __m256 z_hi = _mm256_fnmadd_ps(alpha_v, vy, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_fnmadd_ps(alpha_v, vy, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_fnmadd_ps(alpha_v, y_lo, x_lo);
+        __m256 z_hi = _mm256_fnmadd_ps(alpha_v, y_hi, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_fnmadd_ps(alpha_v, y, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf - alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf =
+        xf - alpha * yf +
+        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  // Newton-Raphson reciprocal helper constant
+  const __m256 two = _mm256_set1_ps(2.0f);
+
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      // Precompute refined reciprocal of Y[0] once (rcp + Newton-Raphson)
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      __m256 rcp_est = _mm256_rcp_ps(vy);
+      __m256 vy_inv = _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
+
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, vy_inv);
+        __m256 z_hi = _mm256_mul_ps(x_hi, vy_inv);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, vy_inv);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        // rcp + Newton-Raphson for per-element reciprocal
+        __m256 rcp_lo = _mm256_rcp_ps(y_lo);
+        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
+        __m256 rcp_hi = _mm256_rcp_ps(y_hi);
+        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 rcp_y = _mm256_rcp_ps(y);
+        __m256 inv_y = _mm256_mul_ps(rcp_y, _mm256_fnmadd_ps(y, rcp_y, two));
+        __m256 z = _mm256_mul_ps(x, inv_y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      // Precompute refined reciprocal of (alpha * Y[0])
+      __m256 denom = _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
+      __m256 rcp_d = _mm256_rcp_ps(denom);
+      __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(denom, rcp_d, two));
+
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_d);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_d);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, inv_d);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 d_lo = _mm256_mul_ps(alpha_v, y_lo);
+        __m256 d_hi = _mm256_mul_ps(alpha_v, y_hi);
+        // rcp + Newton-Raphson for per-element reciprocal
+        __m256 rcp_lo = _mm256_rcp_ps(d_lo);
+        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
+        __m256 rcp_hi = _mm256_rcp_ps(d_hi);
+        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 d = _mm256_mul_ps(alpha_v, y);
+        __m256 rcp_d = _mm256_rcp_ps(d);
+        __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(d, rcp_d, two));
+        __m256 z = _mm256_mul_ps(x, inv_d);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf / (alpha * yf) + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf = xf / (alpha * yf) +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+// ============================================================
+// FP16 BLAS-like operations
+// ============================================================
+
+void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
+           const unsigned int incX, _Float16 *Y, const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+
+    // Main loop: process 16 elements per iteration via 256-bit loads
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+
+      __m128i x_lo = _mm256_castsi256_si128(x_raw);
+      __m128i x_hi = _mm256_extracti128_si256(x_raw, 1);
+      __m128i y_lo = _mm256_castsi256_si128(y_raw);
+      __m128i y_hi = _mm256_extracti128_si256(y_raw, 1);
+
+      __m256 xf0 = _mm256_cvtph_ps(x_lo);
+      __m256 xf1 = _mm256_cvtph_ps(x_hi);
+      __m256 yf0 = _mm256_cvtph_ps(y_lo);
+      __m256 yf1 = _mm256_cvtph_ps(y_hi);
+
+      __m256 r0 = _mm256_fmadd_ps(alpha_v, xf0, yf0);
+      __m256 r1 = _mm256_fmadd_ps(alpha_v, xf1, yf1);
+
+      __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+      __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
+                                           out_hi, 1);
+      _mm256_storeu_si256((__m256i *)(Y + i), out);
+    }
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+      __m256 result = _mm256_fmadd_ps(alpha_v, x, y);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(static_cast<float>(Y[i]) +
+                                   alpha * static_cast<float>(X[i]));
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      Y[i * incY] = static_cast<_Float16>(
+        static_cast<float>(Y[i * incY]) +
+        alpha * static_cast<float>(X[i * incX]));
+    }
+  }
+}
+
+_Float16 sdot(const unsigned int N, const _Float16 *X, const unsigned int incX,
+              const _Float16 *Y, const unsigned int incY) {
+  assert(incX > 0 && incY > 0);
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+
+    // Main loop: 16 elements with dual accumulators to break dependency
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+
+      __m256 xf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(x_raw));
+      __m256 xf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(x_raw, 1));
+      __m256 yf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(y_raw));
+      __m256 yf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(y_raw, 1));
+
+      acc0 = _mm256_fmadd_ps(xf0, yf0, acc0);
+      acc1 = _mm256_fmadd_ps(xf1, yf1, acc1);
+    }
+
+    // Merge accumulators and reduce
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+      acc = _mm256_fmadd_ps(x, y, acc);
+      i += 8;
+    }
+
+    float sum = hsum_avx(acc);
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      sum += static_cast<float>(X[i]) * static_cast<float>(Y[i]);
+    }
+    return static_cast<_Float16>(sum);
+  } else {
+    float sum = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      sum += static_cast<float>(X[i * incX]) * static_cast<float>(Y[i * incY]);
+    }
+    return static_cast<_Float16>(sum);
+  }
+}
+
+_Float16 snrm2(const unsigned int N, const _Float16 *X,
+               const unsigned int incX) {
+  if (incX == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+
+    // Main loop: 16 elements with dual accumulators
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+
+      __m256 xf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(x_raw));
+      __m256 xf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(x_raw, 1));
+
+      acc0 = _mm256_fmadd_ps(xf0, xf0, acc0);
+      acc1 = _mm256_fmadd_ps(xf1, xf1, acc1);
+    }
+
+    // Merge accumulators
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      acc = _mm256_fmadd_ps(x, x, acc);
+      i += 8;
+    }
+
+    float sum = hsum_avx(acc);
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      sum += xf * xf;
+    }
+    return static_cast<_Float16>(std::sqrt(sum));
+  } else {
+    float sum = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(X[i * incX]);
+      sum += xf * xf;
+    }
+    return static_cast<_Float16>(std::sqrt(sum));
+  }
+}
+
+void sscal(const unsigned int N, const float alpha, _Float16 *X,
+           const unsigned int incX) {
+  if (incX == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+
+    // Main loop: process 16 elements per iteration via 256-bit loads
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+
+      __m128i x_lo = _mm256_castsi256_si128(x_raw);
+      __m128i x_hi = _mm256_extracti128_si256(x_raw, 1);
+
+      __m256 xf0 = _mm256_cvtph_ps(x_lo);
+      __m256 xf1 = _mm256_cvtph_ps(x_hi);
+
+      __m256 r0 = _mm256_mul_ps(alpha_v, xf0);
+      __m256 r1 = _mm256_mul_ps(alpha_v, xf1);
+
+      __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+      __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
+                                           out_hi, 1);
+      _mm256_storeu_si256((__m256i *)(X + i), out);
+    }
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 result = _mm256_mul_ps(alpha_v, x);
+      _mm_storeu_si128((__m128i *)(X + i),
+                       _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      X[i] = static_cast<_Float16>(alpha * static_cast<float>(X[i]));
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      X[i * incX] = static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
+    }
+  }
+}
+
+void custom_scopy(const unsigned int N, const _Float16 *X,
+                  const unsigned int incX, _Float16 *Y,
+                  const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    for (; i < N16; i += 16) {
+      __m256i data =
+        _mm256_loadu_si256((const __m256i *)(X + i));
+      _mm256_storeu_si256((__m256i *)(Y + i), data);
+    }
+    for (; i < N; ++i) {
+      Y[i] = X[i];
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      Y[i * incY] = X[i * incX];
+    }
+  }
+}
+
+// ============================================================
+// FP16 activation/norm functions
+// ============================================================
+
+_Float16 max_val(const unsigned int N, _Float16 *X) {
+  unsigned int i = 0;
+  __m256 vmax0 = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+  __m256 vmax1 = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+
+  // Main loop: 16 elements per iteration with dual max accumulators
+  unsigned int N16 = (N & ~15u);
+  for (; i < N16; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    vmax0 = _mm256_max_ps(vmax0, x0);
+    vmax1 = _mm256_max_ps(vmax1, x1);
+  }
+
+  // Merge dual accumulators
+  __m256 vmax = _mm256_max_ps(vmax0, vmax1);
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    vmax = _mm256_max_ps(vmax, x);
+    i += 8;
+  }
+
+  // Horizontal max reduction
+  __m128 hi = _mm256_extractf128_ps(vmax, 1);
+  __m128 lo = _mm256_castps256_ps128(vmax);
+  lo = _mm_max_ps(lo, hi);
+  __m128 shuf = _mm_movehl_ps(lo, lo);
+  lo = _mm_max_ps(lo, shuf);
+  shuf = _mm_movehdup_ps(lo);
+  lo = _mm_max_ss(lo, shuf);
+  float result = _mm_cvtss_f32(lo);
+
+  for (; i < N; ++i) {
+    result = std::max(result, static_cast<float>(X[i]));
+  }
+  return static_cast<_Float16>(result);
+}
+
+void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
+  // Step 1: find max
+  float max_x = static_cast<float>(max_val(N, X));
+  __m256 vmax = _mm256_set1_ps(max_x);
+
+  // Step 2: exp(x - max) and accumulate sum with 16-wide loop
+  unsigned int i = 0;
+  __m256 vsum0 = _mm256_setzero_ps();
+  __m256 vsum1 = _mm256_setzero_ps();
+
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    __m256 e0 = exp256_ps(_mm256_sub_ps(x0, vmax));
+    __m256 e1 = exp256_ps(_mm256_sub_ps(x1, vmax));
+    __m128i out_lo = _mm256_cvtps_ph(e0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(e1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(Y + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+    vsum0 = _mm256_add_ps(vsum0, e0);
+    vsum1 = _mm256_add_ps(vsum1, e1);
+  }
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    __m256 e = exp256_ps(_mm256_sub_ps(x, vmax));
+    _mm_storeu_si128((__m128i *)(Y + i),
+                     _mm256_cvtps_ph(e, _MM_FROUND_TO_NEAREST_INT));
+    vsum0 = _mm256_add_ps(vsum0, e);
+    i += 8;
+  }
+
+  float sum = hsum_avx(_mm256_add_ps(vsum0, vsum1));
+  for (; i < N; ++i) {
+    float e = std::exp(static_cast<float>(X[i]) - max_x);
+    Y[i] = static_cast<_Float16>(e);
+    sum += e;
+  }
+
+  // Step 3: normalize with 16-wide loop
+  float inv_sum = 1.0f / sum;
+  __m256 vinv = _mm256_set1_ps(inv_sum);
+
+  i = 0;
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+    __m256 y0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 y1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    __m256 r0 = _mm256_mul_ps(y0, vinv);
+    __m256 r1 = _mm256_mul_ps(y1, vinv);
+    __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(Y + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+  if (i + 8 <= N) {
+    __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+    __m256 result = _mm256_mul_ps(y, vinv);
+    _mm_storeu_si128((__m128i *)(Y + i),
+                     _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+  for (; i < N; ++i) {
+    Y[i] = static_cast<_Float16>(static_cast<float>(Y[i]) * inv_sum);
+  }
+}
+
+void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
+  unsigned int i = 0;
+  const __m256 zero = _mm256_setzero_ps();
+  const __m256 inf_val = _mm256_set1_ps(INFINITY);
+  const __m256 three_half = _mm256_set1_ps(1.5f);
+  const __m256 half = _mm256_set1_ps(0.5f);
+
+  // Main loop: 16 elements per iteration
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+
+    __m256 is_zero0 = _mm256_cmp_ps(x0, zero, _CMP_EQ_OQ);
+    __m256 is_zero1 = _mm256_cmp_ps(x1, zero, _CMP_EQ_OQ);
+
+    __m256 est0 = _mm256_rsqrt_ps(x0);
+    __m256 est1 = _mm256_rsqrt_ps(x1);
+
+    // Newton-Raphson: y = y * (1.5 - 0.5 * x * y * y)
+    __m256 half_x0 = _mm256_mul_ps(half, x0);
+    __m256 half_x1 = _mm256_mul_ps(half, x1);
+    __m256 yy0 = _mm256_mul_ps(est0, est0);
+    __m256 yy1 = _mm256_mul_ps(est1, est1);
+    __m256 ref0 = _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
+    __m256 ref1 = _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
+
+    ref0 = _mm256_blendv_ps(ref0, inf_val, is_zero0);
+    ref1 = _mm256_blendv_ps(ref1, inf_val, is_zero1);
+
+    __m128i out_lo = _mm256_cvtps_ph(ref0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(ref1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(X + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    __m256 is_zero = _mm256_cmp_ps(x, zero, _CMP_EQ_OQ);
+    __m256 est = _mm256_rsqrt_ps(x);
+    __m256 half_x = _mm256_mul_ps(half, x);
+    __m256 yy = _mm256_mul_ps(est, est);
+    __m256 refined = _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    refined = _mm256_blendv_ps(refined, inf_val, is_zero);
+    _mm_storeu_si128((__m128i *)(X + i),
+                     _mm256_cvtps_ph(refined, _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+
+  // Scalar tail
+  for (; i < N; ++i) {
+    X[i] = static_cast<_Float16>(1.0f / std::sqrt(static_cast<float>(X[i])));
+  }
+}
+
+void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
+  unsigned int i = 0;
+
+  const auto oldcsr = _mm_getcsr();
+  _mm_setcsr(oldcsr | 0x8040); // DAZ | FTZ
+
+  // 16-wide blocks with 256-bit loads/stores
+  for (; i + 16 <= N; i += 16) {
+    __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+    __m256i z_raw = _mm256_loadu_si256((const __m256i *)(Z + i));
+
+    __m256 y0 = _mm256_cvtph_ps(_mm256_castsi256_si128(y_raw));
+    __m256 y1 = _mm256_cvtph_ps(_mm256_extracti128_si256(y_raw, 1));
+    __m256 z0 = _mm256_cvtph_ps(_mm256_castsi256_si128(z_raw));
+    __m256 z1 = _mm256_cvtph_ps(_mm256_extracti128_si256(z_raw, 1));
+
+    __m128i out_lo = _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0),
+                                     _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1),
+                                     _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(X + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+
+  // One 8-wide block if available
+  if (i + 8 <= N) {
+    __m256 y0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+    __m256 z0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+    _mm_storeu_si128(
+      (__m128i *)(X + i),
+      _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0), _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+
+  // Scalar remainder
+  for (; i < N; ++i) {
+    float yf = static_cast<float>(Y[i]);
+    float zf = static_cast<float>(Z[i]);
+    X[i] = static_cast<_Float16>(
+      (yf / (1.0f + std::exp(-yf))) * zf);
+  }
+
+  _mm_setcsr(oldcsr);
+}
+
+// ============================================================
+// FP16 rms_norm and rotary embedding
+// ============================================================
+
+void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
+                             _Float16 *__restrict Y, size_t H, size_t W,
+                             float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const _Float16 *rowX = X + h * W;
+    _Float16 *rowY = Y + h * W;
+
+    size_t i = 0;
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+
+    // Sum-of-squares: 32-wide loop with 256-bit loads
+    for (; i + 32 <= W; i += 32) {
+      __m256i raw0 = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256i raw1 = _mm256_loadu_si256((const __m256i *)(rowX + i + 16));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw0));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
+      __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
+      __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
+      acc0 = _mm256_fmadd_ps(x0, x0, acc0);
+      acc1 = _mm256_fmadd_ps(x1, x1, acc1);
+      acc2 = _mm256_fmadd_ps(x2, x2, acc2);
+      acc3 = _mm256_fmadd_ps(x3, x3, acc3);
+    }
+    // 16-wide tail
+    if (i + 16 <= W) {
+      __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+      acc0 = _mm256_fmadd_ps(x0, x0, acc0);
+      acc1 = _mm256_fmadd_ps(x1, x1, acc1);
+      i += 16;
+    }
+    // 8-wide tail
+    if (i + 8 <= W) {
+      __m256 x =
+        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      acc0 = _mm256_fmadd_ps(x, x, acc0);
+      i += 8;
+    }
+    float sumsq =
+      hsum_avx(acc0) + hsum_avx(acc1) + hsum_avx(acc2) + hsum_avx(acc3);
+    for (; i < W; ++i) {
+      float v = static_cast<float>(rowX[i]);
+      sumsq += v * v;
+    }
+
+    float mean = sumsq / static_cast<float>(W);
+    float scale = 1.0f / std::sqrt(mean + epsilon);
+    __m256 vscale = _mm256_set1_ps(scale);
+
+    // Scaling pass: 32-wide loop with 256-bit loads/stores
+    i = 0;
+    for (; i + 32 <= W; i += 32) {
+      __m256i raw0 = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256i raw1 = _mm256_loadu_si256((const __m256i *)(rowX + i + 16));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw0));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
+      __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
+      __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
+      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r2 = _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r3 = _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256((__m256i *)(rowY + i),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
+      _mm256_storeu_si256((__m256i *)(rowY + i + 16),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r2), r3, 1));
+    }
+    // 16-wide tail
+    if (i + 16 <= W) {
+      __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256((__m256i *)(rowY + i),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
+      i += 16;
+    }
+    // 8-wide tail
+    if (i + 8 <= W) {
+      __m256 x =
+        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      _mm_storeu_si128(
+        (__m128i *)(rowY + i),
+        _mm256_cvtps_ph(_mm256_mul_ps(x, vscale), _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+    for (; i < W; ++i) {
+      rowY[i] = static_cast<_Float16>(static_cast<float>(rowX[i]) * scale);
+    }
+  }
+}
+
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _Float16 *in, _Float16 *out,
+                                    float *cos_, float *sin_) {
+  unsigned int k = 0;
+  for (; k + 7 < half_; k += 8) {
+    unsigned int i0 = w + k;
+    unsigned int i1 = w + k + half_;
+
+    __m256 a = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(in + i0)));
+    __m256 b = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(in + i1)));
+    __m256 cos_v = _mm256_loadu_ps(&cos_[k]);
+    __m256 sin_v = _mm256_loadu_ps(&sin_[k]);
+
+    // FMA: out0 = a*cos - b*sin, out1 = a*sin + b*cos
+    __m256 out0 = _mm256_fmsub_ps(a, cos_v, _mm256_mul_ps(b, sin_v));
+    __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
+
+    _mm_storeu_si128(
+      (__m128i *)(out + i0),
+      _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128(
+      (__m128i *)(out + i1),
+      _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
+  }
+
+  for (; k < dim; ++k) {
+    unsigned int span = w + k;
+    float value = static_cast<float>(in[span]);
+    float transformed_value;
+    if (k < half_) {
+      transformed_value = -1.0f * static_cast<float>(in[w + k + half_]);
+    } else {
+      transformed_value = static_cast<float>(in[w + k - half_]);
+    }
+    out[span] =
+      static_cast<_Float16>(value * cos_[k] + transformed_value * sin_[k]);
+  }
+}
+
+// ============================================================
+// FP16 Group B functions
+// ============================================================
+
+unsigned int isamax(const unsigned int N, const _Float16 *X,
+                    const unsigned int incX) {
+  if (incX == 1 && N >= 8) {
+    unsigned int N8 = (N & ~7u);
+    __m256 sign_mask = _mm256_set1_ps(-0.0f);
+    unsigned int max_idx = 0;
+    float max_abs = 0.0f;
+
+    for (unsigned int i = 0; i < N8; i += 8) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 abs_x = _mm256_andnot_ps(sign_mask, x);
+      // Check each element individually for max tracking
+      alignas(32) float buf[8];
+      _mm256_storeu_ps(buf, abs_x);
+      for (int j = 0; j < 8; ++j) {
+        if (buf[j] > max_abs) {
+          max_abs = buf[j];
+          max_idx = i + j;
+        }
+      }
+    }
+    for (unsigned int i = N8; i < N; ++i) {
+      float cur = std::abs(static_cast<float>(X[i]));
+      if (cur > max_abs) {
+        max_abs = cur;
+        max_idx = i;
+      }
+    }
+    return max_idx;
+  } else {
+    unsigned int max_idx = 0;
+    float max_val = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      float cur = std::abs(static_cast<float>(X[i * incX]));
+      if (cur > max_val) {
+        max_val = cur;
+        max_idx = i;
+      }
+    }
+    return max_idx;
+  }
+}
+
+void transpose_matrix(const unsigned int M, const unsigned int N,
+                      const _Float16 *src, unsigned int ld_src, _Float16 *dst,
+                      unsigned int ld_dst) {
+  for (unsigned int i = 0; i < M; i++) {
+    for (unsigned int j = 0; j < N; j++) {
+      dst[i + j * ld_dst] = src[i * ld_src + j];
+    }
+  }
+}
+
+void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      alignas(32) float buf[16];
+      for (int j = 0; j < 8; ++j) {
+        buf[2 * j] = static_cast<float>(X[i + j] >> 4);
+        buf[2 * j + 1] = static_cast<float>(X[i + j] & 0x0f);
+      }
+      __m256 v0 = _mm256_loadu_ps(buf);
+      __m256 v1 = _mm256_loadu_ps(buf + 8);
+      _mm_storeu_si128((__m128i *)(Y + 2 * i),
+                       _mm256_cvtps_ph(v0, _MM_FROUND_TO_NEAREST_INT));
+      _mm_storeu_si128((__m128i *)(Y + 2 * i + 8),
+                       _mm256_cvtps_ph(v1, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[2 * i] = static_cast<_Float16>(X[i] >> 4);
+      Y[2 * i + 1] = static_cast<_Float16>(X[i] & 0x0f);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[2 * idx] = static_cast<_Float16>(X[idx] >> 4);
+      Y[2 * idx + 1] = static_cast<_Float16>(X[idx] & 0x0f);
+    }
+  }
+}
+
+void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      __m256i xi = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256 xf = _mm256_cvtepi32_ps(xi);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(X[i]);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[idx * incY] = static_cast<_Float16>(X[idx * incX]);
+    }
+  }
+}
+
+void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      __m256i xi = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256 xf = _mm256_cvtepi32_ps(xi);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(X[i]);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[idx * incY] = static_cast<_Float16>(X[idx * incX]);
+    }
+  }
 }
 
 } // namespace nntrainer::avx2

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "avx2_internal.h"
+#include <algorithm>
 #include <avx2_impl.h>
 #include <cassert>
 #include <cmath>
@@ -20,6 +21,7 @@
 #include <cstring>
 #include <immintrin.h>
 #include <limits>
+#include <nntrainer_error.h>
 #include <type_traits>
 #include <util_func.h>
 #include <vector>
@@ -1813,6 +1815,258 @@ void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
       Y[idx * incY] = static_cast<_Float16>(X[idx * incX]);
     }
   }
+}
+
+/*****************************************************************************
+ * FP16-input attention kernels (AVX2 + F16C).
+ *
+ * x86 has no native FP16 arithmetic, so every operation is done in FP32:
+ * operands are widened with F16C on load and narrowed on store. These mirror
+ * the ARM NEON FP16 kernels in neon_impl_fp16.cpp but accumulate in FP32 for
+ * accuracy. Scratch buffers are static thread_local for zero per-call
+ * allocations (each ThreadManager worker owns its own copy).
+ *****************************************************************************/
+
+/// Load 8 contiguous FP16 values and widen to FP32.
+static inline __m256 load8_f16_to_f32(const _Float16 *p) {
+  return _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i *>(p)));
+}
+
+/// Narrow 8 FP32 values to FP16 and store contiguously.
+static inline void store8_f32_to_f16(_Float16 *p, __m256 v) {
+  _mm_storeu_si128(reinterpret_cast<__m128i *>(p),
+                   _mm256_cvtps_ph(v, _MM_FROUND_TO_NEAREST_INT));
+}
+
+void compute_kcaches(const _Float16 *in, const _Float16 *kcache,
+                     _Float16 *output, int num_rows, int num_cache_head,
+                     int head_dim, int gqa_size, int tile_size,
+                     size_t local_window_size, int head_start, int head_end) {
+  int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  NNTR_THROW_IF(head_start >= actual_head_end, std::invalid_argument)
+    << "head_start (" << head_start << ") must be less than head_end ("
+    << actual_head_end << ")";
+
+  int start_row =
+    num_rows < local_window_size ? 0 : num_rows - local_window_size;
+  int row_cnt = num_rows < local_window_size ? num_rows : local_window_size;
+  const int tile_count = (row_cnt + tile_size - 1) / tile_size;
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int t = 0; t < tile_count; ++t) {
+      int row_tile_start = t * tile_size;
+      int tile_rows = std::min(tile_size, row_cnt - row_tile_start);
+
+      for (int g = 0; g < gqa_size; ++g) {
+        const _Float16 *in_ptr = in + (n * gqa_size + g) * head_dim;
+        for (int t_row = 0; t_row < tile_rows; ++t_row) {
+          int row = start_row + row_tile_start + t_row;
+          if (t_row + 1 < tile_rows) {
+            const _Float16 *next_kptr =
+              kcache + ((row + 1) * num_cache_head + n) * head_dim;
+            _mm_prefetch(reinterpret_cast<const char *>(next_kptr),
+                         _MM_HINT_T0);
+          }
+          const _Float16 *k_row =
+            kcache + (row * num_cache_head + n) * head_dim;
+
+          // Dot product of the FP16 query and key rows, widened to FP32.
+          float sum = 0.0f;
+          int i = 0;
+          __m256 acc = _mm256_setzero_ps();
+          for (; i + 8 <= head_dim; i += 8) {
+            acc = _mm256_fmadd_ps(load8_f16_to_f32(in_ptr + i),
+                                  load8_f16_to_f32(k_row + i), acc);
+          }
+          sum += hsum_avx(acc);
+          for (; i < head_dim; ++i)
+            sum += static_cast<float>(in_ptr[i]) * static_cast<float>(k_row[i]);
+
+          output[(row - start_row) * num_cache_head * gqa_size + n * gqa_size +
+                 g] =
+            static_cast<_Float16>(sum /
+                                  std::sqrt(static_cast<float>(head_dim)));
+        }
+      }
+    }
+  }
+}
+
+void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
+                                   const _Float16 *vcache, _Float16 *output,
+                                   int num_cache_head, int gqa_size,
+                                   int head_dim, size_t local_window_size,
+                                   int head_start, int head_end) {
+  int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  NNTR_THROW_IF(head_start >= actual_head_end, std::invalid_argument)
+    << "head_start (" << head_start << ") must be less than head_end ("
+    << actual_head_end << ")";
+
+  const int num_blocks = head_dim / 8;
+  const int rem = head_dim % 8;
+
+  // Reusable thread-local FP32 accumulators (0 per-call allocations).
+  static thread_local std::vector<float> sumVec;
+  static thread_local std::vector<float> sumRem;
+  sumVec.resize((size_t)std::max(1, num_blocks * gqa_size) * 8);
+  sumRem.resize((size_t)gqa_size * rem);
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int i = 0; i < num_blocks * gqa_size; ++i) {
+      _mm256_storeu_ps(&sumVec[(size_t)i * 8], _mm256_setzero_ps());
+    }
+    std::fill(sumRem.begin(), sumRem.end(), 0.0f);
+
+    for (int j = row_num < local_window_size ? 0
+                                             : row_num + 1 - local_window_size;
+         j <= row_num; ++j) {
+      const _Float16 *vptr = vcache + (j * num_cache_head + n) * head_dim;
+
+      for (int h = 0; h < gqa_size; ++h) {
+        float a_val = static_cast<float>(
+          in[(row_num < local_window_size
+                ? (size_t)j
+                : (size_t)(j - (row_num + 1 - local_window_size))) *
+               (size_t)(gqa_size * num_cache_head) +
+             (size_t)(n * gqa_size) + h]);
+
+        __m256 inVec = _mm256_set1_ps(a_val);
+        for (int b = 0; b < num_blocks; ++b) {
+          __m256 bVec = load8_f16_to_f32(vptr + b * 8);
+          float *accPtr = &sumVec[(size_t)(h * num_blocks + b) * 8];
+          _mm256_storeu_ps(
+            accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
+        }
+
+        float *remPtr = &sumRem[(size_t)h * rem];
+        int base = num_blocks * 8;
+        for (int r = 0; r < rem; ++r) {
+          remPtr[r] += a_val * static_cast<float>(vptr[base + r]);
+        }
+      }
+    }
+
+    for (int h = 0; h < gqa_size; ++h) {
+      for (int b = 0; b < num_blocks; ++b) {
+        int out_base = (n * gqa_size + h) * head_dim + b * 8;
+        store8_f32_to_f16(
+          &output[out_base],
+          _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
+      }
+      float *remPtr = &sumRem[(size_t)h * rem];
+      int base = num_blocks * 8;
+      for (int r = 0; r < rem; ++r) {
+        output[(n * gqa_size + h) * head_dim + base + r] =
+          static_cast<_Float16>(remPtr[r]);
+      }
+    }
+  }
+}
+
+/// FP32-precision multi-head softmax over FP16 rows. `sink16`/`sink32` are
+/// mutually exclusive; both null means the no-sink variant.
+static void softmax_row_fp16_core(_Float16 *qk_out, size_t start_row,
+                                  size_t end_row, size_t num_heads,
+                                  const _Float16 *sink16, const float *sink32) {
+  const size_t vec_end = num_heads & ~((size_t)7);
+  const bool has_sink = (sink16 != nullptr) || (sink32 != nullptr);
+
+  static thread_local std::vector<float> max_buf;
+  static thread_local std::vector<float> sum_buf;
+  max_buf.resize(num_heads);
+  sum_buf.resize(num_heads);
+  float *max_vals = max_buf.data();
+  float *sum_vals = sum_buf.data();
+
+  // 1. find max per head (seed from sink, else from the first row)
+  size_t max_start = start_row;
+  if (has_sink) {
+    for (size_t c = 0; c < num_heads; ++c)
+      max_vals[c] = sink16 ? static_cast<float>(sink16[c]) : sink32[c];
+  } else {
+    const _Float16 *row0 = qk_out + start_row * num_heads;
+    for (size_t c = 0; c < num_heads; ++c)
+      max_vals[c] = static_cast<float>(row0[c]);
+    max_start = start_row + 1;
+  }
+  for (size_t r = max_start; r < end_row; ++r) {
+    const _Float16 *row = qk_out + num_heads * r;
+    size_t c = 0;
+    for (; c < vec_end; c += 8) {
+      __m256 m =
+        _mm256_max_ps(load8_f16_to_f32(row + c), _mm256_loadu_ps(max_vals + c));
+      _mm256_storeu_ps(max_vals + c, m);
+    }
+    for (; c < num_heads; ++c)
+      max_vals[c] = std::max(max_vals[c], static_cast<float>(row[c]));
+  }
+
+  // 2. exp(x - max), store back as FP16, accumulate sum (seed with
+  // exp(sink-max))
+  if (has_sink) {
+    size_t c = 0;
+    for (; c < vec_end; c += 8) {
+      __m256 v =
+        sink16 ? load8_f16_to_f32(sink16 + c) : _mm256_loadu_ps(sink32 + c);
+      __m256 e = exp256_ps(_mm256_sub_ps(v, _mm256_loadu_ps(max_vals + c)));
+      _mm256_storeu_ps(sum_vals + c, e);
+    }
+    for (; c < num_heads; ++c) {
+      float s = sink16 ? static_cast<float>(sink16[c]) : sink32[c];
+      sum_vals[c] = std::exp(s - max_vals[c]);
+    }
+  } else {
+    std::fill(sum_buf.begin(), sum_buf.end(), 0.0f);
+  }
+
+  for (size_t r = start_row; r < end_row; ++r) {
+    _Float16 *row = qk_out + num_heads * r;
+    size_t c = 0;
+    for (; c < vec_end; c += 8) {
+      __m256 e = exp256_ps(_mm256_sub_ps(load8_f16_to_f32(row + c),
+                                         _mm256_loadu_ps(max_vals + c)));
+      store8_f32_to_f16(row + c, e);
+      _mm256_storeu_ps(sum_vals + c,
+                       _mm256_add_ps(_mm256_loadu_ps(sum_vals + c), e));
+    }
+    for (; c < num_heads; ++c) {
+      float e = std::exp(static_cast<float>(row[c]) - max_vals[c]);
+      row[c] = static_cast<_Float16>(e);
+      sum_vals[c] += e;
+    }
+  }
+
+  // 3. reciprocal of the sum (multiply is faster than divide)
+  {
+    size_t c = 0;
+    for (; c < vec_end; c += 8)
+      _mm256_storeu_ps(sum_vals + c, rcp_ps(_mm256_loadu_ps(sum_vals + c)));
+    for (; c < num_heads; ++c)
+      sum_vals[c] = 1.0f / sum_vals[c];
+  }
+
+  // 4. normalize: exp(x - max) * (1/sum)
+  for (size_t r = start_row; r < end_row; ++r) {
+    _Float16 *row = qk_out + num_heads * r;
+    size_t c = 0;
+    for (; c < vec_end; c += 8) {
+      store8_f32_to_f16(row + c, _mm256_mul_ps(load8_f16_to_f32(row + c),
+                                               _mm256_loadu_ps(sum_vals + c)));
+    }
+    for (; c < num_heads; ++c)
+      row[c] = static_cast<_Float16>(static_cast<float>(row[c]) * sum_vals[c]);
+  }
+}
+
+template <>
+void softmax_row_inplace(_Float16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, _Float16 *sink) {
+  softmax_row_fp16_core(qk_out, start_row, end_row, num_heads, sink, nullptr);
+}
+
+void softmax_row_inplace(_Float16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, float *sink) {
+  softmax_row_fp16_core(qk_out, start_row, end_row, num_heads, nullptr, sink);
 }
 
 } // namespace nntrainer::avx2

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -1851,6 +1851,8 @@ void compute_kcaches(const _Float16 *in, const _Float16 *kcache,
     num_rows < local_window_size ? 0 : num_rows - local_window_size;
   int row_cnt = num_rows < local_window_size ? num_rows : local_window_size;
   const int tile_count = (row_cnt + tile_size - 1) / tile_size;
+  const float inv_sqrt_head_dim =
+    1.0f / std::sqrt(static_cast<float>(head_dim));
 
   for (int n = head_start; n < actual_head_end; ++n) {
     for (int t = 0; t < tile_count; ++t) {
@@ -1883,9 +1885,7 @@ void compute_kcaches(const _Float16 *in, const _Float16 *kcache,
             sum += static_cast<float>(in_ptr[i]) * static_cast<float>(k_row[i]);
 
           output[(row - start_row) * num_cache_head * gqa_size + n * gqa_size +
-                 g] =
-            static_cast<_Float16>(sum /
-                                  std::sqrt(static_cast<float>(head_dim)));
+                 g] = static_cast<_Float16>(sum * inv_sqrt_head_dim);
         }
       }
     }
@@ -1938,10 +1938,12 @@ void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
             accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
         }
 
-        float *remPtr = &sumRem[(size_t)h * rem];
-        int base = num_blocks * 8;
-        for (int r = 0; r < rem; ++r) {
-          remPtr[r] += a_val * static_cast<float>(vptr[base + r]);
+        if (rem > 0) {
+          float *remPtr = &sumRem[(size_t)h * rem];
+          int base = num_blocks * 8;
+          for (int r = 0; r < rem; ++r) {
+            remPtr[r] += a_val * static_cast<float>(vptr[base + r]);
+          }
         }
       }
     }
@@ -1953,11 +1955,13 @@ void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
           &output[out_base],
           _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
       }
-      float *remPtr = &sumRem[(size_t)h * rem];
-      int base = num_blocks * 8;
-      for (int r = 0; r < rem; ++r) {
-        output[(n * gqa_size + h) * head_dim + base + r] =
-          static_cast<_Float16>(remPtr[r]);
+      if (rem > 0) {
+        float *remPtr = &sumRem[(size_t)h * rem];
+        int base = num_blocks * 8;
+        for (int r = 0; r < rem; ++r) {
+          output[(n * gqa_size + h) * head_dim + base + r] =
+            static_cast<_Float16>(remPtr[r]);
+        }
       }
     }
   }

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -12,8 +12,8 @@
  *
  */
 
-#include <avx2_impl.h>
 #include "avx2_internal.h"
+#include <avx2_impl.h>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -209,7 +209,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -233,7 +234,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -275,7 +277,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -308,7 +311,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -327,7 +331,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf * alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf * alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
@@ -359,7 +364,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_add_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -384,7 +390,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_add_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -426,7 +433,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -459,7 +467,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -478,16 +487,16 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf + alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf + alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       float xf = static_cast<float>(*X);
       float yf = static_cast<float>(*Y);
-      float zf =
-        xf + alpha * yf +
-        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      float zf = xf + alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
       *Z = static_cast<_Float16>(zf);
       X += o_stride;
       Y += i_stride;
@@ -511,7 +520,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_sub_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -536,7 +546,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_sub_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -578,7 +589,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -611,7 +623,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -630,16 +643,16 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf - alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf - alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       float xf = static_cast<float>(*X);
       float yf = static_cast<float>(*Y);
-      float zf =
-        xf - alpha * yf +
-        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      float zf = xf - alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
       *Z = static_cast<_Float16>(zf);
       X += o_stride;
       Y += i_stride;
@@ -660,7 +673,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
       // Precompute refined reciprocal of Y[0] once (rcp + Newton-Raphson)
       __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
       __m256 rcp_est = _mm256_rcp_ps(vy);
-      __m256 vy_inv = _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
+      __m256 vy_inv =
+        _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
 
       for (; i + 16 <= N; i += 16) {
         __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
@@ -670,7 +684,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, vy_inv);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -693,14 +708,17 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
         // rcp + Newton-Raphson for per-element reciprocal
         __m256 rcp_lo = _mm256_rcp_ps(y_lo);
-        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
+        __m256 inv_lo =
+          _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
         __m256 rcp_hi = _mm256_rcp_ps(y_hi);
-        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
+        __m256 inv_hi =
+          _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
         __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
         __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -729,7 +747,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
 
     if (i_stride == 0) {
       // Precompute refined reciprocal of (alpha * Y[0])
-      __m256 denom = _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
+      __m256 denom =
+        _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
       __m256 rcp_d = _mm256_rcp_ps(denom);
       __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(denom, rcp_d, two));
 
@@ -748,7 +767,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -774,9 +794,11 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 d_hi = _mm256_mul_ps(alpha_v, y_hi);
         // rcp + Newton-Raphson for per-element reciprocal
         __m256 rcp_lo = _mm256_rcp_ps(d_lo);
-        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
+        __m256 inv_lo =
+          _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
         __m256 rcp_hi = _mm256_rcp_ps(d_hi);
-        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
+        __m256 inv_hi =
+          _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
         __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
         __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
         if (beta != 0.0f) {
@@ -788,7 +810,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -810,7 +833,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf / (alpha * yf) + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf / (alpha * yf) +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
@@ -858,8 +882,8 @@ void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
 
       __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
       __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
-                                           out_hi, 1);
+      __m256i out =
+        _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1);
       _mm256_storeu_si256((__m256i *)(Y + i), out);
     }
 
@@ -880,9 +904,9 @@ void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
-      Y[i * incY] = static_cast<_Float16>(
-        static_cast<float>(Y[i * incY]) +
-        alpha * static_cast<float>(X[i * incX]));
+      Y[i * incY] =
+        static_cast<_Float16>(static_cast<float>(Y[i * incY]) +
+                              alpha * static_cast<float>(X[i * incX]));
     }
   }
 }
@@ -1006,8 +1030,8 @@ void sscal(const unsigned int N, const float alpha, _Float16 *X,
 
       __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
       __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
-                                           out_hi, 1);
+      __m256i out =
+        _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1);
       _mm256_storeu_si256((__m256i *)(X + i), out);
     }
 
@@ -1026,7 +1050,8 @@ void sscal(const unsigned int N, const float alpha, _Float16 *X,
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
-      X[i * incX] = static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
+      X[i * incX] =
+        static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
     }
   }
 }
@@ -1038,8 +1063,7 @@ void custom_scopy(const unsigned int N, const _Float16 *X,
     unsigned int i = 0;
     unsigned int N16 = (N & ~15u);
     for (; i < N16; i += 16) {
-      __m256i data =
-        _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i data = _mm256_loadu_si256((const __m256i *)(X + i));
       _mm256_storeu_si256((__m256i *)(Y + i), data);
     }
     for (; i < N; ++i) {
@@ -1115,7 +1139,8 @@ void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
     __m256 e1 = exp256_ps(_mm256_sub_ps(x1, vmax));
     __m128i out_lo = _mm256_cvtps_ph(e0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(e1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(Y + i),
+    _mm256_storeu_si256(
+      (__m256i *)(Y + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
     vsum0 = _mm256_add_ps(vsum0, e0);
     vsum1 = _mm256_add_ps(vsum1, e1);
@@ -1151,7 +1176,8 @@ void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
     __m256 r1 = _mm256_mul_ps(y1, vinv);
     __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(Y + i),
+    _mm256_storeu_si256(
+      (__m256i *)(Y + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
   if (i + 8 <= N) {
@@ -1190,15 +1216,18 @@ void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
     __m256 half_x1 = _mm256_mul_ps(half, x1);
     __m256 yy0 = _mm256_mul_ps(est0, est0);
     __m256 yy1 = _mm256_mul_ps(est1, est1);
-    __m256 ref0 = _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
-    __m256 ref1 = _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
+    __m256 ref0 =
+      _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
+    __m256 ref1 =
+      _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
 
     ref0 = _mm256_blendv_ps(ref0, inf_val, is_zero0);
     ref1 = _mm256_blendv_ps(ref1, inf_val, is_zero1);
 
     __m128i out_lo = _mm256_cvtps_ph(ref0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(ref1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(X + i),
+    _mm256_storeu_si256(
+      (__m256i *)(X + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
 
@@ -1209,7 +1238,8 @@ void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
     __m256 est = _mm256_rsqrt_ps(x);
     __m256 half_x = _mm256_mul_ps(half, x);
     __m256 yy = _mm256_mul_ps(est, est);
-    __m256 refined = _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    __m256 refined =
+      _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
     refined = _mm256_blendv_ps(refined, inf_val, is_zero);
     _mm_storeu_si128((__m128i *)(X + i),
                      _mm256_cvtps_ph(refined, _MM_FROUND_TO_NEAREST_INT));
@@ -1238,11 +1268,12 @@ void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
     __m256 z0 = _mm256_cvtph_ps(_mm256_castsi256_si128(z_raw));
     __m256 z1 = _mm256_cvtph_ps(_mm256_extracti128_si256(z_raw, 1));
 
-    __m128i out_lo = _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0),
-                                     _MM_FROUND_TO_NEAREST_INT);
-    __m128i out_hi = _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1),
-                                     _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(X + i),
+    __m128i out_lo =
+      _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0), _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi =
+      _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1), _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256(
+      (__m256i *)(X + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
 
@@ -1260,8 +1291,7 @@ void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
   for (; i < N; ++i) {
     float yf = static_cast<float>(Y[i]);
     float zf = static_cast<float>(Z[i]);
-    X[i] = static_cast<_Float16>(
-      (yf / (1.0f + std::exp(-yf))) * zf);
+    X[i] = static_cast<_Float16>((yf / (1.0f + std::exp(-yf))) * zf);
   }
 
   _mm_setcsr(oldcsr);
@@ -1308,8 +1338,7 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
     }
     // 8-wide tail
     if (i + 8 <= W) {
-      __m256 x =
-        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
       acc0 = _mm256_fmadd_ps(x, x, acc0);
       i += 8;
     }
@@ -1333,13 +1362,19 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
       __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
       __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
       __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
-      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r2 = _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r3 = _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
-      _mm256_storeu_si256((__m256i *)(rowY + i),
+      __m128i r0 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r2 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r3 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
-      _mm256_storeu_si256((__m256i *)(rowY + i + 16),
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i + 16),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r2), r3, 1));
     }
     // 16-wide tail
@@ -1347,16 +1382,18 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
       __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
       __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
       __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
-      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
-      _mm256_storeu_si256((__m256i *)(rowY + i),
+      __m128i r0 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
       i += 16;
     }
     // 8-wide tail
     if (i + 8 <= W) {
-      __m256 x =
-        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
       _mm_storeu_si128(
         (__m128i *)(rowY + i),
         _mm256_cvtps_ph(_mm256_mul_ps(x, vscale), _MM_FROUND_TO_NEAREST_INT));
@@ -1385,12 +1422,10 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
     __m256 out0 = _mm256_fmsub_ps(a, cos_v, _mm256_mul_ps(b, sin_v));
     __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
 
-    _mm_storeu_si128(
-      (__m128i *)(out + i0),
-      _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128(
-      (__m128i *)(out + i1),
-      _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i *)(out + i0),
+                     _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i *)(out + i1),
+                     _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
   }
 
   for (; k < dim; ++k) {
@@ -1502,7 +1537,8 @@ void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
     unsigned int i = 0;
     unsigned int N8 = (N & ~7u);
     for (; i < N8; i += 8) {
-      __m256i xi = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256i xi =
+        _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
       __m256 xf = _mm256_cvtepi32_ps(xi);
       _mm_storeu_si128((__m128i *)(Y + i),
                        _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
@@ -1524,7 +1560,8 @@ void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
     unsigned int i = 0;
     unsigned int N8 = (N & ~7u);
     for (; i < N8; i += 8) {
-      __m256i xi = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256i xi =
+        _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
       __m256 xf = _mm256_cvtepi32_ps(xi);
       _mm_storeu_si128((__m128i *)(Y + i),
                        _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -1905,15 +1905,19 @@ void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
   const int num_blocks = head_dim / 8;
   const int rem = head_dim % 8;
 
-  // Reusable thread-local FP32 accumulators (0 per-call allocations).
+  // Reusable thread-local FP32 accumulators (0 per-call allocations). Resolve
+  // each thread_local data pointer once into a local so the hot loops do plain
+  // pointer arithmetic (no per-access TLS/vector indirection).
   static thread_local std::vector<float> sumVec;
   static thread_local std::vector<float> sumRem;
   sumVec.resize((size_t)std::max(1, num_blocks * gqa_size) * 8);
   sumRem.resize((size_t)gqa_size * rem);
+  float *sv = sumVec.data();
+  float *rem_buf = sumRem.data();
 
   for (int n = head_start; n < actual_head_end; ++n) {
     for (int i = 0; i < num_blocks * gqa_size; ++i) {
-      _mm256_storeu_ps(&sumVec[(size_t)i * 8], _mm256_setzero_ps());
+      _mm256_storeu_ps(&sv[(size_t)i * 8], _mm256_setzero_ps());
     }
     std::fill(sumRem.begin(), sumRem.end(), 0.0f);
 
@@ -1933,13 +1937,13 @@ void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
         __m256 inVec = _mm256_set1_ps(a_val);
         for (int b = 0; b < num_blocks; ++b) {
           __m256 bVec = load8_f16_to_f32(vptr + b * 8);
-          float *accPtr = &sumVec[(size_t)(h * num_blocks + b) * 8];
+          float *accPtr = &sv[(size_t)(h * num_blocks + b) * 8];
           _mm256_storeu_ps(
             accPtr, _mm256_fmadd_ps(inVec, bVec, _mm256_loadu_ps(accPtr)));
         }
 
         if (rem > 0) {
-          float *remPtr = &sumRem[(size_t)h * rem];
+          float *remPtr = &rem_buf[(size_t)h * rem];
           int base = num_blocks * 8;
           for (int r = 0; r < rem; ++r) {
             remPtr[r] += a_val * static_cast<float>(vptr[base + r]);
@@ -1953,10 +1957,10 @@ void compute_fp16vcache_transposed(int row_num, const _Float16 *in,
         int out_base = (n * gqa_size + h) * head_dim + b * 8;
         store8_f32_to_f16(
           &output[out_base],
-          _mm256_loadu_ps(&sumVec[(size_t)(h * num_blocks + b) * 8]));
+          _mm256_loadu_ps(&sv[(size_t)(h * num_blocks + b) * 8]));
       }
       if (rem > 0) {
-        float *remPtr = &sumRem[(size_t)h * rem];
+        float *remPtr = &rem_buf[(size_t)h * rem];
         int base = num_blocks * 8;
         for (int r = 0; r < rem; ++r) {
           output[(n * gqa_size + h) * head_dim + base + r] =

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2023 Donghyeon Jeong <dhyeon.jeong@samsung.com>
  *
- * @file   avx2_impl.cpp
+ * @file   avx2_impl_fp16.cpp
  * @date   20 Feb 2024
  * @see    https://github.com/nntrainer/nntrainer
  * @author Donghyeon Jeong <dhyeon.jeong@samsung.com>

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -139,6 +139,7 @@ constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
 
 // --- Exp2 lookup table ---
 
+/** @brief Exp2 lookup table for fast vectorized exponential approximation */
 template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
           typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
 struct Exp2Table {
@@ -157,6 +158,7 @@ struct Exp2Table {
 };
 
 #if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
+/** @brief Exp2 lookup table explicit specialization for 8-entry float table on platforms lacking consteval */
 template <> struct Exp2Table<8, uint32_t, float> {
   [[nodiscard]] static constexpr auto calculate() noexcept {
     std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
+ *
+ * @file   avx2_internal.h
+ * @date   10 Apr 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Shared AVX2 SIMD helper functions used by both avx2_impl.cpp and
+ *         avx2_impl_fp16.cpp
+ */
+
+#ifndef __AVX2_INTERNAL_H_
+#define __AVX2_INTERNAL_H_
+#ifdef __cplusplus
+
+#include <array>
+#if __has_include(<bit>)
+#include <bit>
+#endif
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <immintrin.h>
+#include <limits>
+#if __has_include(<numbers>)
+#include <numbers>
+#endif
+#include <type_traits>
+#if __has_include(<version>)
+#include <version>
+#endif
+
+#if !defined(__has_constexpr_builtin)
+#define __has_constexpr_builtin(x) (0)
+#endif
+
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) (0)
+#endif
+
+// VECTORCALL calling-conv (default for x86_64-linux-gnu)
+#if !defined(_nnt_CC_VECTORCALL)
+#if _MSC_VER >= 1700
+#define _nnt_CC_VECTORCALL __vectorcall
+#else
+#define _nnt_CC_VECTORCALL
+#endif
+#endif
+
+// Flatten attribute
+#if !defined(_nnt_ATTR_FLATTEN)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
+#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
+#elif __has_cpp_attribute(gnu::flatten)
+#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
+#else
+#define _nnt_ATTR_FLATTEN
+#endif
+#endif
+
+#if !defined(_nnt_ATTR_NOINLINE)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::noinline)
+#define _nnt_ATTR_NOINLINE [[msvc::noinline]]
+#elif __has_cpp_attribute(gnu::noinline)
+#define _nnt_ATTR_NOINLINE [[gnu::noinline]]
+#else
+#define _nnt_ATTR_NOINLINE
+#endif
+#endif
+
+#if !defined(_nnt_ATTR_ALWAYS_INLINE)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
+#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
+#elif __has_cpp_attribute(gnu::always_inline)
+#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
+#endif
+#endif
+
+#if !defined(UNLIKELY)
+#if __has_cpp_attribute(unlikely)
+#define UNLIKELY [[unlikely]]
+#else
+#define UNLIKELY
+#endif
+#endif
+
+namespace nntrainer::avx2::internal {
+
+// --- bit_cast / popcount / power-of-two helpers ---
+
+template <typename To_, typename From_>
+constexpr inline bool concept17_BinaryCastable =
+  sizeof(To_) == sizeof(From_) &&
+  std::is_trivially_copyable_v<From_> &&std::is_trivially_copyable_v<To_>;
+
+template <class To_, class From_>
+inline auto compat_bit_cast(const From_ &src) noexcept
+  -> std::enable_if_t<concept17_BinaryCastable<To_, From_>, To_> {
+#if __cpp_lib_bit_cast >= 201806L
+  return std::bit_cast<To_>(src);
+#else
+  To_ dst;
+  std::memcpy(&dst, &src, sizeof(To_));
+  return dst;
+#endif
+}
+
+[[nodiscard]] constexpr inline unsigned
+constexpr_popcount(uint32_t v) noexcept {
+#if __cpp_lib_bitops >= 201907L
+  return std::popcount(v);
+#else
+  v = v - ((v >> 1) & 0x55555555);
+  v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+  return c;
+#endif
+}
+
+template <unsigned I_>
+constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
+
+namespace numbers {
+#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
+using std::numbers::ln2_v;
+using std::numbers::log2e_v;
+#else
+template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
+template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
+#endif
+} // namespace numbers
+
+// --- Exp constants ---
+
+constexpr inline float EXP_ARG_MIN = -87.0;
+constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
+
+// --- Exp2 lookup table ---
+
+template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
+          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+struct Exp2Table {
+  constexpr static inline auto MANTISSA_BITS =
+    std::numeric_limits<Float_>::digits - 1;
+
+#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
+  [[nodiscard]] static consteval auto calculate() noexcept {
+    std::array<Ty_, N_> t;
+    for (unsigned i = 0; i < N_; ++i)
+      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
+             ((i << MANTISSA_BITS) / N_);
+    return t;
+  }
+#endif
+};
+
+#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
+template <> struct Exp2Table<8, uint32_t, float> {
+  [[nodiscard]] static constexpr auto calculate() noexcept {
+    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
+                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
+                                 0x3f7744fdU, 0x3f7ac0c7U};
+    return t;
+  }
+};
+#endif
+
+template <unsigned N_>
+alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
+
+// --- Vectorized exp (lookup-based, used by swiglu) ---
+
+template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_exp_e2lookup(__m256 xs) noexcept {
+  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
+  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
+  constexpr static unsigned MANTISSA_BITS =
+    std::numeric_limits<float>::digits - 1;
+
+  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
+  xs =
+    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
+  xs = _mm256_min_ps(
+    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
+
+  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
+  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
+  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
+
+  auto xs_frac = _mm256_sub_ps(xs, xs_int);
+  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
+
+  __m256i s_ints;
+  if constexpr (N_ == 8) {
+    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
+    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
+  } else {
+    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
+  }
+
+  auto xs_uint_shifted = _mm256_slli_epi32(
+    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
+  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
+  auto s_floats = _mm256_castsi256_ps(s_ints_2);
+
+  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
+                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
+                                      0x1.62e42ff0c52d6p-1f / N_};
+
+  const auto C0 = _mm256_set1_ps(poly_d4[0]);
+  const auto C1 = _mm256_set1_ps(poly_d4[1]);
+  const auto C2 = _mm256_set1_ps(poly_d4[2]);
+
+  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
+  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
+  auto qs2 = _mm256_mul_ps(xs_frac, C2);
+
+  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
+
+  return _mm256_fmadd_ps(xs, s_floats, s_floats);
+}
+
+// --- Negate ---
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_negate_ps(__m256 x) noexcept -> __m256 {
+  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
+  const auto UNDEF = _mm256_undefined_si256();
+  const auto sign_bit =
+    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
+  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
+  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
+  return neg_x;
+}
+
+// --- SwiGLU helpers ---
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
+  auto neg_x = avx2_negate_ps(x);
+  auto inv_sigmoid =
+    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
+  auto alpha_x = _mm256_mul_ps(alpha, x);
+  auto neg_alpha_x = avx2_negate_ps(alpha_x);
+  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
+                                   _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+// --- exp256_ps (used by softmax) ---
+
+static inline __m256 exp256_ps(__m256 x) {
+  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f);
+  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);
+
+  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);
+  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f);
+  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
+
+  __m256 fx = _mm256_mul_ps(x, LOG2EF);
+  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
+
+  __m256 tmp = _mm256_mul_ps(fx, LN2);
+  __m256 r = _mm256_sub_ps(x, tmp);
+
+  const __m256 c0 = _mm256_set1_ps(1.0f);
+  const __m256 c1 = _mm256_set1_ps(1.0f);
+  const __m256 c2 = _mm256_set1_ps(0.5f);
+  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
+  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
+  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
+  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
+  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
+  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
+  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
+  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
+
+  __m256 y = c10;
+  y = _mm256_fmadd_ps(y, r, c9);
+  y = _mm256_fmadd_ps(y, r, c8);
+  y = _mm256_fmadd_ps(y, r, c7);
+  y = _mm256_fmadd_ps(y, r, c6);
+  y = _mm256_fmadd_ps(y, r, c5);
+  y = _mm256_fmadd_ps(y, r, c4);
+  y = _mm256_fmadd_ps(y, r, c3);
+  y = _mm256_fmadd_ps(y, r, c2);
+  y = _mm256_fmadd_ps(y, r, c1);
+  y = _mm256_fmadd_ps(y, r, c0);
+
+  __m256i emm0 = _mm256_cvtps_epi32(fx);
+  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
+  emm0 = _mm256_slli_epi32(emm0, 23);
+  __m256 pow2n = _mm256_castsi256_ps(emm0);
+
+  return _mm256_mul_ps(y, pow2n);
+}
+
+// --- rcp_ps (Newton-Raphson reciprocal) ---
+
+static inline __m256 rcp_ps(__m256 x) {
+  __m256 rcp = _mm256_rcp_ps(x);
+  __m256 two = _mm256_set1_ps(2.0f);
+  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
+}
+
+// --- hsum_avx (horizontal sum) ---
+
+static inline float hsum_avx(__m256 v) {
+  __m128 vlow = _mm256_castps256_ps128(v);
+  __m128 vhigh = _mm256_extractf128_ps(v, 1);
+  vlow = _mm_add_ps(vlow, vhigh);
+  __m128 shuf = _mm_movehdup_ps(vlow);
+  __m128 sums = _mm_add_ps(vlow, shuf);
+  shuf = _mm_movehl_ps(shuf, sums);
+  sums = _mm_add_ss(sums, shuf);
+  return _mm_cvtss_f32(sums);
+}
+
+// --- GELU polynomial approximation (tanh variant) ---
+
+#define gelu_start_tanh -4.38086284326899f
+#define gelu_end_tanh 4.38086284326899f
+
+#define tanh_c_gelu_p0 5.91303808e-6f
+#define tanh_c_gelu_p1 5.00000000e-1f
+#define tanh_c_gelu_p2 3.98865869e-1f
+#define tanh_c_gelu_p4 -6.66574676e-2f
+#define tanh_c_gelu_p6 1.00712610e-2f
+#define tanh_c_gelu_p8 -1.19336340e-3f
+#define tanh_c_gelu_p10 1.09543224e-4f
+#define tanh_c_gelu_p12 -7.55788500e-6f
+#define tanh_c_gelu_p14 3.73374142e-7f
+#define tanh_c_gelu_p16 -1.23162678e-8f
+#define tanh_c_gelu_p18 2.40940960e-10f
+#define tanh_c_gelu_p20 -2.10237709e-12f
+
+static inline __m256 poly_gelu_tanh_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+// --- GELU polynomial approximation (erf variant) ---
+
+#define gelu_start_erf -4.59373833108583f
+#define gelu_end_erf 4.59373833108583f
+
+#define erf_c_gelu_p0 8.70757509e-06f
+#define erf_c_gelu_p1 5.00000000e-1f
+#define erf_c_gelu_p2 3.98833088e-01f
+#define erf_c_gelu_p4 -6.62633808e-02f
+#define erf_c_gelu_p6 9.78776282e-03f
+#define erf_c_gelu_p8 -1.10798998e-03f
+#define erf_c_gelu_p10 9.51056006e-05f
+#define erf_c_gelu_p12 -6.04633051e-06f
+#define erf_c_gelu_p14 2.73076070e-07f
+#define erf_c_gelu_p16 -8.20707325e-09f
+#define erf_c_gelu_p18 1.46115955e-10f
+#define erf_c_gelu_p20 -1.16009840e-12f
+
+static inline __m256 poly_gelu_erf_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+} // namespace nntrainer::avx2::internal
+
+#endif /* __cplusplus */
+#endif /* __AVX2_INTERNAL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -158,7 +158,8 @@ struct Exp2Table {
 };
 
 #if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
-/** @brief Exp2 lookup table explicit specialization for 8-entry float table on platforms lacking consteval */
+/** @brief Exp2 lookup table explicit specialization for 8-entry float table on
+ * platforms lacking consteval */
 template <> struct Exp2Table<8, uint32_t, float> {
   [[nodiscard]] static constexpr auto calculate() noexcept {
     std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.h
@@ -1,0 +1,70 @@
+/**
+ * @file   avx2_mathfun.h
+ * @date   03 Apr 2026
+ * @brief  This is collection of sin, cos function with AVX2 SIMD
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Julien Pommier (original cephes-based algorithm)
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+/** AVX2 implementation of sin, cos
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library.
+
+   Ported from the NEON implementation (neon_mathfun.h/hxx) to AVX2
+   intrinsics, processing 8 floats at a time instead of 4.
+*/
+
+/** Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#ifndef __AVX2_MATHFUN_H_
+#define __AVX2_MATHFUN_H_
+
+#include <immintrin.h>
+
+/**
+ * @brief     sincos function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @param[out] ysin sin register variable (__m256, 8 floats)
+ * @param[out] ycos cos register variable (__m256, 8 floats)
+ */
+inline void sincos256_ps(__m256 x, __m256 *ysin, __m256 *ycos);
+
+/**
+ * @brief     sin function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @return    __m256 result of sin(x)
+ */
+inline __m256 sin256_ps(__m256 x);
+
+/**
+ * @brief     cos function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @return    __m256 result of cos(x)
+ */
+inline __m256 cos256_ps(__m256 x);
+
+#include "avx2_mathfun.hxx"
+
+#endif /* __AVX2_MATHFUN_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.hxx
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.hxx
@@ -1,0 +1,185 @@
+/**
+ * @file   avx2_mathfun.hxx
+ * @date   03 Apr 2026
+ * @brief  This is collection of sin, cos function with AVX2 SIMD
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Julien Pommier (original cephes-based algorithm)
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+/* AVX2 implementation of sin, cos
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library.
+
+   Ported from the NEON implementation (neon_mathfun.hxx) to AVX2
+   intrinsics, processing 8 floats at a time instead of 4.
+*/
+
+/* Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#define c_minus_cephes_DP1 -0.78515625
+#define c_minus_cephes_DP2 -2.4187564849853515625e-4
+#define c_minus_cephes_DP3 -3.77489497744594108e-8
+#define c_sincof_p0 -1.9515295891E-4
+#define c_sincof_p1 8.3321608736E-3
+#define c_sincof_p2 -1.6666654611E-1
+#define c_coscof_p0 2.443315711809948E-005
+#define c_coscof_p1 -1.388731625493765E-003
+#define c_coscof_p2 4.166664568298827E-002
+#define c_cephes_FOPI 1.27323954473516 // 4 / M_PI
+
+/**
+ * @brief AVX2 equivalent of NEON vtstq_u32 : test bits
+ * @note  returns all 1s per lane where (a & b) != 0
+ *
+ * @param a first operand
+ * @param b second operand
+ * @return __m256i mask with all 1s where (a & b) != 0
+ */
+static inline __m256i _mm256_tst_epi32(__m256i a, __m256i b) {
+  __m256i t = _mm256_and_si256(a, b);
+  __m256i zero = _mm256_setzero_si256();
+  __m256i eq_zero = _mm256_cmpeq_epi32(t, zero);
+  return _mm256_xor_si256(eq_zero, _mm256_cmpeq_epi32(zero, zero));
+}
+
+/* evaluation of 8 sines & cosines at once.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Note also that when you compute sin(x), cos(x) is available at
+   almost no extra price so both sin256_ps and cos256_ps make use of
+   sincos256_ps..
+  */
+/**
+ * @brief sincos function with AVX2 SIMD
+ *
+ * @param x input register variable (__m256, 8 floats)
+ * @param ysin output sin register variable
+ * @param ycos output cos register variable
+ */
+inline void sincos256_ps(__m256 x, __m256 *ysin, __m256 *ycos) {
+  __m256 xmm1, xmm2, xmm3, y;
+
+  __m256i emm2;
+
+  __m256i sign_mask_sin, sign_mask_cos;
+  sign_mask_sin =
+    _mm256_castps_si256(_mm256_cmp_ps(x, _mm256_setzero_ps(), _CMP_LT_OQ));
+  x = _mm256_andnot_ps(_mm256_set1_ps(-0.0f), x); /* abs(x) */
+
+  /* scale by 4/Pi */
+  y = _mm256_mul_ps(x, _mm256_set1_ps(c_cephes_FOPI));
+
+  /* store the integer part of y in emm2 */
+  emm2 = _mm256_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm256_add_epi32(emm2, _mm256_set1_epi32(1));
+  emm2 = _mm256_and_si256(emm2, _mm256_set1_epi32(~1));
+  y = _mm256_cvtepi32_ps(emm2);
+
+  /* get the polynom selection mask
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  __m256i poly_mask = _mm256_tst_epi32(emm2, _mm256_set1_epi32(2));
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP1));
+  xmm2 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP2));
+  xmm3 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP3));
+  x = _mm256_add_ps(x, xmm1);
+  x = _mm256_add_ps(x, xmm2);
+  x = _mm256_add_ps(x, xmm3);
+
+  sign_mask_sin = _mm256_xor_si256(
+    sign_mask_sin, _mm256_tst_epi32(emm2, _mm256_set1_epi32(4)));
+  sign_mask_cos = _mm256_tst_epi32(_mm256_sub_epi32(emm2, _mm256_set1_epi32(2)),
+                                   _mm256_set1_epi32(4));
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) in y1,
+     and the second polynom      (Pi/4 <= x <= 0) in y2 */
+  __m256 z = _mm256_mul_ps(x, x);
+  __m256 y1, y2;
+
+  y1 = _mm256_fmadd_ps(_mm256_set1_ps(c_coscof_p0), z,
+                       _mm256_set1_ps(c_coscof_p1));
+  y2 = _mm256_fmadd_ps(_mm256_set1_ps(c_sincof_p0), z,
+                       _mm256_set1_ps(c_sincof_p1));
+  y1 = _mm256_fmadd_ps(y1, z, _mm256_set1_ps(c_coscof_p2));
+  y2 = _mm256_fmadd_ps(y2, z, _mm256_set1_ps(c_sincof_p2));
+  y1 = _mm256_mul_ps(y1, z);
+  y2 = _mm256_mul_ps(y2, z);
+  y1 = _mm256_mul_ps(y1, z);
+  y2 = _mm256_mul_ps(y2, x);
+  y1 = _mm256_sub_ps(y1, _mm256_mul_ps(z, _mm256_set1_ps(0.5f)));
+  y2 = _mm256_add_ps(y2, x);
+  y1 = _mm256_add_ps(y1, _mm256_set1_ps(1));
+
+  /* select the correct result from the two polynoms */
+  __m256 pm = _mm256_castsi256_ps(poly_mask);
+  __m256 ys = _mm256_blendv_ps(y2, y1, pm);
+  __m256 yc = _mm256_blendv_ps(y1, y2, pm);
+
+  /* apply sign */
+  __m256 sign_bit = _mm256_set1_ps(-0.0f);
+  __m256 neg_ys = _mm256_xor_ps(ys, sign_bit);
+  __m256 neg_yc = _mm256_xor_ps(yc, sign_bit);
+  *ysin = _mm256_blendv_ps(ys, neg_ys, _mm256_castsi256_ps(sign_mask_sin));
+  *ycos = _mm256_blendv_ps(neg_yc, yc, _mm256_castsi256_ps(sign_mask_cos));
+}
+
+/**
+ * @brief sin function with AVX2 SIMD
+ *
+ * @param x input register variable
+ * @return __m256 result of sin(x)
+ */
+inline __m256 sin256_ps(__m256 x) {
+  __m256 ysin, ycos;
+  sincos256_ps(x, &ysin, &ycos);
+  return ysin;
+}
+
+/**
+ * @brief cos function with AVX2 SIMD
+ *
+ * @param x input register variable
+ * @return __m256 result of cos(x)
+ */
+inline __m256 cos256_ps(__m256 x) {
+  __m256 ysin, ycos;
+  sincos256_ps(x, &ysin, &ycos);
+  return ycos;
+}

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.cpp
@@ -19,7 +19,7 @@
 
 #include <cmath>
 
-namespace nntrainer::avx2 {
+namespace nntrainer::hgemm {
 
 using namespace internal;
 
@@ -78,4 +78,4 @@ void hsgemm(const _FP16 *A, const float *B, float *C, unsigned int M,
                                      ldb, beta, C, ldc);
 }
 
-} /* namespace nntrainer::avx2 */
+} /* namespace nntrainer::hgemm */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm.cpp
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Entry point for the x86 cache-blocked FP16 GEMM
+ */
+
+#include "hgemm.h"
+
+#include "hgemm_blocked.h"
+#include "hgemm_fast_path.h"
+#include "hgemm_util.h"
+#include "hgemm_workspace.h"
+
+#include <cmath>
+
+namespace nntrainer::avx2 {
+
+using namespace internal;
+
+namespace {
+
+template <typename AType, typename BType, typename CType>
+void hgemm_compute(bool TransA, bool TransB, unsigned int M, unsigned int N,
+                   unsigned int K, float alpha, const AType *A,
+                   unsigned int a_stride, const BType *B, unsigned int b_stride,
+                   float beta, CType *C, unsigned int c_stride) {
+  if (M == 0 || N == 0) {
+    return;
+  }
+
+  if (K == 0 || std::fpclassify(alpha) == FP_ZERO) {
+    apply_beta_to_C<CType>(C, M, N, c_stride, beta);
+    return;
+  }
+
+  HgemmWorkspace &workspace = get_hgemm_workspace();
+
+  if (try_hgemm_fast_path<AType, BType, CType>(TransA, TransB, M, N, K, alpha,
+                                               A, a_stride, B, b_stride, beta,
+                                               C, c_stride, workspace)) {
+    return;
+  }
+
+  run_hgemm_blocked<AType, BType, CType>(TransA, TransB, M, N, K, alpha, A,
+                                         a_stride, B, b_stride, beta, C,
+                                         c_stride, workspace);
+}
+
+} // namespace
+
+void hgemm(const _FP16 *A, const _FP16 *B, _FP16 *C, unsigned int M,
+           unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+           unsigned int ldc, float alpha, float beta, bool TransA,
+           bool TransB) {
+  hgemm_compute<_FP16, _FP16, _FP16>(TransA, TransB, M, N, K, alpha, A, lda, B,
+                                     ldb, beta, C, ldc);
+}
+
+void shgemm(const float *A, const _FP16 *B, float *C, unsigned int M,
+            unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+            unsigned int ldc, float alpha, float beta, bool TransA,
+            bool TransB) {
+  hgemm_compute<float, _FP16, float>(TransA, TransB, M, N, K, alpha, A, lda, B,
+                                     ldb, beta, C, ldc);
+}
+
+void hsgemm(const _FP16 *A, const float *B, float *C, unsigned int M,
+            unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+            unsigned int ldc, float alpha, float beta, bool TransA,
+            bool TransB) {
+  hgemm_compute<_FP16, float, float>(TransA, TransB, M, N, K, alpha, A, lda, B,
+                                     ldb, beta, C, ldc);
+}
+
+} /* namespace nntrainer::avx2 */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm.h
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Entry point for the x86 cache-blocked FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_H_
+#define __X86_HGEMM_H_
+
+#include <tensor_dim.h>
+
+namespace nntrainer::avx2 {
+
+/**
+ * @brief Compute C = alpha * op(A) * op(B) + beta * C in FP16.
+ *
+ * Replaces the legacy FP16 sgemm triple-conversion + CBLAS path with a
+ * cache-blocked GEMM that converts FP16->FP32 during packing in L2-sized
+ * blocks. Internal compute is done in FP32; the result is converted back to
+ * FP16 on writeback.
+ *
+ * @param A    FP16 source matrix, row-major
+ * @param B    FP16 source matrix, row-major
+ * @param C    FP16 destination, row-major
+ * @param M    rows of op(A) / C
+ * @param N    cols of op(B) / C
+ * @param K    inner dimension
+ * @param lda  leading dimension of A (row stride in elements). Must be >=
+ *             (TransA ? M : K).
+ * @param ldb  leading dimension of B (row stride in elements). Must be >=
+ *             (TransB ? K : N).
+ * @param ldc  leading dimension of C (row stride in elements). Must be >= N.
+ * @param alpha scalar applied to op(A) * op(B)
+ * @param beta scalar applied to C before accumulation
+ * @param TransA whether A is transposed
+ * @param TransB whether B is transposed
+ */
+void hgemm(const _FP16 *A, const _FP16 *B, _FP16 *C, unsigned int M,
+           unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+           unsigned int ldc, float alpha, float beta, bool TransA, bool TransB);
+
+/**
+ * @brief Mixed-precision GEMM C = alpha * op(A) * op(B) + beta * C with FP32 A,
+ * FP16 B and FP32 C (shgemm).
+ *
+ * Shares the cache-blocked path with hgemm(): A is re-laid out without
+ * conversion during packing, B is widened from FP16, and the FP32 accumulator
+ * is copied straight back into C with no narrowing.
+ *
+ * @param A    FP32 source matrix, row-major
+ * @param B    FP16 source matrix, row-major
+ * @param C    FP32 destination, row-major
+ * @param M    rows of op(A) / C
+ * @param N    cols of op(B) / C
+ * @param K    inner dimension
+ * @param lda  leading dimension of A (>= TransA ? M : K)
+ * @param ldb  leading dimension of B (>= TransB ? K : N)
+ * @param ldc  leading dimension of C (>= N)
+ * @param alpha scalar applied to op(A) * op(B)
+ * @param beta scalar applied to C before accumulation
+ * @param TransA whether A is transposed
+ * @param TransB whether B is transposed
+ */
+void shgemm(const float *A, const _FP16 *B, float *C, unsigned int M,
+            unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+            unsigned int ldc, float alpha, float beta, bool TransA,
+            bool TransB);
+
+/**
+ * @brief Mixed-precision GEMM C = alpha * op(A) * op(B) + beta * C with FP16 A,
+ * FP32 B and FP32 C (hsgemm).
+ *
+ * Mirror of shgemm() with the converted operand swapped: A is widened from
+ * FP16, B is re-laid out from FP32.
+ *
+ * @param A    FP16 source matrix, row-major
+ * @param B    FP32 source matrix, row-major
+ * @param C    FP32 destination, row-major
+ * @param M    rows of op(A) / C
+ * @param N    cols of op(B) / C
+ * @param K    inner dimension
+ * @param lda  leading dimension of A (>= TransA ? M : K)
+ * @param ldb  leading dimension of B (>= TransB ? K : N)
+ * @param ldc  leading dimension of C (>= N)
+ * @param alpha scalar applied to op(A) * op(B)
+ * @param beta scalar applied to C before accumulation
+ * @param TransA whether A is transposed
+ * @param TransB whether B is transposed
+ */
+void hsgemm(const _FP16 *A, const float *B, float *C, unsigned int M,
+            unsigned int N, unsigned int K, unsigned int lda, unsigned int ldb,
+            unsigned int ldc, float alpha, float beta, bool TransA,
+            bool TransB);
+
+} /* namespace nntrainer::avx2 */
+
+#endif /* __X86_HGEMM_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm.h
@@ -15,7 +15,7 @@
 
 #include <tensor_dim.h>
 
-namespace nntrainer::avx2 {
+namespace nntrainer::hgemm {
 
 /**
  * @brief Compute C = alpha * op(A) * op(B) + beta * C in FP16.
@@ -98,6 +98,6 @@ void hsgemm(const _FP16 *A, const float *B, float *C, unsigned int M,
             unsigned int ldc, float alpha, float beta, bool TransA,
             bool TransB);
 
-} /* namespace nntrainer::avx2 */
+} /* namespace nntrainer::hgemm */
 
 #endif /* __X86_HGEMM_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.cpp
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_blocked.cpp
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  C32 panel orchestration for x86 FP16 GEMM
+ */
+
+#include "hgemm_blocked.h"
+
+#include "hgemm_common.h"
+#include "hgemm_kernel/hgemm_kernel.h"
+#include "hgemm_pack.h"
+#include "hgemm_util.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <thread_manager.h>
+
+namespace nntrainer::avx2::internal {
+
+namespace {
+
+bool should_parallelize_blocked(unsigned int M, unsigned int N, unsigned int K,
+                                unsigned int panel_count) {
+  if (panel_count <= 1) {
+    return false;
+  }
+
+  constexpr std::size_t min_parallel_work = 8u * 1024u * 1024u;
+  const std::size_t work = static_cast<std::size_t>(M) * N * K;
+  return work >= min_parallel_work;
+}
+
+template <typename AType, typename BType>
+void hgemm_blocked_kernel(bool TransA, bool TransB, unsigned int M,
+                          unsigned int N, unsigned int K, float alpha,
+                          const AType *A, unsigned int a_stride, const BType *B,
+                          unsigned int b_stride, float *C32,
+                          unsigned int c32_stride, float *sa, float *sb,
+                          const HgemmBlockSizes &block) {
+  const unsigned int m_tile_block =
+    std::max(1u, std::min<unsigned int>(block.m, block.c_m));
+  const unsigned int raw_n_tile_block =
+    std::max(1u, std::min<unsigned int>(block.n, block.c_n));
+  const unsigned int n_tile_block = std::max<unsigned int>(
+    X86_HGEMM_NR, (raw_n_tile_block / X86_HGEMM_NR) * X86_HGEMM_NR);
+  const unsigned int k_block = std::max(1u, block.k);
+
+  for (unsigned int ks = 0; ks < K; ks += k_block) {
+    const unsigned int k_min = std::min<unsigned int>(K - ks, k_block);
+
+    // Pack B once for this K block and the full outer N panel. The packed
+    // buffer is indexed by absolute NR-column blocks inside the panel, so all
+    // M tiles below can reuse it.
+    for (unsigned int nn = 0; nn < N; nn += X86_HGEMM_NR) {
+      const unsigned int n_act = std::min<unsigned int>(N - nn, X86_HGEMM_NR);
+      float *pb = sb + (nn / X86_HGEMM_NR) * (k_min * X86_HGEMM_NR);
+      if (TransB) {
+        packing_B_N16_trans(k_min, n_act,
+                            B + static_cast<std::size_t>(nn) * b_stride + ks,
+                            b_stride, pb);
+      } else {
+        packing_B_N16(k_min, n_act,
+                      B + static_cast<std::size_t>(ks) * b_stride + nn,
+                      b_stride, pb);
+      }
+    }
+
+    for (unsigned int mcs = 0; mcs < M; mcs += m_tile_block) {
+      const unsigned int m_tile = std::min<unsigned int>(M - mcs, m_tile_block);
+
+      // Pack A once for this M tile and K block, then reuse it across the
+      // current outer N panel.
+      for (unsigned int mm = 0; mm < m_tile; mm += X86_HGEMM_MR) {
+        const unsigned int m_act =
+          std::min<unsigned int>(m_tile - mm, X86_HGEMM_MR);
+        float *pa = sa + (mm / X86_HGEMM_MR) * (k_min * X86_HGEMM_MR);
+        if (TransA) {
+          packing_A_M6_trans(m_act, k_min,
+                             A + static_cast<std::size_t>(ks) * a_stride +
+                               (mcs + mm),
+                             a_stride, alpha, pa);
+        } else {
+          packing_A_M6(m_act, k_min,
+                       A + static_cast<std::size_t>(mcs + mm) * a_stride + ks,
+                       a_stride, alpha, pa);
+        }
+      }
+
+      for (unsigned int ncs = 0; ncs < N; ncs += n_tile_block) {
+        const unsigned int n_end =
+          std::min<unsigned int>(N, ncs + n_tile_block);
+
+        for (unsigned int mm = 0; mm < m_tile; mm += X86_HGEMM_MR) {
+          const unsigned int m_act =
+            std::min<unsigned int>(m_tile - mm, X86_HGEMM_MR);
+          const float *pa = sa + (mm / X86_HGEMM_MR) * (k_min * X86_HGEMM_MR);
+          for (unsigned int nn = ncs; nn < n_end; nn += X86_HGEMM_NR) {
+            const unsigned int n_act =
+              std::min<unsigned int>(n_end - nn, X86_HGEMM_NR);
+            const float *pb = sb + (nn / X86_HGEMM_NR) * (k_min * X86_HGEMM_NR);
+            float *c_tile =
+              C32 + static_cast<std::size_t>(mcs + mm) * c32_stride + nn;
+            hgemm_kernel_mxn(m_act, n_act, k_min, pa, pb, c_tile, c32_stride);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename AType, typename BType, typename CType>
+void run_hgemm_panel(bool TransA, bool TransB, unsigned int M, unsigned int N,
+                     unsigned int K, float alpha, const AType *A,
+                     unsigned int a_stride, const BType *B,
+                     unsigned int b_stride, float beta, CType *C,
+                     unsigned int c_stride, HgemmWorkspace &workspace,
+                     const HgemmBlockSizes &block) {
+  const unsigned int k_block_size = std::max(1u, block.k);
+  const unsigned int m_tile_block =
+    std::max(1u, std::min<unsigned int>(block.m, block.c_m));
+  const unsigned int max_k_block = std::min<unsigned int>(K, k_block_size);
+  const unsigned int max_m_tile = std::min<unsigned int>(M, m_tile_block);
+
+  const unsigned int c32_m_capacity = round_up(M, X86_HGEMM_MR);
+  const unsigned int c32_n_capacity = round_up(N, X86_HGEMM_NR);
+  float *C32 = workspace.ensure_c32(static_cast<std::size_t>(c32_m_capacity) *
+                                    c32_n_capacity);
+
+  const std::size_t sa_capacity =
+    static_cast<std::size_t>(round_up(max_m_tile, X86_HGEMM_MR)) * max_k_block;
+  const std::size_t sb_capacity =
+    static_cast<std::size_t>(max_k_block) * c32_n_capacity;
+
+  float *sa = workspace.ensure_pack_a(sa_capacity);
+  float *sb = workspace.ensure_pack_b(sb_capacity);
+
+  std::memset(C32, 0,
+              static_cast<std::size_t>(c32_m_capacity) * c32_n_capacity *
+                sizeof(float));
+  if (std::fpclassify(beta) != FP_ZERO) {
+    copy_C_to_C32<CType>(C, C32, M, N, c_stride, c32_n_capacity, beta);
+  }
+
+  hgemm_blocked_kernel<AType, BType>(TransA, TransB, M, N, K, alpha, A,
+                                     a_stride, B, b_stride, C32, c32_n_capacity,
+                                     sa, sb, block);
+
+  copy_C32_to_C<CType>(C32, C, M, N, c32_n_capacity, c_stride);
+}
+
+} // namespace
+
+template <typename AType, typename BType, typename CType>
+void run_hgemm_blocked(bool TransA, bool TransB, unsigned int M, unsigned int N,
+                       unsigned int K, float alpha, const AType *A,
+                       unsigned int a_stride, const BType *B,
+                       unsigned int b_stride, float beta, CType *C,
+                       unsigned int c_stride, HgemmWorkspace &workspace) {
+  const HgemmBlockSizes &block = get_hgemm_block_sizes();
+
+  // Outer-panel sizes used purely to slice work for the thread pool. They start
+  // at the cache-blocking sizes, but when a large GEMM produces fewer panels
+  // than there are worker threads (e.g. M <= block.m with a modest N yields
+  // only 1-2 panels), the panels are subdivided — N width first (NR-aligned),
+  // then M height (MR-aligned) — until there is at least one panel per thread.
+  // The inner cache tiling still uses `block`, so this only changes parallel
+  // granularity, not the per-tile working set.
+  unsigned int pm = std::max(1u, block.m);
+  unsigned int pn = std::max(1u, block.n);
+  {
+    constexpr std::size_t min_parallel_work = 8u * 1024u * 1024u;
+    const std::size_t work = static_cast<std::size_t>(M) * N * K;
+    const unsigned int tc = ThreadManager::Global().getComputeThreadCount();
+    if (tc > 1 && work >= min_parallel_work) {
+      auto panels = [&](unsigned int a, unsigned int b) {
+        return ((M + a - 1) / a) * ((N + b - 1) / b);
+      };
+      while (panels(pm, pn) < tc && pn > X86_HGEMM_NR) {
+        pn = std::max<unsigned int>(X86_HGEMM_NR,
+                                    (pn / 2 / X86_HGEMM_NR) * X86_HGEMM_NR);
+      }
+      while (panels(pm, pn) < tc && pm > X86_HGEMM_MR) {
+        pm = std::max<unsigned int>(X86_HGEMM_MR,
+                                    (pm / 2 / X86_HGEMM_MR) * X86_HGEMM_MR);
+      }
+    }
+  }
+
+  const unsigned int m_panel_count = (M + pm - 1) / pm;
+  const unsigned int n_panel_count = (N + pn - 1) / pn;
+  const unsigned int panel_count = m_panel_count * n_panel_count;
+
+  auto run_panel = [&](unsigned int panel_idx,
+                       HgemmWorkspace &local_workspace) {
+    const unsigned int mi = panel_idx / n_panel_count;
+    const unsigned int ni = panel_idx % n_panel_count;
+    const unsigned int ms = mi * pm;
+    const unsigned int ns = ni * pn;
+    const unsigned int m_min = std::min<unsigned int>(M - ms, pm);
+    const unsigned int n_min = std::min<unsigned int>(N - ns, pn);
+    const AType *a_panel =
+      TransA ? A + ms : A + static_cast<std::size_t>(ms) * a_stride;
+    const BType *b_panel =
+      TransB ? B + static_cast<std::size_t>(ns) * b_stride : B + ns;
+    CType *c_panel = C + static_cast<std::size_t>(ms) * c_stride + ns;
+
+    run_hgemm_panel<AType, BType, CType>(
+      TransA, TransB, m_min, n_min, K, alpha, a_panel, a_stride, b_panel,
+      b_stride, beta, c_panel, c_stride, local_workspace, block);
+  };
+
+  if (should_parallelize_blocked(M, N, K, panel_count)) {
+    auto &tm = ThreadManager::Global();
+    tm.parallel_for(
+      0, static_cast<std::size_t>(panel_count), [&](std::size_t panel_idx) {
+        run_panel(static_cast<unsigned int>(panel_idx), get_hgemm_workspace());
+      });
+    return;
+  }
+
+  for (unsigned int panel_idx = 0; panel_idx < panel_count; ++panel_idx) {
+    run_panel(panel_idx, workspace);
+  }
+}
+
+template void run_hgemm_blocked<_FP16, _FP16, _FP16>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const _FP16 *,
+  unsigned int, const _FP16 *, unsigned int, float, _FP16 *, unsigned int,
+  HgemmWorkspace &);
+template void run_hgemm_blocked<float, _FP16, float>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const float *,
+  unsigned int, const _FP16 *, unsigned int, float, float *, unsigned int,
+  HgemmWorkspace &);
+template void run_hgemm_blocked<_FP16, float, float>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const _FP16 *,
+  unsigned int, const float *, unsigned int, float, float *, unsigned int,
+  HgemmWorkspace &);
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.cpp
@@ -22,7 +22,7 @@
 #include <cstring>
 #include <thread_manager.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 namespace {
 
@@ -243,4 +243,4 @@ template void run_hgemm_blocked<_FP16, float, float>(
   unsigned int, const float *, unsigned int, float, float *, unsigned int,
   HgemmWorkspace &);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.h
@@ -17,7 +17,7 @@
 
 #include <tensor_dim.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 template <typename AType, typename BType, typename CType>
 void run_hgemm_blocked(bool TransA, bool TransB, unsigned int M, unsigned int N,
@@ -26,6 +26,6 @@ void run_hgemm_blocked(bool TransA, bool TransB, unsigned int M, unsigned int N,
                        unsigned int b_stride, float beta, CType *C,
                        unsigned int c_stride, HgemmWorkspace &workspace);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_BLOCKED_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_blocked.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_blocked.h
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  C32 panel orchestration for x86 FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_BLOCKED_H_
+#define __X86_HGEMM_BLOCKED_H_
+
+#include "hgemm_workspace.h"
+
+#include <tensor_dim.h>
+
+namespace nntrainer::avx2::internal {
+
+template <typename AType, typename BType, typename CType>
+void run_hgemm_blocked(bool TransA, bool TransB, unsigned int M, unsigned int N,
+                       unsigned int K, float alpha, const AType *A,
+                       unsigned int a_stride, const BType *B,
+                       unsigned int b_stride, float beta, CType *C,
+                       unsigned int c_stride, HgemmWorkspace &workspace);
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_BLOCKED_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_common.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_common.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_common.h
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Block-size constants for x86 FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_COMMON_H_
+#define __X86_HGEMM_COMMON_H_
+
+/// Default outer blocking sizes. Runtime CPU detection can override these for
+/// older Intel cores or AMD Zen cores with smaller private L2 caches.
+#define X86_HGEMM_M_BLOCKING 1024
+#define X86_HGEMM_N_BLOCKING 512
+#define X86_HGEMM_K_BLOCKING 256
+
+/// Default C-panel tile sizes used inside the outer blocking panels. These are
+/// intentionally smaller than the outer M/N blocks so the FP32 accumulator
+/// panel stays cache-resident while K blocks are accumulated.
+#define X86_HGEMM_C_M_BLOCKING 192
+#define X86_HGEMM_C_N_BLOCKING 128
+
+/// Micro-kernel tile dimensions.
+/// 6 x 16 = 12 YMM accumulators + 2 YMM B + 1 YMM A broadcast = 15 of 16 YMMs.
+#define X86_HGEMM_MR 6
+#define X86_HGEMM_NR 16
+
+namespace nntrainer::avx2::internal {
+
+/** @brief Resolved blocking sizes for the x86 FP16 GEMM panel/tile loops */
+struct HgemmBlockSizes {
+  /// Outer panel size. The entry point copies/writes one MxN panel of C32 at a
+  /// time, so C32 never scales with the full output matrix.
+  unsigned int m;
+  unsigned int n;
+
+  /// K blocking depth used by the pack/compute loop.
+  unsigned int k;
+
+  /// Inner C tile size. K blocks are accumulated while this C tile is hot.
+  unsigned int c_m;
+  unsigned int c_n;
+};
+
+const HgemmBlockSizes &get_hgemm_block_sizes();
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_COMMON_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_common.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_common.h
@@ -13,24 +13,38 @@
 #ifndef __X86_HGEMM_COMMON_H_
 #define __X86_HGEMM_COMMON_H_
 
-/// Default outer blocking sizes. Runtime CPU detection can override these for
-/// older Intel cores or AMD Zen cores with smaller private L2 caches.
+/// Default outer blocking sizes (in elements). They bound the per-thread panel
+/// and the packed-operand working set that has to stay resident in the shared
+/// L2/L3 while the micro-kernel streams over it. Runtime CPU detection
+/// (tune_block_sizes) overrides these for cores with smaller private L2 caches.
+///
+/// One outer panel packs B once into N_BLOCKING * K_BLOCKING FP32 =
+/// 512 * 256 * 4 B = 512 KiB and every M tile in the panel re-reads it, so this
+/// buffer is sized for L2-tier reuse. M_BLOCKING bounds the FP32 C accumulator
+/// height (the panel is also the unit of work handed to the thread pool).
 #define X86_HGEMM_M_BLOCKING 1024
 #define X86_HGEMM_N_BLOCKING 512
+/// K depth packed/accumulated per pass. Sized so each packed micro-stripe stays
+/// inside a 32 KiB L1D: packed B stripe = NR * K * 4 B = 16 * 256 * 4 = 16 KiB,
+/// packed A stripe = MR * K * 4 B = 6 * 256 * 4 = 6 KiB.
 #define X86_HGEMM_K_BLOCKING 256
 
-/// Default C-panel tile sizes used inside the outer blocking panels. These are
-/// intentionally smaller than the outer M/N blocks so the FP32 accumulator
-/// panel stays cache-resident while K blocks are accumulated.
+/// Inner C accumulator tile, kept smaller than the outer M/N blocks so the FP32
+/// accumulator (C_M * C_N * 4 B = 192 * 128 * 4 = 96 KiB) stays cache-resident
+/// while successive K blocks are accumulated into it.
 #define X86_HGEMM_C_M_BLOCKING 192
 #define X86_HGEMM_C_N_BLOCKING 128
 
-/// Micro-kernel tile dimensions.
-/// 6 x 16 = 12 YMM accumulators + 2 YMM B + 1 YMM A broadcast = 15 of 16 YMMs.
+/// Micro-kernel tile dimensions: rows (MR) x cols (NR) of the FP32 C tile
+/// produced per kernel call. NR = 16 cols = 2 YMM registers (8 FP32 each),
+/// MR = 6 rows. AVX2 has 16 YMM registers; the kernel uses MR * 2 = 12 of them
+/// as C accumulators + 2 for the loaded B columns + 1 for the broadcast A
+/// scalar = 15 of 16, the largest register-blocked tile that still avoids
+/// spilling the accumulators back to memory.
 #define X86_HGEMM_MR 6
 #define X86_HGEMM_NR 16
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 /** @brief Resolved blocking sizes for the x86 FP16 GEMM panel/tile loops */
 struct HgemmBlockSizes {
@@ -49,6 +63,6 @@ struct HgemmBlockSizes {
 
 const HgemmBlockSizes &get_hgemm_block_sizes();
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_COMMON_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.cpp
@@ -21,7 +21,7 @@
 #include <immintrin.h>
 #include <thread_manager.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 namespace {
 
@@ -367,4 +367,4 @@ template bool try_hgemm_fast_path<_FP16, float, float>(
   unsigned int, const float *, unsigned int, float, float *, unsigned int,
   HgemmWorkspace &);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.cpp
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_fast_path.cpp
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Small/skinny x86 FP16 GEMM fast paths
+ */
+
+#include "hgemm_fast_path.h"
+
+#include "hgemm_util.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <immintrin.h>
+#include <thread_manager.h>
+
+namespace nntrainer::avx2::internal {
+
+namespace {
+
+bool should_parallelize_fast_path(unsigned int M, unsigned int N,
+                                  unsigned int K) {
+  constexpr std::size_t min_parallel_work = 1u * 1024u * 1024u;
+  const std::size_t work = static_cast<std::size_t>(M) * N * K;
+  return work >= min_parallel_work;
+}
+
+template <typename AType, typename BType, typename CType>
+void direct_small_gemm(bool TransA, bool TransB, unsigned int M, unsigned int N,
+                       unsigned int K, float alpha, const AType *A,
+                       unsigned int a_stride, const BType *B,
+                       unsigned int b_stride, float beta, CType *C,
+                       unsigned int c_stride) {
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      float sum = 0.0F;
+      for (unsigned int k = 0; k < K; ++k) {
+        const float a =
+          TransA ? read_f32(A + static_cast<std::size_t>(k) * a_stride + m)
+                 : read_f32(A + static_cast<std::size_t>(m) * a_stride + k);
+        const float b =
+          TransB ? read_f32(B + static_cast<std::size_t>(n) * b_stride + k)
+                 : read_f32(B + static_cast<std::size_t>(k) * b_stride + n);
+        sum += a * b;
+      }
+
+      const std::size_t c_idx = static_cast<std::size_t>(m) * c_stride + n;
+      float out = alpha * sum;
+      if (std::fpclassify(beta) != FP_ZERO) {
+        out += beta * static_cast<float>(C[c_idx]);
+      }
+      C[c_idx] = static_cast<CType>(out);
+    }
+  }
+}
+
+template <typename AType, typename BType, typename CType>
+void small_k_notrans_fast_path(bool TransA, unsigned int M, unsigned int N,
+                               unsigned int K, float alpha, const AType *A,
+                               unsigned int a_stride, const BType *B,
+                               unsigned int b_stride, float beta, CType *C,
+                               unsigned int c_stride) {
+  const bool beta_zero = std::fpclassify(beta) == FP_ZERO;
+  const __m256 vbeta = _mm256_set1_ps(beta);
+
+  auto compute_row = [&](unsigned int m) {
+    CType *c_row = C + static_cast<std::size_t>(m) * c_stride;
+    unsigned int n = 0;
+    for (; n + 8 <= N; n += 8) {
+      __m256 acc = beta_zero
+                     ? _mm256_setzero_ps()
+                     : _mm256_mul_ps(load8_to_f32<CType>(c_row + n), vbeta);
+      for (unsigned int k = 0; k < K; ++k) {
+        const AType *a_ptr = TransA
+                               ? A + static_cast<std::size_t>(k) * a_stride + m
+                               : A + static_cast<std::size_t>(m) * a_stride + k;
+        const float scale = alpha * static_cast<float>(*a_ptr);
+        if (std::fpclassify(scale) == FP_ZERO) {
+          continue;
+        }
+        const __m256 vscale = _mm256_set1_ps(scale);
+        const BType *b_row = B + static_cast<std::size_t>(k) * b_stride;
+        acc = _mm256_fmadd_ps(vscale, load8_to_f32<BType>(b_row + n), acc);
+      }
+      store8_from_f32<CType>(c_row + n, acc);
+    }
+
+    for (; n < N; ++n) {
+      float out = beta_zero ? 0.0F : beta * static_cast<float>(c_row[n]);
+      for (unsigned int k = 0; k < K; ++k) {
+        const AType *a_ptr = TransA
+                               ? A + static_cast<std::size_t>(k) * a_stride + m
+                               : A + static_cast<std::size_t>(m) * a_stride + k;
+        out +=
+          alpha * static_cast<float>(*a_ptr) *
+          static_cast<float>(B[static_cast<std::size_t>(k) * b_stride + n]);
+      }
+      c_row[n] = static_cast<CType>(out);
+    }
+  };
+
+  if (should_parallelize_fast_path(M, N, K)) {
+    auto &tm = ThreadManager::Global();
+    tm.parallel_for(0, static_cast<std::size_t>(M), [&](std::size_t m) {
+      compute_row(static_cast<unsigned int>(m));
+    });
+    return;
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    compute_row(m);
+  }
+}
+
+template <typename AType, typename BType, typename CType>
+void skinny_n_fast_path(bool TransA, bool TransB, unsigned int M,
+                        unsigned int N, unsigned int K, float alpha,
+                        const AType *A, unsigned int a_stride, const BType *B,
+                        unsigned int b_stride, float beta, CType *C,
+                        unsigned int c_stride) {
+  const bool beta_zero = std::fpclassify(beta) == FP_ZERO;
+
+  auto compute_row = [&](unsigned int m) {
+    float acc0 = 0.0F;
+    float acc1 = 0.0F;
+    for (unsigned int k = 0; k < K; ++k) {
+      const float a =
+        TransA ? read_f32(A + static_cast<std::size_t>(k) * a_stride + m)
+               : read_f32(A + static_cast<std::size_t>(m) * a_stride + k);
+      if (TransB) {
+        acc0 += a * read_f32(B + k);
+        if (N == 2) {
+          acc1 += a * read_f32(B + b_stride + k);
+        }
+      } else {
+        const BType *b_row = B + static_cast<std::size_t>(k) * b_stride;
+        acc0 += a * read_f32(b_row);
+        if (N == 2) {
+          acc1 += a * read_f32(b_row + 1);
+        }
+      }
+    }
+
+    CType *c_row = C + static_cast<std::size_t>(m) * c_stride;
+    float out0 = alpha * acc0;
+    if (!beta_zero) {
+      out0 += beta * static_cast<float>(c_row[0]);
+    }
+    c_row[0] = static_cast<CType>(out0);
+
+    if (N == 2) {
+      float out1 = alpha * acc1;
+      if (!beta_zero) {
+        out1 += beta * static_cast<float>(c_row[1]);
+      }
+      c_row[1] = static_cast<CType>(out1);
+    }
+  };
+
+  if (should_parallelize_fast_path(M, N, K)) {
+    auto &tm = ThreadManager::Global();
+    tm.parallel_for(0, static_cast<std::size_t>(M), [&](std::size_t m) {
+      compute_row(static_cast<unsigned int>(m));
+    });
+    return;
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    compute_row(m);
+  }
+}
+
+template <typename AType, typename BType, typename CType>
+void row_gemm_fast_path(bool TransA, unsigned int N, unsigned int K,
+                        float alpha, const AType *A, unsigned int a_stride,
+                        const BType *B, unsigned int b_stride, float beta,
+                        CType *C, float *scratch) {
+  const bool beta_zero = std::fpclassify(beta) == FP_ZERO;
+
+  auto compute_columns = [&](unsigned int n_begin, unsigned int n_end) {
+    if (beta_zero) {
+      std::memset(scratch + n_begin, 0,
+                  static_cast<std::size_t>(n_end - n_begin) * sizeof(float));
+    } else {
+      const __m256 vbeta = _mm256_set1_ps(beta);
+      unsigned int n = n_begin;
+      for (; n + 8 <= n_end; n += 8) {
+        __m256 c32 = load8_to_f32<CType>(C + n);
+        _mm256_storeu_ps(scratch + n, _mm256_mul_ps(c32, vbeta));
+      }
+      for (; n < n_end; ++n) {
+        scratch[n] = beta * static_cast<float>(C[n]);
+      }
+    }
+
+    for (unsigned int k = 0; k < K; ++k) {
+      const AType *a_ptr =
+        TransA ? A + static_cast<std::size_t>(k) * a_stride : A + k;
+      const float scale = alpha * static_cast<float>(*a_ptr);
+      if (std::fpclassify(scale) == FP_ZERO) {
+        continue;
+      }
+
+      const __m256 vscale = _mm256_set1_ps(scale);
+      const BType *b_row = B + static_cast<std::size_t>(k) * b_stride;
+      unsigned int n = n_begin;
+      for (; n + 8 <= n_end; n += 8) {
+        __m256 b32 = load8_to_f32<BType>(b_row + n);
+        __m256 acc = _mm256_loadu_ps(scratch + n);
+        acc = _mm256_fmadd_ps(vscale, b32, acc);
+        _mm256_storeu_ps(scratch + n, acc);
+      }
+      for (; n < n_end; ++n) {
+        scratch[n] += scale * static_cast<float>(b_row[n]);
+      }
+    }
+
+    unsigned int n = n_begin;
+    for (; n + 8 <= n_end; n += 8) {
+      store8_from_f32<CType>(C + n, _mm256_loadu_ps(scratch + n));
+    }
+    for (; n < n_end; ++n) {
+      C[n] = static_cast<CType>(scratch[n]);
+    }
+  };
+
+  if (should_parallelize_fast_path(1, N, K)) {
+    constexpr unsigned int chunk_size = 256;
+    const unsigned int chunks = (N + chunk_size - 1) / chunk_size;
+    auto &tm = ThreadManager::Global();
+    tm.parallel_for(0, static_cast<std::size_t>(chunks),
+                    [&](std::size_t chunk_idx) {
+                      const unsigned int n_begin =
+                        static_cast<unsigned int>(chunk_idx) * chunk_size;
+                      const unsigned int n_end =
+                        std::min<unsigned int>(N, n_begin + chunk_size);
+                      compute_columns(n_begin, n_end);
+                    });
+    return;
+  }
+
+  compute_columns(0, N);
+}
+
+template <typename AType, typename BType, typename CType>
+void row_gemm_transB_fast_path(bool TransA, unsigned int N, unsigned int K,
+                               float alpha, const AType *A,
+                               unsigned int a_stride, const BType *B,
+                               unsigned int b_stride, float beta, CType *C,
+                               float *scratch) {
+  for (unsigned int k = 0; k < K; ++k) {
+    const AType *a_ptr =
+      TransA ? A + static_cast<std::size_t>(k) * a_stride : A + k;
+    scratch[k] = alpha * static_cast<float>(*a_ptr);
+  }
+
+  const bool beta_zero = std::fpclassify(beta) == FP_ZERO;
+
+  auto compute_columns = [&](unsigned int n_begin, unsigned int n_end) {
+    for (unsigned int n = n_begin; n < n_end; ++n) {
+      const BType *b_row = B + static_cast<std::size_t>(n) * b_stride;
+      __m256 vacc = _mm256_setzero_ps();
+      unsigned int k = 0;
+      for (; k + 8 <= K; k += 8) {
+        vacc = _mm256_fmadd_ps(_mm256_loadu_ps(scratch + k),
+                               load8_to_f32<BType>(b_row + k), vacc);
+      }
+
+      float out = hsum8_f32(vacc);
+      for (; k < K; ++k) {
+        out += scratch[k] * static_cast<float>(b_row[k]);
+      }
+      if (!beta_zero) {
+        out += beta * static_cast<float>(C[n]);
+      }
+      C[n] = static_cast<CType>(out);
+    }
+  };
+
+  if (should_parallelize_fast_path(1, N, K)) {
+    constexpr unsigned int chunk_size = 32;
+    const unsigned int chunks = (N + chunk_size - 1) / chunk_size;
+    auto &tm = ThreadManager::Global();
+    tm.parallel_for(0, static_cast<std::size_t>(chunks),
+                    [&](std::size_t chunk_idx) {
+                      const unsigned int n_begin =
+                        static_cast<unsigned int>(chunk_idx) * chunk_size;
+                      const unsigned int n_end =
+                        std::min<unsigned int>(N, n_begin + chunk_size);
+                      compute_columns(n_begin, n_end);
+                    });
+    return;
+  }
+
+  compute_columns(0, N);
+}
+
+bool should_use_direct_small_path(bool TransB, unsigned int M, unsigned int N,
+                                  unsigned int K) {
+  const std::size_t mn = static_cast<std::size_t>(M) * N;
+  const bool small_k_without_fast_path = K <= 4 && (TransB || N < 8);
+  return small_k_without_fast_path || mn <= 512 || (M <= 2 && N <= 512);
+}
+
+} // namespace
+
+template <typename AType, typename BType, typename CType>
+bool try_hgemm_fast_path(bool TransA, bool TransB, unsigned int M,
+                         unsigned int N, unsigned int K, float alpha,
+                         const AType *A, unsigned int a_stride, const BType *B,
+                         unsigned int b_stride, float beta, CType *C,
+                         unsigned int c_stride, HgemmWorkspace &workspace) {
+  if (K <= 4 && !TransB && N >= 8) {
+    small_k_notrans_fast_path<AType, BType, CType>(
+      TransA, M, N, K, alpha, A, a_stride, B, b_stride, beta, C, c_stride);
+    return true;
+  }
+
+  if (M == 1 && TransB) {
+    float *scratch = workspace.ensure_scratch(K);
+    row_gemm_transB_fast_path<AType, BType, CType>(
+      TransA, N, K, alpha, A, a_stride, B, b_stride, beta, C, scratch);
+    return true;
+  }
+
+  if (N <= 2) {
+    skinny_n_fast_path<AType, BType, CType>(TransA, TransB, M, N, K, alpha, A,
+                                            a_stride, B, b_stride, beta, C,
+                                            c_stride);
+    return true;
+  }
+
+  if (M == 1 && !TransB) {
+    float *scratch = workspace.ensure_scratch(N);
+    row_gemm_fast_path<AType, BType, CType>(TransA, N, K, alpha, A, a_stride, B,
+                                            b_stride, beta, C, scratch);
+    return true;
+  }
+
+  if (should_use_direct_small_path(TransB, M, N, K)) {
+    direct_small_gemm<AType, BType, CType>(TransA, TransB, M, N, K, alpha, A,
+                                           a_stride, B, b_stride, beta, C,
+                                           c_stride);
+    return true;
+  }
+
+  return false;
+}
+
+template bool try_hgemm_fast_path<_FP16, _FP16, _FP16>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const _FP16 *,
+  unsigned int, const _FP16 *, unsigned int, float, _FP16 *, unsigned int,
+  HgemmWorkspace &);
+template bool try_hgemm_fast_path<float, _FP16, float>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const float *,
+  unsigned int, const _FP16 *, unsigned int, float, float *, unsigned int,
+  HgemmWorkspace &);
+template bool try_hgemm_fast_path<_FP16, float, float>(
+  bool, bool, unsigned int, unsigned int, unsigned int, float, const _FP16 *,
+  unsigned int, const float *, unsigned int, float, float *, unsigned int,
+  HgemmWorkspace &);
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_fast_path.h
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Small/skinny x86 FP16 GEMM fast-path dispatcher
+ */
+
+#ifndef __X86_HGEMM_FAST_PATH_H_
+#define __X86_HGEMM_FAST_PATH_H_
+
+#include "hgemm_workspace.h"
+
+#include <tensor_dim.h>
+
+namespace nntrainer::avx2::internal {
+
+template <typename AType, typename BType, typename CType>
+bool try_hgemm_fast_path(bool TransA, bool TransB, unsigned int M,
+                         unsigned int N, unsigned int K, float alpha,
+                         const AType *A, unsigned int a_stride, const BType *B,
+                         unsigned int b_stride, float beta, CType *C,
+                         unsigned int c_stride, HgemmWorkspace &workspace);
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_FAST_PATH_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_fast_path.h
@@ -17,7 +17,7 @@
 
 #include <tensor_dim.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 template <typename AType, typename BType, typename CType>
 bool try_hgemm_fast_path(bool TransA, bool TransB, unsigned int M,
@@ -26,6 +26,6 @@ bool try_hgemm_fast_path(bool TransA, bool TransB, unsigned int M,
                          unsigned int b_stride, float beta, CType *C,
                          unsigned int c_stride, HgemmWorkspace &workspace);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_FAST_PATH_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel.h
@@ -13,7 +13,7 @@
 #ifndef __X86_HGEMM_KERNEL_H_
 #define __X86_HGEMM_KERNEL_H_
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 /**
  * @brief Primary 6x16 micro-kernel.
@@ -64,6 +64,6 @@ void hgemm_kernel_mxn(unsigned int M, unsigned int N, unsigned int K,
                       const float *packed_A, const float *packed_B, float *C,
                       unsigned int c_stride);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_KERNEL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel.h
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Micro-kernel declarations for x86 FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_KERNEL_H_
+#define __X86_HGEMM_KERNEL_H_
+
+namespace nntrainer::avx2::internal {
+
+/**
+ * @brief Primary 6x16 micro-kernel.
+ *
+ * Computes C[0..5][0..15] += packed_A * packed_B over @p K iterations.
+ * packed_A layout: dst[k * 6 + m].
+ * packed_B layout: dst[k * 16 + n].
+ *
+ * @param K          inner-dimension count
+ * @param packed_A   FP32 packed A stripe (size K * 6)
+ * @param packed_B   FP32 packed B stripe (size K * 16)
+ * @param C          FP32 accumulator origin (M_tile = 6 rows, N_tile = 16 cols)
+ * @param c_stride   row stride of C (in elements)
+ */
+void hgemm_kernel_6x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_6x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_4x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_4x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_2x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_2x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_1x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride);
+
+void hgemm_kernel_1x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride);
+
+/**
+ * @brief Dispatch to a row/column-tail-aware AVX2 micro-kernel.
+ *
+ * @p M and @p N are the logical tile sizes at the edge of a 6x16 tile. The
+ * dispatcher chooses 1/2/4/6 rows and 8/16 columns. The selected kernel may
+ * write padded rows or columns inside the already padded C32 buffer, but avoids
+ * unnecessary padded traffic for common 1/2/4-row and <=8-column skinny tiles.
+ */
+void hgemm_kernel_mxn(unsigned int M, unsigned int N, unsigned int K,
+                      const float *packed_A, const float *packed_B, float *C,
+                      unsigned int c_stride);
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_KERNEL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x16.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_1x16.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  1x16 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_1x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride) {
+  (void)c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(C + 0);
+  __m256 c01 = _mm256_loadu_ps(C + 8);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb + 0);
+    const __m256 b1 = _mm256_loadu_ps(pb + 8);
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+    c01 = _mm256_fmadd_ps(a0, b1, c01);
+  }
+
+  _mm256_storeu_ps(C + 0, c00);
+  _mm256_storeu_ps(C + 8, c01);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x16.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_1x16(unsigned int K, const float *packed_A,
                        const float *packed_B, float *C, unsigned int c_stride) {
@@ -38,4 +38,4 @@ void hgemm_kernel_1x16(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(C + 8, c01);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_1x8(unsigned int K, const float *packed_A,
                       const float *packed_B, float *C, unsigned int c_stride) {
@@ -34,4 +34,4 @@ void hgemm_kernel_1x8(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(C, c00);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_1x8.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  1x8 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_1x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride) {
+  (void)c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(C);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb);
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+  }
+
+  _mm256_storeu_ps(C, c00);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x16.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_2x16(unsigned int K, const float *packed_A,
                        const float *packed_B, float *C, unsigned int c_stride) {
@@ -48,4 +48,4 @@ void hgemm_kernel_2x16(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c1 + 8, c11);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x16.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_2x16.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  2x16 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_2x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0 + 0);
+  __m256 c01 = _mm256_loadu_ps(c0 + 8);
+  __m256 c10 = _mm256_loadu_ps(c1 + 0);
+  __m256 c11 = _mm256_loadu_ps(c1 + 8);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb + 0);
+    const __m256 b1 = _mm256_loadu_ps(pb + 8);
+
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+    c01 = _mm256_fmadd_ps(a0, b1, c01);
+
+    const __m256 a1 = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a1, b0, c10);
+    c11 = _mm256_fmadd_ps(a1, b1, c11);
+  }
+
+  _mm256_storeu_ps(c0 + 0, c00);
+  _mm256_storeu_ps(c0 + 8, c01);
+  _mm256_storeu_ps(c1 + 0, c10);
+  _mm256_storeu_ps(c1 + 8, c11);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x8.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_2x8(unsigned int K, const float *packed_A,
                       const float *packed_B, float *C, unsigned int c_stride) {
@@ -41,4 +41,4 @@ void hgemm_kernel_2x8(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c1, c10);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_2x8.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_2x8.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  2x8 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_2x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0);
+  __m256 c10 = _mm256_loadu_ps(c1);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb);
+
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+
+    const __m256 a1 = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a1, b0, c10);
+  }
+
+  _mm256_storeu_ps(c0, c00);
+  _mm256_storeu_ps(c1, c10);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x16.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_4x16.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  4x16 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_4x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+  float *c2 = C + 2 * c_stride;
+  float *c3 = C + 3 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0 + 0);
+  __m256 c01 = _mm256_loadu_ps(c0 + 8);
+  __m256 c10 = _mm256_loadu_ps(c1 + 0);
+  __m256 c11 = _mm256_loadu_ps(c1 + 8);
+  __m256 c20 = _mm256_loadu_ps(c2 + 0);
+  __m256 c21 = _mm256_loadu_ps(c2 + 8);
+  __m256 c30 = _mm256_loadu_ps(c3 + 0);
+  __m256 c31 = _mm256_loadu_ps(c3 + 8);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb + 0);
+    const __m256 b1 = _mm256_loadu_ps(pb + 8);
+
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+    c01 = _mm256_fmadd_ps(a0, b1, c01);
+
+    const __m256 a1 = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a1, b0, c10);
+    c11 = _mm256_fmadd_ps(a1, b1, c11);
+
+    const __m256 a2 = _mm256_broadcast_ss(pa + 2);
+    c20 = _mm256_fmadd_ps(a2, b0, c20);
+    c21 = _mm256_fmadd_ps(a2, b1, c21);
+
+    const __m256 a3 = _mm256_broadcast_ss(pa + 3);
+    c30 = _mm256_fmadd_ps(a3, b0, c30);
+    c31 = _mm256_fmadd_ps(a3, b1, c31);
+  }
+
+  _mm256_storeu_ps(c0 + 0, c00);
+  _mm256_storeu_ps(c0 + 8, c01);
+  _mm256_storeu_ps(c1 + 0, c10);
+  _mm256_storeu_ps(c1 + 8, c11);
+  _mm256_storeu_ps(c2 + 0, c20);
+  _mm256_storeu_ps(c2 + 8, c21);
+  _mm256_storeu_ps(c3 + 0, c30);
+  _mm256_storeu_ps(c3 + 8, c31);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x16.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_4x16(unsigned int K, const float *packed_A,
                        const float *packed_B, float *C, unsigned int c_stride) {
@@ -66,4 +66,4 @@ void hgemm_kernel_4x16(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c3 + 8, c31);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_4x8(unsigned int K, const float *packed_A,
                       const float *packed_B, float *C, unsigned int c_stride) {
@@ -53,4 +53,4 @@ void hgemm_kernel_4x8(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c3, c30);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_4x8.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  4x8 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_4x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+  float *c2 = C + 2 * c_stride;
+  float *c3 = C + 3 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0);
+  __m256 c10 = _mm256_loadu_ps(c1);
+  __m256 c20 = _mm256_loadu_ps(c2);
+  __m256 c30 = _mm256_loadu_ps(c3);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb);
+
+    const __m256 a0 = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a0, b0, c00);
+
+    const __m256 a1 = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a1, b0, c10);
+
+    const __m256 a2 = _mm256_broadcast_ss(pa + 2);
+    c20 = _mm256_fmadd_ps(a2, b0, c20);
+
+    const __m256 a3 = _mm256_broadcast_ss(pa + 3);
+    c30 = _mm256_fmadd_ps(a3, b0, c30);
+  }
+
+  _mm256_storeu_ps(c0, c00);
+  _mm256_storeu_ps(c1, c10);
+  _mm256_storeu_ps(c2, c20);
+  _mm256_storeu_ps(c3, c30);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x16.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_6x16.cpp
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Primary 6x16 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_6x16(unsigned int K, const float *packed_A,
+                       const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+  float *c2 = C + 2 * c_stride;
+  float *c3 = C + 3 * c_stride;
+  float *c4 = C + 4 * c_stride;
+  float *c5 = C + 5 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0 + 0);
+  __m256 c01 = _mm256_loadu_ps(c0 + 8);
+  __m256 c10 = _mm256_loadu_ps(c1 + 0);
+  __m256 c11 = _mm256_loadu_ps(c1 + 8);
+  __m256 c20 = _mm256_loadu_ps(c2 + 0);
+  __m256 c21 = _mm256_loadu_ps(c2 + 8);
+  __m256 c30 = _mm256_loadu_ps(c3 + 0);
+  __m256 c31 = _mm256_loadu_ps(c3 + 8);
+  __m256 c40 = _mm256_loadu_ps(c4 + 0);
+  __m256 c41 = _mm256_loadu_ps(c4 + 8);
+  __m256 c50 = _mm256_loadu_ps(c5 + 0);
+  __m256 c51 = _mm256_loadu_ps(c5 + 8);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    __m256 b0 = _mm256_loadu_ps(pb + 0);
+    __m256 b1 = _mm256_loadu_ps(pb + 8);
+
+    __m256 a = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a, b0, c00);
+    c01 = _mm256_fmadd_ps(a, b1, c01);
+
+    a = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a, b0, c10);
+    c11 = _mm256_fmadd_ps(a, b1, c11);
+
+    a = _mm256_broadcast_ss(pa + 2);
+    c20 = _mm256_fmadd_ps(a, b0, c20);
+    c21 = _mm256_fmadd_ps(a, b1, c21);
+
+    a = _mm256_broadcast_ss(pa + 3);
+    c30 = _mm256_fmadd_ps(a, b0, c30);
+    c31 = _mm256_fmadd_ps(a, b1, c31);
+
+    a = _mm256_broadcast_ss(pa + 4);
+    c40 = _mm256_fmadd_ps(a, b0, c40);
+    c41 = _mm256_fmadd_ps(a, b1, c41);
+
+    a = _mm256_broadcast_ss(pa + 5);
+    c50 = _mm256_fmadd_ps(a, b0, c50);
+    c51 = _mm256_fmadd_ps(a, b1, c51);
+  }
+
+  _mm256_storeu_ps(c0 + 0, c00);
+  _mm256_storeu_ps(c0 + 8, c01);
+  _mm256_storeu_ps(c1 + 0, c10);
+  _mm256_storeu_ps(c1 + 8, c11);
+  _mm256_storeu_ps(c2 + 0, c20);
+  _mm256_storeu_ps(c2 + 8, c21);
+  _mm256_storeu_ps(c3 + 0, c30);
+  _mm256_storeu_ps(c3 + 8, c31);
+  _mm256_storeu_ps(c4 + 0, c40);
+  _mm256_storeu_ps(c4 + 8, c41);
+  _mm256_storeu_ps(c5 + 0, c50);
+  _mm256_storeu_ps(c5 + 8, c51);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x16.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_6x16(unsigned int K, const float *packed_A,
                        const float *packed_B, float *C, unsigned int c_stride) {
@@ -84,4 +84,4 @@ void hgemm_kernel_6x16(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c5 + 8, c51);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x8.cpp
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_6x8(unsigned int K, const float *packed_A,
                       const float *packed_B, float *C, unsigned int c_stride) {
@@ -65,4 +65,4 @@ void hgemm_kernel_6x8(unsigned int K, const float *packed_A,
   _mm256_storeu_ps(c5, c50);
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x8.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_6x8.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_6x8.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  6x8 AVX2+FMA micro-kernel for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+#include <immintrin.h>
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_6x8(unsigned int K, const float *packed_A,
+                      const float *packed_B, float *C, unsigned int c_stride) {
+  float *c0 = C + 0 * c_stride;
+  float *c1 = C + 1 * c_stride;
+  float *c2 = C + 2 * c_stride;
+  float *c3 = C + 3 * c_stride;
+  float *c4 = C + 4 * c_stride;
+  float *c5 = C + 5 * c_stride;
+
+  __m256 c00 = _mm256_loadu_ps(c0);
+  __m256 c10 = _mm256_loadu_ps(c1);
+  __m256 c20 = _mm256_loadu_ps(c2);
+  __m256 c30 = _mm256_loadu_ps(c3);
+  __m256 c40 = _mm256_loadu_ps(c4);
+  __m256 c50 = _mm256_loadu_ps(c5);
+
+  for (unsigned int k = 0; k < K; ++k) {
+    const float *pa = packed_A + k * 6;
+    const float *pb = packed_B + k * 16;
+
+    const __m256 b0 = _mm256_loadu_ps(pb);
+
+    __m256 a = _mm256_broadcast_ss(pa + 0);
+    c00 = _mm256_fmadd_ps(a, b0, c00);
+
+    a = _mm256_broadcast_ss(pa + 1);
+    c10 = _mm256_fmadd_ps(a, b0, c10);
+
+    a = _mm256_broadcast_ss(pa + 2);
+    c20 = _mm256_fmadd_ps(a, b0, c20);
+
+    a = _mm256_broadcast_ss(pa + 3);
+    c30 = _mm256_fmadd_ps(a, b0, c30);
+
+    a = _mm256_broadcast_ss(pa + 4);
+    c40 = _mm256_fmadd_ps(a, b0, c40);
+
+    a = _mm256_broadcast_ss(pa + 5);
+    c50 = _mm256_fmadd_ps(a, b0, c50);
+  }
+
+  _mm256_storeu_ps(c0, c00);
+  _mm256_storeu_ps(c1, c10);
+  _mm256_storeu_ps(c2, c20);
+  _mm256_storeu_ps(c3, c30);
+  _mm256_storeu_ps(c4, c40);
+  _mm256_storeu_ps(c5, c50);
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_mxn.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_mxn.cpp
@@ -12,7 +12,7 @@
 
 #include "hgemm_kernel.h"
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 void hgemm_kernel_mxn(unsigned int M, unsigned int N, unsigned int K,
                       const float *packed_A, const float *packed_B, float *C,
@@ -42,4 +42,4 @@ void hgemm_kernel_mxn(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_mxn.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/hgemm_kernel_mxn.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_kernel_mxn.cpp
+ * @date   30 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Micro-kernel shape dispatcher for x86 FP16 GEMM
+ */
+
+#include "hgemm_kernel.h"
+
+namespace nntrainer::avx2::internal {
+
+void hgemm_kernel_mxn(unsigned int M, unsigned int N, unsigned int K,
+                      const float *packed_A, const float *packed_B, float *C,
+                      unsigned int c_stride) {
+  if (M <= 1) {
+    if (N <= 8) {
+      hgemm_kernel_1x8(K, packed_A, packed_B, C, c_stride);
+    } else {
+      hgemm_kernel_1x16(K, packed_A, packed_B, C, c_stride);
+    }
+  } else if (M <= 2) {
+    if (N <= 8) {
+      hgemm_kernel_2x8(K, packed_A, packed_B, C, c_stride);
+    } else {
+      hgemm_kernel_2x16(K, packed_A, packed_B, C, c_stride);
+    }
+  } else if (M <= 4) {
+    if (N <= 8) {
+      hgemm_kernel_4x8(K, packed_A, packed_B, C, c_stride);
+    } else {
+      hgemm_kernel_4x16(K, packed_A, packed_B, C, c_stride);
+    }
+  } else if (N <= 8) {
+    hgemm_kernel_6x8(K, packed_A, packed_B, C, c_stride);
+  } else {
+    hgemm_kernel_6x16(K, packed_A, packed_B, C, c_stride);
+  }
+}
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/meson.build
@@ -1,7 +1,3 @@
-x86_hgemm_kernel_headers = [
-  'hgemm_kernel.h',
-]
-
 x86_hgemm_kernel_sources = [
   'hgemm_kernel_1x8.cpp',
   'hgemm_kernel_1x16.cpp',
@@ -16,8 +12,4 @@ x86_hgemm_kernel_sources = [
 
 foreach s : x86_hgemm_kernel_sources
   nntrainer_sources += meson.current_source_dir() / s
-endforeach
-
-foreach h : x86_hgemm_kernel_headers
-  nntrainer_headers += meson.current_source_dir() / h
 endforeach

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_kernel/meson.build
@@ -1,0 +1,23 @@
+x86_hgemm_kernel_headers = [
+  'hgemm_kernel.h',
+]
+
+x86_hgemm_kernel_sources = [
+  'hgemm_kernel_1x8.cpp',
+  'hgemm_kernel_1x16.cpp',
+  'hgemm_kernel_2x8.cpp',
+  'hgemm_kernel_2x16.cpp',
+  'hgemm_kernel_4x8.cpp',
+  'hgemm_kernel_4x16.cpp',
+  'hgemm_kernel_6x8.cpp',
+  'hgemm_kernel_6x16.cpp',
+  'hgemm_kernel_mxn.cpp',
+]
+
+foreach s : x86_hgemm_kernel_sources
+  nntrainer_sources += meson.current_source_dir() / s
+endforeach
+
+foreach h : x86_hgemm_kernel_headers
+  nntrainer_headers += meson.current_source_dir() / h
+endforeach

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.cpp
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_pack.cpp
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Packing routines for x86 FP16 GEMM (source->FP32 during pack)
+ */
+
+#include "hgemm_pack.h"
+#include "hgemm_common.h"
+
+#include <immintrin.h>
+#include <type_traits>
+
+namespace nntrainer::avx2::internal {
+
+namespace {
+
+/**
+ * @brief Load 8 contiguous source elements and widen to FP32.
+ *
+ * For @c _FP16 sources this is an F16C convert; for @c float it is a plain
+ * 256-bit load. Reads 8 elements starting at @p p.
+ */
+template <typename SrcT> inline __m256 load8_to_f32(const SrcT *p) {
+  if constexpr (std::is_same_v<SrcT, float>) {
+    return _mm256_loadu_ps(p);
+  } else {
+    return _mm256_cvtph_ps(
+      _mm_loadu_si128(reinterpret_cast<const __m128i *>(p)));
+  }
+}
+
+/**
+ * @brief Load 4 contiguous source elements and widen to FP32.
+ *
+ * Used by the transposed-A fast path, which must not over-read past the MR=6
+ * contiguous lanes at the final k. For @c _FP16 the 8-byte @c _mm_loadl_epi64
+ * never reads past lane 3; for @c float a 16-byte load covers lanes 0..3.
+ */
+template <typename SrcT> inline __m128 load4_to_f32(const SrcT *p) {
+  if constexpr (std::is_same_v<SrcT, float>) {
+    return _mm_loadu_ps(p);
+  } else {
+    return _mm_cvtph_ps(_mm_loadl_epi64(reinterpret_cast<const __m128i *>(p)));
+  }
+}
+
+inline void transpose_store_8x8(__m256 r0, __m256 r1, __m256 r2, __m256 r3,
+                                __m256 r4, __m256 r5, __m256 r6, __m256 r7,
+                                float *dst, unsigned int col_offset) {
+  const __m256 t0 = _mm256_unpacklo_ps(r0, r1);
+  const __m256 t1 = _mm256_unpackhi_ps(r0, r1);
+  const __m256 t2 = _mm256_unpacklo_ps(r2, r3);
+  const __m256 t3 = _mm256_unpackhi_ps(r2, r3);
+  const __m256 t4 = _mm256_unpacklo_ps(r4, r5);
+  const __m256 t5 = _mm256_unpackhi_ps(r4, r5);
+  const __m256 t6 = _mm256_unpacklo_ps(r6, r7);
+  const __m256 t7 = _mm256_unpackhi_ps(r6, r7);
+
+  const __m256 s0 = _mm256_shuffle_ps(t0, t2, 0x44);
+  const __m256 s1 = _mm256_shuffle_ps(t0, t2, 0xee);
+  const __m256 s2 = _mm256_shuffle_ps(t1, t3, 0x44);
+  const __m256 s3 = _mm256_shuffle_ps(t1, t3, 0xee);
+  const __m256 s4 = _mm256_shuffle_ps(t4, t6, 0x44);
+  const __m256 s5 = _mm256_shuffle_ps(t4, t6, 0xee);
+  const __m256 s6 = _mm256_shuffle_ps(t5, t7, 0x44);
+  const __m256 s7 = _mm256_shuffle_ps(t5, t7, 0xee);
+
+  _mm256_storeu_ps(dst + 0 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s0, s4, 0x20));
+  _mm256_storeu_ps(dst + 1 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s1, s5, 0x20));
+  _mm256_storeu_ps(dst + 2 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s2, s6, 0x20));
+  _mm256_storeu_ps(dst + 3 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s3, s7, 0x20));
+  _mm256_storeu_ps(dst + 4 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s0, s4, 0x31));
+  _mm256_storeu_ps(dst + 5 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s1, s5, 0x31));
+  _mm256_storeu_ps(dst + 6 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s2, s6, 0x31));
+  _mm256_storeu_ps(dst + 7 * X86_HGEMM_NR + col_offset,
+                   _mm256_permute2f128_ps(s3, s7, 0x31));
+}
+
+} // namespace
+
+template <typename SrcT>
+void packing_A_M6(unsigned int m_actual, unsigned int k_min, const SrcT *src,
+                  unsigned int src_stride, float alpha, float *dst) {
+  const bool alpha_one = (alpha == 1.0F);
+  const __m256 valpha = _mm256_set1_ps(alpha);
+
+  if (m_actual == X86_HGEMM_MR) {
+    // Fast path: 6 rows, SIMD convert 8 k-elements per row, then transpose
+    // into k-major MR-tile layout via scalar scatter store.
+    unsigned int k = 0;
+    alignas(32) float tmp[X86_HGEMM_MR][8];
+    for (; k + 8 <= k_min; k += 8) {
+      for (unsigned int mr = 0; mr < X86_HGEMM_MR; ++mr) {
+        __m256 a32 = load8_to_f32<SrcT>(src + mr * src_stride + k);
+        if (!alpha_one) {
+          a32 = _mm256_mul_ps(a32, valpha);
+        }
+        _mm256_store_ps(tmp[mr], a32);
+      }
+      for (unsigned int koff = 0; koff < 8; ++koff) {
+        float *out = dst + (k + koff) * X86_HGEMM_MR;
+        out[0] = tmp[0][koff];
+        out[1] = tmp[1][koff];
+        out[2] = tmp[2][koff];
+        out[3] = tmp[3][koff];
+        out[4] = tmp[4][koff];
+        out[5] = tmp[5][koff];
+      }
+    }
+    for (; k < k_min; ++k) {
+      float *out = dst + k * X86_HGEMM_MR;
+      out[0] = alpha * static_cast<float>(src[0 * src_stride + k]);
+      out[1] = alpha * static_cast<float>(src[1 * src_stride + k]);
+      out[2] = alpha * static_cast<float>(src[2 * src_stride + k]);
+      out[3] = alpha * static_cast<float>(src[3 * src_stride + k]);
+      out[4] = alpha * static_cast<float>(src[4 * src_stride + k]);
+      out[5] = alpha * static_cast<float>(src[5 * src_stride + k]);
+    }
+    return;
+  }
+
+  // Edge path: m_actual in [1, MR). Pad missing rows with 0.
+  for (unsigned int k = 0; k < k_min; ++k) {
+    float *out = dst + k * X86_HGEMM_MR;
+    unsigned int m = 0;
+    for (; m < m_actual; ++m) {
+      out[m] = alpha * static_cast<float>(src[m * src_stride + k]);
+    }
+    for (; m < X86_HGEMM_MR; ++m) {
+      out[m] = 0.0F;
+    }
+  }
+}
+
+template <typename SrcT>
+void packing_A_M6_trans(unsigned int m_actual, unsigned int k_min,
+                        const SrcT *src, unsigned int src_stride, float alpha,
+                        float *dst) {
+  const bool alpha_one = (alpha == 1.0F);
+
+  if (m_actual == X86_HGEMM_MR) {
+    // Fast path: per k, m runs unit-stride over MR=6 contiguous elements.
+    // Load the first 4 lanes wide (never reads past row[3]) and finish the
+    // remaining 2 lanes in scalar. Avoids the OOB risk of a full 8-element
+    // load at the last k iteration.
+    const __m128 valpha = _mm_set1_ps(alpha);
+    for (unsigned int k = 0; k < k_min; ++k) {
+      const SrcT *row = src + k * src_stride;
+      float *out = dst + k * X86_HGEMM_MR;
+      __m128 a32 = load4_to_f32<SrcT>(row);
+      if (!alpha_one) {
+        a32 = _mm_mul_ps(a32, valpha);
+      }
+      _mm_storeu_ps(out, a32);
+      out[4] = alpha * static_cast<float>(row[4]);
+      out[5] = alpha * static_cast<float>(row[5]);
+    }
+    return;
+  }
+
+  // Edge path: m_actual in [1, MR). Pad missing rows with 0.
+  for (unsigned int k = 0; k < k_min; ++k) {
+    const SrcT *row = src + k * src_stride;
+    float *out = dst + k * X86_HGEMM_MR;
+    unsigned int m = 0;
+    for (; m < m_actual; ++m) {
+      out[m] = alpha * static_cast<float>(row[m]);
+    }
+    for (; m < X86_HGEMM_MR; ++m) {
+      out[m] = 0.0F;
+    }
+  }
+}
+
+template <typename SrcT>
+void packing_B_N16(unsigned int k_min, unsigned int n_actual, const SrcT *src,
+                   unsigned int src_stride, float *dst) {
+  if (n_actual == X86_HGEMM_NR) {
+    // Fast path: each k-row contributes 16 contiguous elements -> 16 FP32.
+    for (unsigned int k = 0; k < k_min; ++k) {
+      const SrcT *row = src + k * src_stride;
+      __m256 b32_lo = load8_to_f32<SrcT>(row);
+      __m256 b32_hi = load8_to_f32<SrcT>(row + 8);
+      float *out = dst + k * X86_HGEMM_NR;
+      _mm256_storeu_ps(out, b32_lo);
+      _mm256_storeu_ps(out + 8, b32_hi);
+    }
+    return;
+  }
+
+  // Edge path: n_actual in [1, NR). Pad missing cols with 0.
+  for (unsigned int k = 0; k < k_min; ++k) {
+    const SrcT *row = src + k * src_stride;
+    float *out = dst + k * X86_HGEMM_NR;
+    unsigned int n = 0;
+    for (; n < n_actual; ++n) {
+      out[n] = static_cast<float>(row[n]);
+    }
+    for (; n < X86_HGEMM_NR; ++n) {
+      out[n] = 0.0F;
+    }
+  }
+}
+
+template <typename SrcT>
+void packing_B_N16_trans(unsigned int k_min, unsigned int n_actual,
+                         const SrcT *src, unsigned int src_stride, float *dst) {
+  if (n_actual == X86_HGEMM_NR) {
+    // Fast path: per n-row, k runs unit-stride. SIMD-convert 8 contiguous
+    // k-elements per row, then transpose two 8x8 halves into k-major NR-tile
+    // layout.
+    unsigned int k = 0;
+    for (; k + 8 <= k_min; k += 8) {
+      float *out = dst + k * X86_HGEMM_NR;
+      transpose_store_8x8(load8_to_f32<SrcT>(src + 0 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 1 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 2 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 3 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 4 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 5 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 6 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 7 * src_stride + k), out, 0);
+      transpose_store_8x8(load8_to_f32<SrcT>(src + 8 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 9 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 10 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 11 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 12 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 13 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 14 * src_stride + k),
+                          load8_to_f32<SrcT>(src + 15 * src_stride + k), out,
+                          8);
+    }
+    for (; k < k_min; ++k) {
+      float *out = dst + k * X86_HGEMM_NR;
+      for (unsigned int n = 0; n < X86_HGEMM_NR; ++n) {
+        out[n] = static_cast<float>(src[n * src_stride + k]);
+      }
+    }
+    return;
+  }
+
+  // Edge path: n_actual in [1, NR). Pad missing cols with 0.
+  for (unsigned int k = 0; k < k_min; ++k) {
+    float *out = dst + k * X86_HGEMM_NR;
+    unsigned int n = 0;
+    for (; n < n_actual; ++n) {
+      out[n] = static_cast<float>(src[n * src_stride + k]);
+    }
+    for (; n < X86_HGEMM_NR; ++n) {
+      out[n] = 0.0F;
+    }
+  }
+}
+
+// Explicit instantiations: _FP16 source (pure-FP16 / hsgemm A / shgemm B) and
+// float source (mixed-precision FP32 operand).
+template void packing_A_M6<_FP16>(unsigned int, unsigned int, const _FP16 *,
+                                  unsigned int, float, float *);
+template void packing_A_M6<float>(unsigned int, unsigned int, const float *,
+                                  unsigned int, float, float *);
+template void packing_A_M6_trans<_FP16>(unsigned int, unsigned int,
+                                        const _FP16 *, unsigned int, float,
+                                        float *);
+template void packing_A_M6_trans<float>(unsigned int, unsigned int,
+                                        const float *, unsigned int, float,
+                                        float *);
+template void packing_B_N16<_FP16>(unsigned int, unsigned int, const _FP16 *,
+                                   unsigned int, float *);
+template void packing_B_N16<float>(unsigned int, unsigned int, const float *,
+                                   unsigned int, float *);
+template void packing_B_N16_trans<_FP16>(unsigned int, unsigned int,
+                                         const _FP16 *, unsigned int, float *);
+template void packing_B_N16_trans<float>(unsigned int, unsigned int,
+                                         const float *, unsigned int, float *);
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.cpp
@@ -16,7 +16,7 @@
 #include <immintrin.h>
 #include <type_traits>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 namespace {
 
@@ -286,4 +286,4 @@ template void packing_B_N16_trans<_FP16>(unsigned int, unsigned int,
 template void packing_B_N16_trans<float>(unsigned int, unsigned int,
                                          const float *, unsigned int, float *);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_pack.h
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Packing routines for x86 FP16 GEMM (source->FP32 during pack)
+ */
+
+#ifndef __X86_HGEMM_PACK_H_
+#define __X86_HGEMM_PACK_H_
+
+#include <tensor_dim.h>
+
+namespace nntrainer::avx2::internal {
+
+/**
+ * @brief Pack an MR-row stripe of A (row-major source) into FP32.
+ *
+ * @c SrcT may be @c _FP16 (converted via F16C while packing) or @c float
+ * (re-laid out without conversion), so the same blocking loop drives both the
+ * pure-FP16 and the mixed-precision GEMM paths.
+ *
+ * Source shape: m_actual rows x k_min cols at stride @p src_stride. Output is
+ * stored in k-major MR-tile layout:
+ * dst[k * MR + m] = alpha * (float) src[m * src_stride + k] for valid rows.
+ * Remaining rows (m_actual..MR) are filled with 0.
+ *
+ * @tparam SrcT source element type (_FP16 or float)
+ * @param m_actual number of valid rows (1..MR)
+ * @param k_min K dimension of the stripe
+ * @param src   source pointer
+ * @param src_stride source row stride in elements
+ * @param alpha scalar applied while packing A
+ * @param dst   FP32 packed buffer, capacity >= k_min * MR
+ */
+template <typename SrcT>
+void packing_A_M6(unsigned int m_actual, unsigned int k_min, const SrcT *src,
+                  unsigned int src_stride, float alpha, float *dst);
+
+/**
+ * @brief Pack an MR-row stripe of transposed A into FP32.
+ *
+ * Source is A in transposed storage for op(A): src[k * src_stride + m].
+ */
+template <typename SrcT>
+void packing_A_M6_trans(unsigned int m_actual, unsigned int k_min,
+                        const SrcT *src, unsigned int src_stride, float alpha,
+                        float *dst);
+
+/**
+ * @brief Pack an NR-col stripe of B (row-major source) into FP32.
+ *
+ * @c SrcT may be @c _FP16 or @c float (see packing_A_M6).
+ *
+ * Source shape: k_min rows x n_actual cols at stride @p src_stride. Output is
+ * stored in k-major NR-tile layout:
+ * dst[k * NR + n] = (float) src[k * src_stride + n] for valid cols.
+ * Remaining cols (n_actual..NR) are filled with 0.
+ *
+ * @tparam SrcT source element type (_FP16 or float)
+ * @param k_min    K dimension of the stripe
+ * @param n_actual number of valid cols (1..NR)
+ * @param src      source pointer
+ * @param src_stride source row stride in elements
+ * @param dst      FP32 packed buffer, capacity >= k_min * NR
+ */
+template <typename SrcT>
+void packing_B_N16(unsigned int k_min, unsigned int n_actual, const SrcT *src,
+                   unsigned int src_stride, float *dst);
+
+/**
+ * @brief Pack an NR-col stripe of transposed B into FP32.
+ *
+ * Source is B in transposed storage for op(B): src[n * src_stride + k].
+ */
+template <typename SrcT>
+void packing_B_N16_trans(unsigned int k_min, unsigned int n_actual,
+                         const SrcT *src, unsigned int src_stride, float *dst);
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_PACK_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_pack.h
@@ -15,7 +15,7 @@
 
 #include <tensor_dim.h>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 /**
  * @brief Pack an MR-row stripe of A (row-major source) into FP32.
@@ -81,6 +81,6 @@ template <typename SrcT>
 void packing_B_N16_trans(unsigned int k_min, unsigned int n_actual,
                          const SrcT *src, unsigned int src_stride, float *dst);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_PACK_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_test.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_test.h
@@ -17,7 +17,7 @@
 
 #include <cstddef>
 
-namespace nntrainer::avx2::internal::testing {
+namespace nntrainer::hgemm::internal::testing {
 
 /**
  * @brief Test/benchmark-only snapshot of the internal hgemm workspace.
@@ -43,7 +43,7 @@ HgemmWorkspaceStats get_hgemm_workspace_stats();
 void reset_hgemm_workspace_stats();
 void clear_hgemm_workspace();
 
-} // namespace nntrainer::avx2::internal::testing
+} // namespace nntrainer::hgemm::internal::testing
 
 #endif // ENABLE_TEST
 

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_test.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_test.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_test.h
+ * @date   18 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Test-only instrumentation for x86 FP16 hgemm
+ */
+
+#ifndef __X86_HGEMM_TEST_H_
+#define __X86_HGEMM_TEST_H_
+
+#ifdef ENABLE_TEST
+
+#include <cstddef>
+
+namespace nntrainer::avx2::internal::testing {
+
+/**
+ * @brief Test/benchmark-only snapshot of the internal hgemm workspace.
+ *
+ * This is intentionally not part of the public hgemm API. It exists only for
+ * unit tests and local benchmarks to verify workspace reuse without relying on
+ * noisy process-wide heap allocation counters.
+ */
+struct HgemmWorkspaceStats {
+  std::size_t c32_capacity = 0;
+  std::size_t pack_a_capacity = 0;
+  std::size_t pack_b_capacity = 0;
+  std::size_t scratch_capacity = 0;
+  std::size_t c32_realloc_count = 0;
+  std::size_t pack_a_realloc_count = 0;
+  std::size_t pack_b_realloc_count = 0;
+  std::size_t scratch_realloc_count = 0;
+  std::size_t total_realloc_count = 0;
+  std::size_t total_capacity_bytes = 0;
+};
+
+HgemmWorkspaceStats get_hgemm_workspace_stats();
+void reset_hgemm_workspace_stats();
+void clear_hgemm_workspace();
+
+} // namespace nntrainer::avx2::internal::testing
+
+#endif // ENABLE_TEST
+
+#endif /* __X86_HGEMM_TEST_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.cpp
@@ -29,7 +29,11 @@
 #include <cpuid.h>
 #endif
 
-namespace nntrainer::avx2::internal {
+#if defined(_WIN32)
+#include <malloc.h> // _aligned_malloc / _aligned_free
+#endif
+
+namespace nntrainer::hgemm::internal {
 
 namespace {
 
@@ -149,15 +153,27 @@ const HgemmBlockSizes &get_hgemm_block_sizes() {
 }
 
 float *aligned_alloc_f32(std::size_t n_floats) {
-  void *p = nullptr;
-  std::size_t bytes = ((n_floats * sizeof(float) + 63u) / 64u) * 64u;
-  if (posix_memalign(&p, 64, bytes) != 0) {
+  // Round up so the byte count is a multiple of the 64-byte alignment, which
+  // std::aligned_alloc requires (C11 size must be a multiple of alignment).
+  const std::size_t bytes = ((n_floats * sizeof(float) + 63u) / 64u) * 64u;
+#if defined(_WIN32)
+  void *p = _aligned_malloc(bytes, 64);
+#else
+  void *p = std::aligned_alloc(64, bytes);
+#endif
+  if (p == nullptr) {
     throw std::bad_alloc();
   }
   return static_cast<float *>(p);
 }
 
-void aligned_free(float *p) { std::free(p); }
+void aligned_free(float *p) {
+#if defined(_WIN32)
+  _aligned_free(p);
+#else
+  std::free(p);
+#endif
+}
 
 namespace {
 
@@ -261,4 +277,4 @@ template void apply_beta_to_C<_FP16>(_FP16 *, unsigned int, unsigned int,
 template void apply_beta_to_C<float>(float *, unsigned int, unsigned int,
                                      unsigned int, float);
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.cpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_util.cpp
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Utility helpers for x86 FP16 GEMM
+ */
+
+#include "hgemm_util.h"
+
+#include "hgemm_common.h"
+
+#include <avx2_impl.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <immintrin.h>
+#include <initializer_list>
+#include <new>
+#include <type_traits>
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__GNUC__) || defined(__clang__)
+#include <cpuid.h>
+#endif
+
+namespace nntrainer::avx2::internal {
+
+namespace {
+
+/** @brief Decoded x86 CPU vendor string and family/model identification */
+struct X86CpuInfo {
+  char vendor[13] = {};
+  unsigned int family = 0;
+  unsigned int model = 0;
+};
+
+bool read_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int &eax,
+                unsigned int &ebx, unsigned int &ecx, unsigned int &edx) {
+#if defined(_MSC_VER)
+  int regs[4] = {};
+  __cpuidex(regs, static_cast<int>(leaf), static_cast<int>(subleaf));
+  eax = static_cast<unsigned int>(regs[0]);
+  ebx = static_cast<unsigned int>(regs[1]);
+  ecx = static_cast<unsigned int>(regs[2]);
+  edx = static_cast<unsigned int>(regs[3]);
+  return true;
+#elif defined(__GNUC__) || defined(__clang__)
+  return __get_cpuid_count(leaf, subleaf, &eax, &ebx, &ecx, &edx) != 0;
+#else
+  (void)leaf;
+  (void)subleaf;
+  eax = ebx = ecx = edx = 0;
+  return false;
+#endif
+}
+
+X86CpuInfo detect_x86_cpu() {
+  X86CpuInfo info;
+  unsigned int eax = 0;
+  unsigned int ebx = 0;
+  unsigned int ecx = 0;
+  unsigned int edx = 0;
+
+  if (!read_cpuid(0, 0, eax, ebx, ecx, edx)) {
+    return info;
+  }
+
+  std::memcpy(info.vendor + 0, &ebx, sizeof(ebx));
+  std::memcpy(info.vendor + 4, &edx, sizeof(edx));
+  std::memcpy(info.vendor + 8, &ecx, sizeof(ecx));
+
+  if (!read_cpuid(1, 0, eax, ebx, ecx, edx)) {
+    return info;
+  }
+
+  const unsigned int base_family = (eax >> 8) & 0xf;
+  const unsigned int base_model = (eax >> 4) & 0xf;
+  const unsigned int ext_family = (eax >> 20) & 0xff;
+  const unsigned int ext_model = (eax >> 16) & 0xf;
+
+  info.family = base_family;
+  if (base_family == 0xf) {
+    info.family += ext_family;
+  }
+  info.model = base_model;
+  if (base_family == 0x6 || base_family == 0xf) {
+    info.model += ext_model << 4;
+  }
+
+  return info;
+}
+
+bool is_vendor(const X86CpuInfo &info, const char *vendor) {
+  return std::strncmp(info.vendor, vendor, 12) == 0;
+}
+
+bool is_intel_model(unsigned int model,
+                    std::initializer_list<unsigned int> ms) {
+  for (unsigned int m : ms) {
+    if (model == m) {
+      return true;
+    }
+  }
+  return false;
+}
+
+HgemmBlockSizes tune_block_sizes() {
+  const X86CpuInfo cpu = detect_x86_cpu();
+
+  if (is_vendor(cpu, "GenuineIntel") && cpu.family == 0x6) {
+    if (is_intel_model(cpu.model, {0x3c, 0x3f, 0x45, 0x46, 0x47, 0x4f, 0x56})) {
+      return {256, 384, 256, 96, 128}; // Haswell/Broadwell-era private L2.
+    }
+    if (is_intel_model(cpu.model, {0x4e, 0x5e, 0x8e, 0x9e})) {
+      return {384, 512, 256, 96, 128}; // Skylake/Kaby/Coffee client.
+    }
+    if (is_intel_model(cpu.model, {0x55, 0x6a, 0x6c, 0x8f})) {
+      return {768, 512, 256, 192, 128}; // Skylake-X/Ice Lake server.
+    }
+    if (is_intel_model(cpu.model, {0x97, 0x9a, 0xb7, 0xba, 0xbf})) {
+      return {1024, 512, 256, 192, 128}; // Alder/Raptor Lake class cores.
+    }
+  }
+
+  if (is_vendor(cpu, "AuthenticAMD")) {
+    if (cpu.family == 0x17) {
+      return {384, 384, 256, 128, 128}; // Zen/Zen+/Zen2, 512KB L2.
+    }
+    if (cpu.family == 0x19) {
+      return {512, 512, 256, 192, 128}; // Zen3/Zen4, 512KB+ L2.
+    }
+  }
+
+  return {X86_HGEMM_M_BLOCKING, X86_HGEMM_N_BLOCKING, X86_HGEMM_K_BLOCKING,
+          X86_HGEMM_C_M_BLOCKING, X86_HGEMM_C_N_BLOCKING};
+}
+
+} // namespace
+
+const HgemmBlockSizes &get_hgemm_block_sizes() {
+  static const HgemmBlockSizes sizes = tune_block_sizes();
+  return sizes;
+}
+
+float *aligned_alloc_f32(std::size_t n_floats) {
+  void *p = nullptr;
+  std::size_t bytes = ((n_floats * sizeof(float) + 63u) / 64u) * 64u;
+  if (posix_memalign(&p, 64, bytes) != 0) {
+    throw std::bad_alloc();
+  }
+  return static_cast<float *>(p);
+}
+
+void aligned_free(float *p) { std::free(p); }
+
+namespace {
+
+/// Widen one C row into the FP32 accumulator. F16C for _FP16, plain copy for
+/// float so the FP32-output GEMMs avoid a needless conversion pass.
+template <typename CType>
+inline void widen_C_row(const CType *src, float *dst, unsigned int N) {
+  if constexpr (std::is_same_v<CType, float>) {
+    std::memcpy(dst, src, static_cast<std::size_t>(N) * sizeof(float));
+  } else {
+    nntrainer::avx2::vcvt_f16_f32(N, src, dst);
+  }
+}
+
+/// Narrow one FP32 accumulator row back into C (F16C for _FP16, copy for
+/// float).
+template <typename CType>
+inline void narrow_C_row(const float *src, CType *dst, unsigned int N) {
+  if constexpr (std::is_same_v<CType, float>) {
+    std::memcpy(dst, src, static_cast<std::size_t>(N) * sizeof(float));
+  } else {
+    nntrainer::avx2::vcvt_f32_f16(N, src, dst);
+  }
+}
+
+} // namespace
+
+template <typename CType>
+void copy_C_to_C32(const CType *C, float *C32, unsigned int M, unsigned int N,
+                   unsigned int c_stride, unsigned int c32_stride, float beta) {
+  if (std::fpclassify(beta) == FP_ZERO) {
+    const std::size_t row_bytes = static_cast<std::size_t>(N) * sizeof(float);
+    for (unsigned int m = 0; m < M; ++m) {
+      std::memset(C32 + m * c32_stride, 0, row_bytes);
+    }
+    return;
+  }
+
+  const bool beta_one = (beta == 1.0F);
+  for (unsigned int m = 0; m < M; ++m) {
+    float *row = C32 + m * c32_stride;
+    widen_C_row<CType>(C + m * c_stride, row, N);
+    if (!beta_one) {
+      const __m256 vbeta = _mm256_set1_ps(beta);
+      unsigned int n = 0;
+      for (; n + 8 <= N; n += 8) {
+        __m256 v = _mm256_loadu_ps(row + n);
+        _mm256_storeu_ps(row + n, _mm256_mul_ps(vbeta, v));
+      }
+      for (; n < N; ++n) {
+        row[n] *= beta;
+      }
+    }
+  }
+}
+
+template <typename CType>
+void copy_C32_to_C(const float *C32, CType *C, unsigned int M, unsigned int N,
+                   unsigned int c32_stride, unsigned int c_stride) {
+  for (unsigned int m = 0; m < M; ++m) {
+    narrow_C_row<CType>(C32 + m * c32_stride, C + m * c_stride, N);
+  }
+}
+
+template <typename CType>
+void apply_beta_to_C(CType *C, unsigned int M, unsigned int N,
+                     unsigned int c_stride, float beta) {
+  if (std::fpclassify(beta) == FP_ZERO) {
+    for (unsigned int m = 0; m < M; ++m) {
+      for (unsigned int n = 0; n < N; ++n) {
+        C[m * c_stride + n] = static_cast<CType>(0.0F);
+      }
+    }
+    return;
+  }
+
+  if (beta == 1.0F) {
+    return;
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * c_stride + n;
+      C[idx] = static_cast<CType>(beta * static_cast<float>(C[idx]));
+    }
+  }
+}
+
+template void copy_C_to_C32<_FP16>(const _FP16 *, float *, unsigned int,
+                                   unsigned int, unsigned int, unsigned int,
+                                   float);
+template void copy_C_to_C32<float>(const float *, float *, unsigned int,
+                                   unsigned int, unsigned int, unsigned int,
+                                   float);
+template void copy_C32_to_C<_FP16>(const float *, _FP16 *, unsigned int,
+                                   unsigned int, unsigned int, unsigned int);
+template void copy_C32_to_C<float>(const float *, float *, unsigned int,
+                                   unsigned int, unsigned int, unsigned int);
+template void apply_beta_to_C<_FP16>(_FP16 *, unsigned int, unsigned int,
+                                     unsigned int, float);
+template void apply_beta_to_C<float>(float *, unsigned int, unsigned int,
+                                     unsigned int, float);
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.h
@@ -18,7 +18,7 @@
 #include <tensor_dim.h>
 #include <type_traits>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 /**
  * @brief Allocate cache-line-aligned FP32 buffer.
@@ -132,6 +132,6 @@ inline unsigned int round_up(unsigned int v, unsigned int n) {
   return ((v + n - 1) / n) * n;
 }
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_UTIL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_util.h
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_util.h
+ * @date   15 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Utility helpers for x86 FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_UTIL_H_
+#define __X86_HGEMM_UTIL_H_
+
+#include <cstddef>
+#include <immintrin.h>
+#include <tensor_dim.h>
+#include <type_traits>
+
+namespace nntrainer::avx2::internal {
+
+/**
+ * @brief Allocate cache-line-aligned FP32 buffer.
+ * @param n_floats element count
+ * @return aligned pointer, must be released with aligned_free
+ */
+float *aligned_alloc_f32(std::size_t n_floats);
+
+/**
+ * @brief Release a buffer allocated via aligned_alloc_f32.
+ */
+void aligned_free(float *p);
+
+/**
+ * @brief Load 8 source elements and widen/reinterpret to FP32.
+ *
+ * For @c _FP16 this uses F16C conversion; for @c float this is a plain AVX
+ * load. Kept inline because the source type is selected by GEMM templates.
+ */
+template <typename SrcT> inline __m256 load8_to_f32(const SrcT *p) {
+  if constexpr (std::is_same_v<SrcT, float>) {
+    return _mm256_loadu_ps(p);
+  } else {
+    return _mm256_cvtph_ps(
+      _mm_loadu_si128(reinterpret_cast<const __m128i *>(p)));
+  }
+}
+
+/**
+ * @brief Store 8 FP32 values into @c float or narrow into @c _FP16.
+ */
+template <typename DstT> inline void store8_from_f32(DstT *p, __m256 v) {
+  if constexpr (std::is_same_v<DstT, float>) {
+    _mm256_storeu_ps(p, v);
+  } else {
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(p),
+                     _mm256_cvtps_ph(v, _MM_FROUND_TO_NEAREST_INT));
+  }
+}
+
+template <typename T> inline float read_f32(const T *p) {
+  return static_cast<float>(*p);
+}
+
+inline float hsum8_f32(__m256 v) {
+  __m128 sum =
+    _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+  sum = _mm_hadd_ps(sum, sum);
+  sum = _mm_hadd_ps(sum, sum);
+  return _mm_cvtss_f32(sum);
+}
+
+/**
+ * @brief Copy C into padded FP32 accumulation buffer with beta scaling.
+ *
+ * @c CType may be @c _FP16 (F16C-widened on the way in) or @c float (copied
+ * directly), so FP16- and FP32-output GEMMs share one accumulator path.
+ *
+ * @tparam CType C element type (_FP16 or float)
+ * @param C source C matrix
+ * @param C32 destination FP32 matrix
+ * @param M row size of C
+ * @param N column size of C
+ * @param c_stride row stride of C in elements
+ * @param c32_stride row stride of C32 in elements
+ * @param beta scale factor applied to C
+ */
+template <typename CType>
+void copy_C_to_C32(const CType *C, float *C32, unsigned int M, unsigned int N,
+                   unsigned int c_stride, unsigned int c32_stride, float beta);
+
+/**
+ * @brief Copy padded FP32 accumulation buffer back to C.
+ *
+ * For @c _FP16 output the result is narrowed via F16C; for @c float output it
+ * is copied verbatim.
+ *
+ * @tparam CType C element type (_FP16 or float)
+ * @param C32 source FP32 matrix
+ * @param C destination C matrix
+ * @param M row size of C
+ * @param N column size of C
+ * @param c32_stride row stride of C32 in elements
+ * @param c_stride row stride of C in elements
+ */
+template <typename CType>
+void copy_C32_to_C(const float *C32, CType *C, unsigned int M, unsigned int N,
+                   unsigned int c32_stride, unsigned int c_stride);
+
+/**
+ * @brief Apply beta scaling directly to C.
+ *
+ * Handles the GEMM degenerate case C = beta * C when alpha is zero or K is
+ * zero. Respects row stride @p c_stride and touches only logical M x N values.
+ *
+ * @tparam CType C element type (_FP16 or float)
+ * @param C C matrix
+ * @param M row size of C
+ * @param N column size of C
+ * @param c_stride row stride of C in elements
+ * @param beta scale factor applied to C
+ */
+template <typename CType>
+void apply_beta_to_C(CType *C, unsigned int M, unsigned int N,
+                     unsigned int c_stride, float beta);
+
+/**
+ * @brief Round @p v up to the next multiple of @p n.
+ */
+inline unsigned int round_up(unsigned int v, unsigned int n) {
+  return ((v + n - 1) / n) * n;
+}
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_UTIL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_workspace.cpp
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Thread-local scratch workspace for x86 FP16 GEMM
+ */
+
+#include "hgemm_workspace.h"
+
+#ifdef ENABLE_TEST
+#include "hgemm_test.h"
+#endif
+#include "hgemm_util.h"
+
+namespace nntrainer::avx2::internal {
+
+HgemmWorkspace::~HgemmWorkspace() { release_buffers(); }
+
+float *HgemmWorkspace::ensure_c32(std::size_t required) {
+  return ensure_buffer(c32, c32_capacity, c32_realloc_count, required);
+}
+
+float *HgemmWorkspace::ensure_pack_a(std::size_t required) {
+  return ensure_buffer(pack_a, pack_a_capacity, pack_a_realloc_count, required);
+}
+
+float *HgemmWorkspace::ensure_pack_b(std::size_t required) {
+  return ensure_buffer(pack_b, pack_b_capacity, pack_b_realloc_count, required);
+}
+
+float *HgemmWorkspace::ensure_scratch(std::size_t required) {
+  return ensure_buffer(scratch, scratch_capacity, scratch_realloc_count,
+                       required);
+}
+
+void HgemmWorkspace::reset_realloc_counts() {
+  c32_realloc_count = 0;
+  pack_a_realloc_count = 0;
+  pack_b_realloc_count = 0;
+  scratch_realloc_count = 0;
+}
+
+void HgemmWorkspace::release_buffers() {
+  aligned_free(pack_b);
+  aligned_free(pack_a);
+  aligned_free(scratch);
+  aligned_free(c32);
+  pack_b = nullptr;
+  pack_a = nullptr;
+  scratch = nullptr;
+  c32 = nullptr;
+  c32_capacity = 0;
+  pack_a_capacity = 0;
+  pack_b_capacity = 0;
+  scratch_capacity = 0;
+  reset_realloc_counts();
+}
+
+float *HgemmWorkspace::ensure_buffer(float *&buffer, std::size_t &capacity,
+                                     std::size_t &realloc_count,
+                                     std::size_t required) {
+  if (required <= capacity) {
+    return buffer;
+  }
+
+  float *next = aligned_alloc_f32(required);
+  aligned_free(buffer);
+  buffer = next;
+  capacity = required;
+  ++realloc_count;
+  return buffer;
+}
+
+HgemmWorkspace &get_hgemm_workspace() {
+  thread_local HgemmWorkspace workspace;
+  return workspace;
+}
+
+#ifdef ENABLE_TEST
+namespace testing {
+
+HgemmWorkspaceStats get_hgemm_workspace_stats() {
+  const HgemmWorkspace &workspace = get_hgemm_workspace();
+  HgemmWorkspaceStats stats;
+  stats.c32_capacity = workspace.c32_capacity;
+  stats.pack_a_capacity = workspace.pack_a_capacity;
+  stats.pack_b_capacity = workspace.pack_b_capacity;
+  stats.scratch_capacity = workspace.scratch_capacity;
+  stats.c32_realloc_count = workspace.c32_realloc_count;
+  stats.pack_a_realloc_count = workspace.pack_a_realloc_count;
+  stats.pack_b_realloc_count = workspace.pack_b_realloc_count;
+  stats.scratch_realloc_count = workspace.scratch_realloc_count;
+  stats.total_realloc_count =
+    stats.c32_realloc_count + stats.pack_a_realloc_count +
+    stats.pack_b_realloc_count + stats.scratch_realloc_count;
+  stats.total_capacity_bytes =
+    (stats.c32_capacity + stats.pack_a_capacity + stats.pack_b_capacity +
+     stats.scratch_capacity) *
+    sizeof(float);
+  return stats;
+}
+
+void reset_hgemm_workspace_stats() {
+  get_hgemm_workspace().reset_realloc_counts();
+}
+
+void clear_hgemm_workspace() { get_hgemm_workspace().release_buffers(); }
+
+} // namespace testing
+#endif
+
+} /* namespace nntrainer::avx2::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.cpp
@@ -17,33 +17,121 @@
 #endif
 #include "hgemm_util.h"
 
-namespace nntrainer::avx2::internal {
+#include <algorithm>
+#include <cstdlib>
+#include <mutex>
+#include <vector>
 
-HgemmWorkspace::~HgemmWorkspace() { release_buffers(); }
+namespace nntrainer::hgemm::internal {
+
+namespace {
+
+/**
+ * @brief Process-wide registry of every thread-local HgemmWorkspace.
+ *
+ * The workspaces are reused across GEMM calls (that reuse is the whole point of
+ * the thread-local cache), so their buffers intentionally outlive a single
+ * call. In a thread pool the owning worker threads never terminate, so without
+ * a registry the buffers would only be freed at process teardown via
+ * thread_local destruction and look like a leak to external tooling.
+ * Registering every workspace keeps the live set reachable and lets
+ * release_all_hgemm_workspaces() drop the buffers deterministically at a safe
+ * teardown point.
+ */
+class WorkspaceRegistry {
+public:
+  void add(HgemmWorkspace *ws) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    workspaces_.push_back(ws);
+  }
+
+  void remove(HgemmWorkspace *ws) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    workspaces_.erase(std::remove(workspaces_.begin(), workspaces_.end(), ws),
+                      workspaces_.end());
+  }
+
+  void release_all() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (HgemmWorkspace *ws : workspaces_) {
+      ws->release_buffers();
+    }
+  }
+
+private:
+  std::mutex mutex_;
+  std::vector<HgemmWorkspace *> workspaces_;
+};
+
+/// Lazily-constructed registry. Built on the first workspace registration, so
+/// it is guaranteed to outlive every workspace it tracks (each workspace
+/// destructor unregisters before the registry itself is destroyed at process
+/// exit). The first construction also registers an atexit hook so the buffers
+/// are released deterministically at teardown, independent of thread_local
+/// destruction order.
+WorkspaceRegistry &workspace_registry() {
+  static WorkspaceRegistry instance;
+  static const bool atexit_registered = [] {
+    std::atexit([] { workspace_registry().release_all(); });
+    return true;
+  }();
+  (void)atexit_registered;
+  return instance;
+}
+
+} // namespace
+
+HgemmWorkspace::HgemmWorkspace() { workspace_registry().add(this); }
+
+HgemmWorkspace::~HgemmWorkspace() {
+  workspace_registry().remove(this);
+  release_buffers();
+}
 
 float *HgemmWorkspace::ensure_c32(std::size_t required) {
-  return ensure_buffer(c32, c32_capacity, c32_realloc_count, required);
+#ifdef ENABLE_TEST
+  if (required > c32_capacity) {
+    ++c32_realloc_count;
+  }
+#endif
+  return ensure_buffer(c32, c32_capacity, required);
 }
 
 float *HgemmWorkspace::ensure_pack_a(std::size_t required) {
-  return ensure_buffer(pack_a, pack_a_capacity, pack_a_realloc_count, required);
+#ifdef ENABLE_TEST
+  if (required > pack_a_capacity) {
+    ++pack_a_realloc_count;
+  }
+#endif
+  return ensure_buffer(pack_a, pack_a_capacity, required);
 }
 
 float *HgemmWorkspace::ensure_pack_b(std::size_t required) {
-  return ensure_buffer(pack_b, pack_b_capacity, pack_b_realloc_count, required);
+#ifdef ENABLE_TEST
+  if (required > pack_b_capacity) {
+    ++pack_b_realloc_count;
+  }
+#endif
+  return ensure_buffer(pack_b, pack_b_capacity, required);
 }
 
 float *HgemmWorkspace::ensure_scratch(std::size_t required) {
-  return ensure_buffer(scratch, scratch_capacity, scratch_realloc_count,
-                       required);
+#ifdef ENABLE_TEST
+  if (required > scratch_capacity) {
+    ++scratch_realloc_count;
+  }
+#endif
+  return ensure_buffer(scratch, scratch_capacity, required);
 }
 
+#ifdef ENABLE_TEST
 void HgemmWorkspace::reset_realloc_counts() {
   c32_realloc_count = 0;
   pack_a_realloc_count = 0;
   pack_b_realloc_count = 0;
   scratch_realloc_count = 0;
 }
+#endif
 
 void HgemmWorkspace::release_buffers() {
   aligned_free(pack_b);
@@ -58,11 +146,12 @@ void HgemmWorkspace::release_buffers() {
   pack_a_capacity = 0;
   pack_b_capacity = 0;
   scratch_capacity = 0;
+#ifdef ENABLE_TEST
   reset_realloc_counts();
+#endif
 }
 
 float *HgemmWorkspace::ensure_buffer(float *&buffer, std::size_t &capacity,
-                                     std::size_t &realloc_count,
                                      std::size_t required) {
   if (required <= capacity) {
     return buffer;
@@ -72,7 +161,6 @@ float *HgemmWorkspace::ensure_buffer(float *&buffer, std::size_t &capacity,
   aligned_free(buffer);
   buffer = next;
   capacity = required;
-  ++realloc_count;
   return buffer;
 }
 
@@ -80,6 +168,8 @@ HgemmWorkspace &get_hgemm_workspace() {
   thread_local HgemmWorkspace workspace;
   return workspace;
 }
+
+void release_all_hgemm_workspaces() { workspace_registry().release_all(); }
 
 #ifdef ENABLE_TEST
 namespace testing {
@@ -114,4 +204,4 @@ void clear_hgemm_workspace() { get_hgemm_workspace().release_buffers(); }
 } // namespace testing
 #endif
 
-} /* namespace nntrainer::avx2::internal */
+} /* namespace nntrainer::hgemm::internal */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.h
@@ -15,13 +15,13 @@
 
 #include <cstddef>
 
-namespace nntrainer::avx2::internal {
+namespace nntrainer::hgemm::internal {
 
 /** @brief Thread-local scratch buffers reused across x86 FP16 GEMM calls */
 struct HgemmWorkspace {
   ~HgemmWorkspace();
 
-  HgemmWorkspace() = default;
+  HgemmWorkspace();
   HgemmWorkspace(const HgemmWorkspace &) = delete;
   HgemmWorkspace &operator=(const HgemmWorkspace &) = delete;
 
@@ -30,8 +30,10 @@ struct HgemmWorkspace {
   float *ensure_pack_b(std::size_t required);
   float *ensure_scratch(std::size_t required);
 
-  void reset_realloc_counts();
   void release_buffers();
+#ifdef ENABLE_TEST
+  void reset_realloc_counts();
+#endif
 
   float *c32 = nullptr;
   float *pack_a = nullptr;
@@ -41,18 +43,30 @@ struct HgemmWorkspace {
   std::size_t pack_a_capacity = 0;
   std::size_t pack_b_capacity = 0;
   std::size_t scratch_capacity = 0;
+#ifdef ENABLE_TEST
   std::size_t c32_realloc_count = 0;
   std::size_t pack_a_realloc_count = 0;
   std::size_t pack_b_realloc_count = 0;
   std::size_t scratch_realloc_count = 0;
+#endif
 
 private:
   static float *ensure_buffer(float *&buffer, std::size_t &capacity,
-                              std::size_t &realloc_count, std::size_t required);
+                              std::size_t required);
 };
 
 HgemmWorkspace &get_hgemm_workspace();
 
-} /* namespace nntrainer::avx2::internal */
+/**
+ * @brief Release the scratch buffers of every live thread-local workspace.
+ *
+ * Frees the reuse cache held by all threads; each buffer is lazily re-created
+ * on the next GEMM call. Intended for deterministic teardown so the pooled
+ * thread-local buffers do not look like a leak. Must only be called when no
+ * GEMM is in flight on any thread.
+ */
+void release_all_hgemm_workspaces();
+
+} /* namespace nntrainer::hgemm::internal */
 
 #endif /* __X86_HGEMM_WORKSPACE_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.h
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/hgemm_workspace.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Yonghyeon Cho <dyddyd8574@gmail.com>
+ *
+ * @file   hgemm_workspace.h
+ * @date   01 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Thread-local scratch workspace for x86 FP16 GEMM
+ */
+
+#ifndef __X86_HGEMM_WORKSPACE_H_
+#define __X86_HGEMM_WORKSPACE_H_
+
+#include <cstddef>
+
+namespace nntrainer::avx2::internal {
+
+/** @brief Thread-local scratch buffers reused across x86 FP16 GEMM calls */
+struct HgemmWorkspace {
+  ~HgemmWorkspace();
+
+  HgemmWorkspace() = default;
+  HgemmWorkspace(const HgemmWorkspace &) = delete;
+  HgemmWorkspace &operator=(const HgemmWorkspace &) = delete;
+
+  float *ensure_c32(std::size_t required);
+  float *ensure_pack_a(std::size_t required);
+  float *ensure_pack_b(std::size_t required);
+  float *ensure_scratch(std::size_t required);
+
+  void reset_realloc_counts();
+  void release_buffers();
+
+  float *c32 = nullptr;
+  float *pack_a = nullptr;
+  float *pack_b = nullptr;
+  float *scratch = nullptr;
+  std::size_t c32_capacity = 0;
+  std::size_t pack_a_capacity = 0;
+  std::size_t pack_b_capacity = 0;
+  std::size_t scratch_capacity = 0;
+  std::size_t c32_realloc_count = 0;
+  std::size_t pack_a_realloc_count = 0;
+  std::size_t pack_b_realloc_count = 0;
+  std::size_t scratch_realloc_count = 0;
+
+private:
+  static float *ensure_buffer(float *&buffer, std::size_t &capacity,
+                              std::size_t &realloc_count, std::size_t required);
+};
+
+HgemmWorkspace &get_hgemm_workspace();
+
+} /* namespace nntrainer::avx2::internal */
+
+#endif /* __X86_HGEMM_WORKSPACE_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/meson.build
@@ -1,12 +1,6 @@
-x86_hgemm_headers = [
-  'hgemm.h',
-  'hgemm_blocked.h',
-  'hgemm_common.h',
-  'hgemm_fast_path.h',
-  'hgemm_pack.h',
-  'hgemm_util.h',
-  'hgemm_workspace.h',
-]
+# The x86 hgemm headers are internal (nntrainer::hgemm::internal) and are used
+# only through the cpu_backend dispatch inside this library, so they are added to
+# the include path below but intentionally not installed.
 
 subdir('hgemm_kernel')
 nntrainer_inc += include_directories('hgemm_kernel')
@@ -23,8 +17,4 @@ x86_hgemm_sources = [
 
 foreach s : x86_hgemm_sources
   nntrainer_sources += meson.current_source_dir() / s
-endforeach
-
-foreach h : x86_hgemm_headers
-  nntrainer_headers += meson.current_source_dir() / h
 endforeach

--- a/nntrainer/tensor/cpu_backend/x86/hgemm/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/hgemm/meson.build
@@ -1,0 +1,30 @@
+x86_hgemm_headers = [
+  'hgemm.h',
+  'hgemm_blocked.h',
+  'hgemm_common.h',
+  'hgemm_fast_path.h',
+  'hgemm_pack.h',
+  'hgemm_util.h',
+  'hgemm_workspace.h',
+]
+
+subdir('hgemm_kernel')
+nntrainer_inc += include_directories('hgemm_kernel')
+nntrainer_inc_abs += meson.current_source_dir() / 'hgemm_kernel'
+
+x86_hgemm_sources = [
+  'hgemm.cpp',
+  'hgemm_blocked.cpp',
+  'hgemm_fast_path.cpp',
+  'hgemm_pack.cpp',
+  'hgemm_util.cpp',
+  'hgemm_workspace.cpp',
+]
+
+foreach s : x86_hgemm_sources
+  nntrainer_sources += meson.current_source_dir() / s
+endforeach
+
+foreach h : x86_hgemm_headers
+  nntrainer_headers += meson.current_source_dir() / h
+endforeach

--- a/nntrainer/tensor/cpu_backend/x86/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/meson.build
@@ -1,6 +1,8 @@
 simd_interface_x86_headers = [
   'x86_compute_backend.h',
   'avx2_impl.h',
+  'avx2_mathfun.h',
+  'avx2_mathfun.hxx',
 ]
 simd_interface_x86_sources = [
   'x86_compute_backend.cpp',

--- a/nntrainer/tensor/cpu_backend/x86/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/meson.build
@@ -13,6 +13,10 @@ simd_interface_x86_sources = [
 if get_option('enable-fp16')
     simd_interface_x86_sources += 'avx2_impl_fp16.cpp'
     simd_interface_x86_sources += 'x86_compute_backend_fp16.cpp'
+
+    subdir('hgemm')
+    nntrainer_inc += include_directories('hgemm')
+    nntrainer_inc_abs += meson.current_source_dir() / 'hgemm'
 endif
 
 foreach s : simd_interface_x86_sources

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -144,16 +144,16 @@ void scopy_int8_to_float32(const unsigned int N, const int8_t *X,
 
 template <>
 void sine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
-  __fallback_sine(N, X, Y, alpha, beta);
+  nntrainer::avx2::sine(N, X, Y, alpha, beta);
 }
 
 template <>
 void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
-  __fallback_cosine(N, X, Y, alpha, beta);
+  nntrainer::avx2::cosine(N, X, Y, alpha, beta);
 }
 
 void inv_sqrt_inplace(const unsigned int N, float *X) {
-  __fallback_inv_sqrt_inplace(N, X);
+  nntrainer::avx2::inv_sqrt_inplace(N, X);
 }
 
 void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
@@ -171,13 +171,13 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
 void ele_sub(const unsigned N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  nntrainer::avx2::ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  nntrainer::avx2::ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void saxpy(const unsigned int N, const float alpha, const float *X,
@@ -287,8 +287,8 @@ template <>
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
                                  float *sin_, unsigned int from,
                                  float attention_scaling) {
-  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from,
-                                         attention_scaling);
+  nntrainer::avx2::calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from,
+                                               attention_scaling);
 }
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z) {
@@ -300,8 +300,7 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha) {
 }
 
 void tanh_gelu(const unsigned int N, const float *X, float *Y) {
-  // AVX implmenetation will be implemented, now fallback instead
-  __fallback_tanh_gelu(N, X, Y);
+  nntrainer::avx2::tanh_gelu(N, X, Y);
 }
 
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
@@ -313,17 +312,19 @@ void gelu_v2(const unsigned int N, const float *X, float *Y) {
 }
 
 void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z) {
-  __fallback_tanh_gelu_mul(N, X, Y, Z);
+  nntrainer::avx2::tanh_gelu_mul(N, X, Y, Z);
 }
 
 void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z) {
-  __fallback_tanh_gelu_mul(N, X, Y, Z);
+  nntrainer::avx2::tanh_gelu_v2_mul(N, X, Y, Z);
 }
 
-float max_val(const unsigned int N, float *X) { return __fallback_max(N, X); }
+float max_val(const unsigned int N, float *X) {
+  return nntrainer::avx2::max_val(N, X);
+}
 
 void softmax(const unsigned int N, float *X, float *Y) {
-  __fallback_softmax(N, X, Y);
+  nntrainer::avx2::softmax(N, X, Y);
 }
 
 template <>

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1193,6 +1193,43 @@ template <typename T = float>
 void softmax_row(T *qk_out, size_t start_row, size_t end_row, size_t num_heads,
                  T *sink = nullptr);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief Multihead softmax with mixed precision, inplace version (overload).
+ * FP16 in/out with an FP32 sink (can be nullptr).
+ */
+void softmax_row_inplace(_FP16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, float *sink);
+
+/**
+ * @brief Multihead softmax with mixed precision (overload). FP16 in/out with an
+ * FP32 sink (can be nullptr).
+ */
+void softmax_row(_FP16 *qk_out, size_t start_row, size_t end_row,
+                 size_t num_heads, float *sink);
+
+/**
+ * @brief FP16-input attention-weighted value aggregation (softmax_out * V).
+ * Mirrors compute_fp16vcache_fp32_transposed but with FP16 in/vcache/output.
+ */
+void compute_fp16vcache_transposed(int row_num, const _FP16 *in,
+                                   const _FP16 *vcache, _FP16 *output,
+                                   int num_cache_head, int gqa_size,
+                                   int head_dim,
+                                   size_t local_window_size = UINT_MAX,
+                                   int head_start = 0, int head_end = -1);
+
+/**
+ * @brief FP16-input scaled dot product Q*K^T. Mirrors the FP32 compute_kcaches
+ * but with FP16 in/kcache/output.
+ */
+void compute_kcaches(const _FP16 *in, const _FP16 *kcache, _FP16 *output,
+                     int num_rows, int num_cache_head, int head_dim,
+                     int gqa_size, int tile_size,
+                     size_t local_window_size = UINT_MAX, int head_start = 0,
+                     int head_end = -1);
+#endif
+
 /**
  * @brief Compute vcache for one row transposed
  * @param[in] row_num row number

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -34,8 +34,8 @@ void shgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
             const _FP16 *B, const unsigned int ldb, const float beta, float *C,
             const unsigned int ldc) {
   if (TStorageOrder == ROW_MAJOR) {
-    nntrainer::avx2::shgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
-                            TransA, TransB);
+    nntrainer::hgemm::shgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
+                             TransA, TransB);
     return;
   }
 
@@ -86,8 +86,8 @@ void hsgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
             const float *B, const unsigned int ldb, const float beta, float *C,
             const unsigned int ldc) {
   if (TStorageOrder == ROW_MAJOR) {
-    nntrainer::avx2::hsgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
-                            TransA, TransB);
+    nntrainer::hgemm::hsgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
+                             TransA, TransB);
     return;
   }
 
@@ -198,13 +198,36 @@ void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const float alpha, const _FP16 *A, const unsigned int lda,
            const _FP16 *B, const unsigned int ldb, const float beta, _FP16 *C,
            const unsigned int ldc) {
-  if (TStorageOrder) {
-    __fallback_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A, lda, B,
-                     ldb, beta, C, ldc);
-  } else {
-    nntrainer::avx2::hgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta, TransA,
-                           TransB);
+  if (TStorageOrder == ROW_MAJOR) {
+    nntrainer::hgemm::hgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
+                            TransA, TransB);
+    return;
   }
+
+  // The cache-blocked hgemm path is row-major only, so column-major inputs fall
+  // back to the legacy FP32-conversion path. CBLAS honors TStorageOrder;
+  // __fallback_sgemm does not, so it is only valid as the non-BLAS baseline.
+#ifdef USE_BLAS
+  float *A_ = new float[M * K];
+  float *B_ = new float[N * K];
+  float *C_ = new float[M * N];
+
+  scopy(M * K, A, 1, A_, 1);
+  scopy(N * K, B, 1, B_, 1);
+  scopy(M * N, C, 1, C_, 1);
+
+  __cblas_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A_, lda, B_, ldb,
+                beta, C_, ldc);
+
+  scopy(M * N, C_, 1, C, 1);
+
+  delete[] A_;
+  delete[] B_;
+  delete[] C_;
+#else
+  __fallback_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A, lda, B,
+                   ldb, beta, C, ldc);
+#endif
 }
 
 void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <avx2_impl.h>
 #include <fallback_internal.h>
+#include <hgemm.h>
 #include <nntrainer_error.h>
 #include <tensor_dim.h>
 #include <x86_compute_backend.h>
@@ -32,6 +33,12 @@ void shgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
             const float alpha, const float *A, const unsigned int lda,
             const _FP16 *B, const unsigned int ldb, const float beta, float *C,
             const unsigned int ldc) {
+  if (TStorageOrder == ROW_MAJOR) {
+    nntrainer::avx2::shgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
+                            TransA, TransB);
+    return;
+  }
+
   float *B_ = new float[N * K];
   scopy(N * K, B, 1, B_, 1);
 
@@ -50,8 +57,13 @@ void shgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
             const unsigned int N, const float alpha, const float *A,
             const unsigned int lda, const _FP16 *X, const unsigned int incX,
             const float beta, float *Y, const unsigned int incY) {
-  unsigned int lenX = (TransA) ? 1 + (M - 1) * (incX) : 1 + (N - 1) * (incX);
-  unsigned int lenY = (TransA) ? 1 + (N - 1) * (incY) : 1 + (M - 1) * (incY);
+  if (TStorageOrder == ROW_MAJOR) {
+    avx2::shgemv(TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
+    return;
+  }
+
+  const unsigned int lenX =
+    (TransA) ? 1 + (M - 1) * (incX) : 1 + (N - 1) * (incX);
 
   float *X_ = new float[lenX];
 
@@ -73,6 +85,12 @@ void hsgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
             const float alpha, const _FP16 *A, const unsigned int lda,
             const float *B, const unsigned int ldb, const float beta, float *C,
             const unsigned int ldc) {
+  if (TStorageOrder == ROW_MAJOR) {
+    nntrainer::avx2::hsgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta,
+                            TransA, TransB);
+    return;
+  }
+
   float *A_ = new float[M * K];
 
   scopy(M * K, A, 1, A_, 1);
@@ -92,8 +110,10 @@ void hsgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
             const unsigned int N, const float alpha, const _FP16 *A,
             const unsigned int lda, const float *X, const unsigned int incX,
             const float beta, float *Y, const unsigned int incY) {
-  unsigned int lenX = (TransA) ? 1 + (M - 1) * (incX) : 1 + (N - 1) * (incX);
-  unsigned int lenY = (TransA) ? 1 + (N - 1) * (incY) : 1 + (M - 1) * (incY);
+  if (TStorageOrder == ROW_MAJOR) {
+    avx2::hsgemv(TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
+    return;
+  }
 
   float *A_ = new float[M * N];
 
@@ -178,34 +198,23 @@ void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const float alpha, const _FP16 *A, const unsigned int lda,
            const _FP16 *B, const unsigned int ldb, const float beta, _FP16 *C,
            const unsigned int ldc) {
-#ifdef USE_BLAS
-
-  float *A_ = new float[M * K];
-  float *B_ = new float[N * K];
-  float *C_ = new float[M * N];
-
-  scopy(M * K, A, 1, A_, 1);
-  scopy(N * K, B, 1, B_, 1);
-  scopy(M * N, C, 1, C_, 1);
-
-  __cblas_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A_, lda, B_, ldb,
-                beta, C_, ldc);
-
-  scopy(M * N, C_, 1, C, 1);
-
-  delete[] A_;
-  delete[] B_;
-  delete[] C_;
-#else
-  __fallback_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A, lda, B,
-                   ldb, beta, C, ldc);
-#endif
+  if (TStorageOrder) {
+    __fallback_sgemm(TStorageOrder, TransA, TransB, M, N, K, alpha, A, lda, B,
+                     ldb, beta, C, ldc);
+  } else {
+    nntrainer::avx2::hgemm(A, B, C, M, N, K, lda, ldb, ldc, alpha, beta, TransA,
+                           TransB);
+  }
 }
 
 void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
            const unsigned int N, const float alpha, const _FP16 *A,
            const unsigned int lda, const _FP16 *X, const unsigned int incX,
            const float beta, _FP16 *Y, const unsigned int incY) {
+  if (TStorageOrder == ROW_MAJOR) {
+    avx2::hgemv(TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
+    return;
+  }
 #ifdef USE_BLAS
   unsigned int lenX = (TransA) ? 1 + (M - 1) * (incX) : 1 + (N - 1) * (incX);
   unsigned int lenY = (TransA) ? 1 + (N - 1) * (incY) : 1 + (M - 1) * (incY);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -112,27 +112,24 @@ void hsgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
 
 void sscal(const unsigned int N, const float alpha, _FP16 *X,
            const unsigned int incX) {
-  __fallback_sscal(N, alpha, X, incX);
+  avx2::sscal(N, alpha, X, incX);
 }
 
 _FP16 snrm2(const unsigned int N, const _FP16 *X, const unsigned int incX) {
   assert(incX > 0);
-  _FP16 sum = __fallback_snrm2(N, X, incX);
+  _FP16 sum = avx2::snrm2(N, X, incX);
   return sum;
 }
 
 void scopy(const unsigned int N, const _FP16 *X, const unsigned int incX,
            _FP16 *Y, const unsigned int incY) {
-  if (incX == 1 && incY == 1) {
-    __fallback_scopy(N, X, incX, Y, incY);
-  }
+  avx2::custom_scopy(N, X, incX, Y, incY);
 }
 
 void scopy(const unsigned int N, const float *X, const unsigned int incX,
            _FP16 *Y, const unsigned int incY) {
   if (incX == 1 && incY == 1) {
     nntrainer::avx2::vcvt_f32_f16(N, X, Y);
-
   } else {
     __fallback_scopy(N, X, incX, Y, incY);
   }
@@ -150,33 +147,30 @@ void scopy(const unsigned int N, const _FP16 *X, const unsigned int incX,
 void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  if (incX == 1 && incY == 1) {
-    __fallback_scopy_int4_to_float16(N, X, incX, Y, incY);
-  }
+  avx2::scopy_int4_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  __fallback_scopy_int8_to_float16(N, X, incX, Y, incY);
+  avx2::scopy_int8_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  __fallback_scopy_int8_to_float16(N, X, incX, Y, incY);
+  avx2::scopy_int8_to_float16(N, X, incX, Y, incY);
 }
 
 _FP16 sdot(const unsigned int N, const _FP16 *X, const unsigned int incX,
            const _FP16 *Y, const unsigned int incY) {
   assert(incX > 0 && incY > 0);
-  _FP16 ret = 0;
-  return __fallback_sdot(N, X, incX, Y, incY);
+  return avx2::sdot(N, X, incX, Y, incY);
 }
 
 void saxpy(const unsigned int N, const float alpha, const _FP16 *X,
            const unsigned int incX, _FP16 *Y, const unsigned int incY) {
-  __fallback_saxpy(N, alpha, X, incX, Y, incY);
+  avx2::saxpy(N, alpha, X, incX, Y, incY);
 }
 
 void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
@@ -242,42 +236,42 @@ void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
 void ele_mul(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_mul(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_mul(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_add(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_add(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_add(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_sub(const unsigned N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_div(const unsigned N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 unsigned int isamax(const unsigned int N, const _FP16 *X,
                     const unsigned int incX) {
   unsigned int max_idx = 0;
-  max_idx = __fallback_isamax(N, X, incX);
+  max_idx = avx2::isamax(N, X, incX);
   return max_idx;
 }
 
 void inv_sqrt_inplace(const unsigned int N, _FP16 *X) {
-  __fallback_inv_sqrt_inplace(N, X);
+  avx2::inv_sqrt_inplace(N, X);
 }
 
 void transpose_matrix(const unsigned int M, const unsigned int N,
                       const _FP16 *src, unsigned int ld_src, _FP16 *dst,
                       unsigned int ld_dst) {
-  __fallback_transpose_matrix(M, N, src, ld_src, dst, ld_dst);
+  avx2::transpose_matrix(M, N, src, ld_src, dst, ld_dst);
 }
 
 bool is_valid(const unsigned int N, const _FP16 *input) {
@@ -287,17 +281,17 @@ bool is_valid(const unsigned int N, const _FP16 *input) {
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
                                     float *cos_, float *sin_) {
-  __fallback_compute_rotary_embedding_value(dim, half_, w, in, out, cos_, sin_);
+  avx2::compute_rotary_embedding_value(dim, half_, w, in, out, cos_, sin_);
 }
 
 void swiglu(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
-  __fallback_swiglu(N, X, Y, Z);
+  avx2::swiglu(N, X, Y, Z);
 }
 
-_FP16 max_val(const unsigned int N, _FP16 *X) { return __fallback_max(N, X); }
+_FP16 max_val(const unsigned int N, _FP16 *X) { return avx2::max_val(N, X); }
 
 void softmax(const unsigned int N, _FP16 *X, _FP16 *Y) {
-  __fallback_softmax(N, X, Y);
+  avx2::softmax(N, X, Y);
 }
 
 template <> void dequantize_row_q8_0(const void *x_raw, _FP16 *y, int64_t k) {
@@ -314,7 +308,19 @@ template <>
 void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
                const _FP16 *A, const unsigned int lda, const void *B,
                const unsigned int ldb, _FP16 *C, const unsigned int ldc) {
-  return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+  float *A_fp32 = new float[M * lda];
+  float *C_fp32 = new float[M * ldc];
+
+  for (unsigned int i = 0; i < M; ++i)
+    nntrainer::avx2::vcvt_f16_f32(K, A + i * lda, A_fp32 + i * lda);
+
+  __ggml_q4_0_8x8_q8_0_GEMM(M, N, K, A_fp32, lda, B, ldb, C_fp32, ldc);
+
+  for (unsigned int i = 0; i < M; ++i)
+    nntrainer::avx2::vcvt_f32_f16(N, C_fp32 + i * ldc, C + i * ldc);
+
+  delete[] A_fp32;
+  delete[] C_fp32;
 }
 
 template <> void quantize_row_q8_K(const _FP16 *src, void *dst, int64_t k) {
@@ -336,7 +342,7 @@ template <>
 void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
                                        _FP16 *__restrict Y, size_t H, size_t W,
                                        float epsilon) {
-  __fallback_rms_norm_wrt_width_fp16_intrinsic<_FP16>(X, Y, H, W, epsilon);
+  avx2::rms_norm_wrt_width_fp16(X, Y, H, W, epsilon);
 }
 
 void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -326,6 +326,50 @@ void softmax(const unsigned int N, _FP16 *X, _FP16 *Y) {
   avx2::softmax(N, X, Y);
 }
 
+// FP16-input attention kernels (delegate to the AVX2+F16C implementations).
+// softmax_row shares semantics with the in-place variant, mirroring the ARM
+// backend.
+template <>
+void softmax_row_inplace(_FP16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, _FP16 *sink) {
+  avx2::softmax_row_inplace<_FP16>(qk_out, start_row, end_row, num_heads, sink);
+}
+
+void softmax_row_inplace(_FP16 *qk_out, size_t start_row, size_t end_row,
+                         size_t num_heads, float *sink) {
+  avx2::softmax_row_inplace(qk_out, start_row, end_row, num_heads, sink);
+}
+
+template <>
+void softmax_row(_FP16 *qk_out, size_t start_row, size_t end_row,
+                 size_t num_heads, _FP16 *sink) {
+  avx2::softmax_row_inplace<_FP16>(qk_out, start_row, end_row, num_heads, sink);
+}
+
+void softmax_row(_FP16 *qk_out, size_t start_row, size_t end_row,
+                 size_t num_heads, float *sink) {
+  avx2::softmax_row_inplace(qk_out, start_row, end_row, num_heads, sink);
+}
+
+void compute_fp16vcache_transposed(int row_num, const _FP16 *in,
+                                   const _FP16 *vcache, _FP16 *output,
+                                   int num_cache_head, int gqa_size,
+                                   int head_dim, size_t local_window_size,
+                                   int head_start, int head_end) {
+  avx2::compute_fp16vcache_transposed(row_num, in, vcache, output,
+                                      num_cache_head, gqa_size, head_dim,
+                                      local_window_size, head_start, head_end);
+}
+
+void compute_kcaches(const _FP16 *in, const _FP16 *kcache, _FP16 *output,
+                     int num_rows, int num_cache_head, int head_dim,
+                     int gqa_size, int tile_size, size_t local_window_size,
+                     int head_start, int head_end) {
+  avx2::compute_kcaches(in, kcache, output, num_rows, num_cache_head, head_dim,
+                        gqa_size, tile_size, local_window_size, head_start,
+                        head_end);
+}
+
 template <> void dequantize_row_q8_0(const void *x_raw, _FP16 *y, int64_t k) {
   __ggml_dequantize_row_q8_0(x_raw, y, k);
 }

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -613,6 +613,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %ifarch %{ix86} x86_64
 %{_includedir}/nntrainer/x86_compute_backend.h
 %{_includedir}/nntrainer/avx2_impl.h
+%{_includedir}/nntrainer/avx2_mathfun.h
+%{_includedir}/nntrainer/avx2_mathfun.hxx
 %endif
 %ifarch aarch64
 %{_includedir}/nntrainer/arm_compute_backend.h

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -96,6 +96,7 @@ endif
 if get_option('enable-fp16')
   test_target += [['unittest_nntrainer_tensor_fp16', []]]
   test_target += [['unittest_nntrainer_tensor_pool_fp16', []]]
+  test_target += [['unittest_nntrainer_cpu_backend_fp16', []]]
 endif
 
 if get_option('enable-profile')

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -96,7 +96,7 @@ endif
 if get_option('enable-fp16')
   test_target += [['unittest_nntrainer_tensor_fp16', []]]
   test_target += [['unittest_nntrainer_tensor_pool_fp16', []]]
-  test_target += [['unittest_nntrainer_cpu_backend_fp16', []]]
+  test_target += [['unittest_nntrainer_cpu_backend_fp16_x86', []]]
 endif
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -2251,10 +2251,8 @@ TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_3072) {
   const int TEST_CNT = 20;
   for (int i = 0; i < TEST_CNT; i++) {
     std::vector<_FP16> X(N), X_ref(N);
-    std::vector<_FP16> Y =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
-    std::vector<_FP16> Z =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
     std::vector<_FP16> Y_ref = Y, Z_ref = Z;
 
     nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
@@ -2270,10 +2268,8 @@ TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_7) {
   const int TEST_CNT = 20;
   for (int i = 0; i < TEST_CNT; i++) {
     std::vector<_FP16> X(N), X_ref(N);
-    std::vector<_FP16> Y =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
-    std::vector<_FP16> Z =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
     std::vector<_FP16> Y_ref = Y, Z_ref = Z;
 
     nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
@@ -2344,9 +2340,8 @@ static void run_rotary_emb_fp16_test(unsigned int dim, unsigned int half_) {
 
     nntrainer::__fallback_compute_rotary_embedding_value(
       dim, half_, w, in.data(), out_ref.data(), cos_v.data(), sin_v.data());
-    nntrainer::compute_rotary_embedding_value(dim, half_, w, in.data(),
-                                              out.data(), cos_v.data(),
-                                              sin_v.data());
+    nntrainer::compute_rotary_embedding_value(
+      dim, half_, w, in.data(), out.data(), cos_v.data(), sin_v.data());
 
     auto mse_val = mse<_FP16, _FP16>(out_ref.data(), out.data(), dim);
     ASSERT_LE(mse_val, 0.005f);

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -322,6 +322,9 @@ TEST(nntrainer_cpu_backend_standalone, q4_0_repack_unpack_dequantize) {
   }
 }
 
+/**
+ * @brief test for gemm_q4_0
+ */
 float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -368,6 +371,9 @@ float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q4_K
+ */
 float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -411,6 +417,9 @@ float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q6_K
+ */
 float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -448,6 +457,9 @@ float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief run quantization tests
+ */
 static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
                            float &q4_0_mse, float &q4_k_mse, float &q6_k_mse,
                            bool print = false) {
@@ -544,6 +556,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x512) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
+/**
+ * @brief run vec dot tests
+ */
 static void run_vec_dot_test(const uint32_t K, bool print = false) {
   const int TEST_CNT = 20;
   nanoseconds ref_time = (nanoseconds)0;
@@ -614,6 +629,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_q_6_K_DOT_10240) {
   run_vec_dot_test(K);
 }
 
+/**
+ * @brief run elementwise multiplication test (Z = X ⊙ alpha * Y + beta * Z)
+ */
 static void run_ele_mul_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -694,6 +712,9 @@ TEST(nntrainer_cpu_backend_standalone, ele_mul_3072_istr_16_ostr_16) {
   run_ele_mul_test(N, alpha, beta, i_stride, o_stride);
 }
 
+/**
+ * @brief run elementwise addition test (Z = X + alpha * Y + beta * Z)
+ */
 static void run_ele_add_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -1438,6 +1459,292 @@ DECLARE_transform_int4_test_K_N(1024, 648, 32);
 DECLARE_transform_int4_test_K_N(1024, 648, 64);
 DECLARE_transform_int4_test_K_N(1024, 648, 128);
 DECLARE_transform_int4_test_K_N(3072, 8192, 32);
+
+// ============================================================================
+// P1: AVX2 replacement tests for formerly-fallback FP32 functions
+// ============================================================================
+
+static void run_ele_sub_test(const unsigned int N, float alpha, float beta,
+                             unsigned int i_stride, unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Y = generate_random_vector<float, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<float> Z =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Z_ref = Z;
+
+    nntrainer::__fallback_ele_sub(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_sub(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mean_squared_error = compute_mse(1, N, Z_ref, Z, false);
+    ASSERT_LE(mean_squared_error, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_0) {
+  run_ele_sub_test(3072, 1.f, 0.f, 0, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_1) {
+  run_ele_sub_test(3072, 1.f, 0.f, 1, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_16_ostrid_16) {
+  run_ele_sub_test(3072, 3.f, 2.f, 16, 16);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_alpha1_beta0_istr_2) {
+  run_ele_sub_test(3072, 1.f, 0.f, 2, 1);
+}
+
+static void run_ele_div_test(const unsigned int N, float alpha, float beta,
+                             unsigned int i_stride, unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Y = generate_random_vector<float, false>(
+      std::max<size_t>(1, (size_t)N * i_stride), 0.1f, 1.0f);
+    std::vector<float> Z =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Z_ref = Z;
+
+    nntrainer::__fallback_ele_div(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_div(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mean_squared_error = compute_mse(1, N, Z_ref, Z, false);
+    ASSERT_LE(mean_squared_error, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_0) {
+  run_ele_div_test(3072, 1.f, 0.f, 0, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_1) {
+  run_ele_div_test(3072, 1.f, 0.f, 1, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_16_ostrid_16) {
+  run_ele_div_test(3072, 3.f, 2.f, 16, 16);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_alpha1_beta0_istr_2) {
+  run_ele_div_test(3072, 1.f, 0.f, 2, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_tanh_gelu(N, X.data(), Y_ref.data());
+    nntrainer::tanh_gelu(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_mul_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> Y = generate_random_vector<float, false>(N);
+    std::vector<float> Z = generate_random_vector<float, false>(N);
+    std::vector<float> X(N), X_ref(N);
+
+    nntrainer::__fallback_tanh_gelu_mul(N, X_ref.data(), Y.data(), Z.data());
+    // Restore Y since fallback may modify it
+    std::vector<float> Y2 = Y;
+    std::vector<float> Z2 = Z;
+    nntrainer::tanh_gelu_mul(N, X.data(), Y2.data(), Z2.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_mul_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> Y = generate_random_vector<float, false>(N);
+    std::vector<float> Z = generate_random_vector<float, false>(N);
+    std::vector<float> X(N), X_ref(N);
+
+    nntrainer::__fallback_tanh_gelu_mul(N, X_ref.data(), Y.data(), Z.data());
+    std::vector<float> Y2 = Y;
+    std::vector<float> Z2 = Z;
+    nntrainer::tanh_gelu_v2_mul(N, X.data(), Y2.data(), Z2.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+
+    float ref = nntrainer::__fallback_max(N, X.data());
+    float result = nntrainer::max_val(N, X.data());
+
+    ASSERT_FLOAT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>(N, 0.01f, 10.0f);
+    std::vector<float> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_with_zeros) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>(N, 0.01f, 10.0f);
+    // Insert zeros at various positions (boundary, middle, tail)
+    X[0] = 0.0f;
+    X[7] = 0.0f; // AVX2 boundary
+    X[8] = 0.0f; // start of second AVX2 chunk
+    X[N / 2] = 0.0f;
+    X[N - 1] = 0.0f; // scalar tail
+    std::vector<float> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    for (unsigned int j = 0; j < N; j++) {
+      if (std::isinf(X_ref[j])) {
+        ASSERT_TRUE(std::isinf(X[j]))
+          << "Expected inf at index " << j << ", got " << X[j];
+      } else {
+        ASSERT_FALSE(std::isnan(X[j])) << "Unexpected NaN at index " << j;
+        ASSERT_NEAR(X[j], X_ref[j], 0.001f);
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sine_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  const float alpha = 0.5f;
+  const float beta = 2.0f;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_sine(N, X.data(), Y_ref.data(), alpha, beta);
+    nntrainer::sine<float>(N, X.data(), Y.data(), alpha, beta);
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, cosine_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  const float alpha = 0.5f;
+  const float beta = 2.0f;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_cosine(N, X.data(), Y_ref.data(), alpha, beta);
+    nntrainer::cosine<float>(N, X.data(), Y.data(), alpha, beta);
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_tanh_gelu(N, X.data(), Y_ref.data());
+    nntrainer::tanh_gelu_v2(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, calc_trigonometric_vals_dup_512) {
+  const unsigned int N_half = 512;
+  const unsigned int N = 2 * N_half;
+  const unsigned int from = 3;
+  const float attention_scaling = 0.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> angle =
+      generate_random_vector<float, false>(N_half, 0.0f, 6.28f);
+    std::vector<float> cos_ref(N, 0.0f), sin_ref(N, 0.0f);
+    std::vector<float> cos_out(N, 0.0f), sin_out(N, 0.0f);
+
+    nntrainer::__fallback_calc_trigonometric_vals_dup(
+      N_half, angle.data(), cos_ref.data(), sin_ref.data(), from,
+      attention_scaling);
+    nntrainer::calc_trigonometric_vals_dup<float>(
+      N_half, angle.data(), cos_out.data(), sin_out.data(), from,
+      attention_scaling);
+
+    auto cos_mse = compute_mse(1, N, cos_ref, cos_out, false);
+    auto sin_mse = compute_mse(1, N, sin_ref, sin_out, false);
+    ASSERT_LE(cos_mse, 0.00001f);
+    ASSERT_LE(sin_mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_template_float) {
+  GTEST_SKIP()
+    << "rms_norm_wrt_width_fp16_intrinsic<float> is NYI on x86 (tracked for "
+       "separate PR)";
+}
 
 int main(int argc, char **argv) {
   int result = -1;

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1256,6 +1256,137 @@ TEST(nntrainer_cpu_backend_standalone, compute_fp16vcache_transposed_fp16) {
 }
 #endif
 
+// x86 AVX2+F16C FP16-input attention kernels. The x86 path computes in FP32
+// internally (no native FP16 arithmetic), so rather than depend on the ARM
+// FP16-rounded golden values above we verify against an in-test FP32 software
+// reference within FP16 tolerance.
+#if defined(ENABLE_FP16) && defined(__AVX2__)
+namespace {
+// Per-head softmax across rows [start_row, end_row). sink (optional) seeds the
+// running max/sum, matching the kernel semantics.
+static std::vector<float> softmax_row_ref(const std::vector<float> &qk,
+                                          size_t start_row, size_t end_row,
+                                          size_t num_heads,
+                                          const std::vector<float> *sink) {
+  std::vector<float> out = qk;
+  for (size_t c = 0; c < num_heads; ++c) {
+    float m = sink ? (*sink)[c] : qk[start_row * num_heads + c];
+    for (size_t r = (sink ? start_row : start_row + 1); r < end_row; ++r)
+      m = std::max(m, qk[r * num_heads + c]);
+    float sum = sink ? std::exp((*sink)[c] - m) : 0.0f;
+    for (size_t r = start_row; r < end_row; ++r)
+      sum += std::exp(qk[r * num_heads + c] - m);
+    for (size_t r = start_row; r < end_row; ++r)
+      out[r * num_heads + c] = std::exp(qk[r * num_heads + c] - m) / sum;
+  }
+  return out;
+}
+
+static std::vector<float> to_f32(const std::vector<_FP16> &v) {
+  return std::vector<float>(v.begin(), v.end());
+}
+} // namespace
+
+TEST(nntrainer_cpu_backend_standalone, compute_softmax_row_inplace_fp16_x86) {
+  size_t start_row = 0, end_row = 3, num_heads = 10;
+  auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
+  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
+  auto ref =
+    softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, nullptr);
+
+  nntrainer::softmax_row_inplace(qk.data(), start_row, end_row, num_heads);
+
+  for (size_t i = 0; i < qk.size(); i++)
+    EXPECT_NEAR(ref[i], static_cast<float>(qk[i]), 5e-3f);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     compute_softmax_row_inplace_fp16_sink_x86) {
+  size_t start_row = 0, end_row = 2, num_heads = 10;
+  auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
+  auto sink_f = generate_random_vector<float>(num_heads, -8.0f, 8.0f);
+  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
+  std::vector<_FP16> sink(sink_f.begin(), sink_f.end());
+  auto sink32 = to_f32(sink);
+  auto ref =
+    softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, &sink32);
+
+  nntrainer::softmax_row_inplace(qk.data(), start_row, end_row, num_heads,
+                                 sink.data());
+
+  for (size_t i = 0; i < qk.size(); i++)
+    EXPECT_NEAR(ref[i], static_cast<float>(qk[i]), 5e-3f);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     compute_softmax_row_inplace_fp32sink_x86) {
+  size_t start_row = 0, end_row = 2, num_heads = 10;
+  auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
+  auto sink32 = generate_random_vector<float>(num_heads, -8.0f, 8.0f);
+  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
+  auto ref =
+    softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, &sink32);
+
+  nntrainer::softmax_row_inplace(qk.data(), start_row, end_row, num_heads,
+                                 sink32.data());
+
+  for (size_t i = 0; i < qk.size(); i++)
+    EXPECT_NEAR(ref[i], static_cast<float>(qk[i]), 5e-3f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, compute_kcaches_fp16_x86) {
+  int num_rows = 5, N = 2, head_dim = 10, gqa = 4, tile_size = 16;
+  auto in_f = generate_random_vector<float>(N * gqa * head_dim, -1.0f, 1.0f);
+  auto kc_f =
+    generate_random_vector<float>(num_rows * N * head_dim, -1.0f, 1.0f);
+  std::vector<_FP16> in(in_f.begin(), in_f.end());
+  std::vector<_FP16> kcache(kc_f.begin(), kc_f.end());
+  std::vector<_FP16> output((size_t)num_rows * N * gqa, (_FP16)0.0f);
+  auto inq = to_f32(in), kcq = to_f32(kcache);
+
+  nntrainer::compute_kcaches(in.data(), kcache.data(), output.data(), num_rows,
+                             N, head_dim, gqa, tile_size);
+
+  const float scale = 1.0f / std::sqrt((float)head_dim);
+  for (int row = 0; row < num_rows; ++row)
+    for (int n = 0; n < N; ++n)
+      for (int g = 0; g < gqa; ++g) {
+        float sum = 0.0f;
+        for (int i = 0; i < head_dim; ++i)
+          sum += inq[(n * gqa + g) * head_dim + i] *
+                 kcq[(row * N + n) * head_dim + i];
+        float ref = sum * scale;
+        float got = static_cast<float>(output[row * N * gqa + n * gqa + g]);
+        EXPECT_NEAR(ref, got, 5e-3f);
+      }
+}
+
+TEST(nntrainer_cpu_backend_standalone, compute_fp16vcache_transposed_fp16_x86) {
+  int row_num = 3, N = 2, gqa = 2, head_dim = 9;
+  int rows = row_num + 1;
+  auto in_f = generate_random_vector<float>(rows * gqa * N, -1.0f, 1.0f);
+  auto vc_f = generate_random_vector<float>(rows * N * head_dim, -1.0f, 1.0f);
+  std::vector<_FP16> in(in_f.begin(), in_f.end());
+  std::vector<_FP16> vcache(vc_f.begin(), vc_f.end());
+  std::vector<_FP16> output((size_t)N * gqa * head_dim, (_FP16)0.0f);
+  auto inq = to_f32(in), vcq = to_f32(vcache);
+
+  nntrainer::compute_fp16vcache_transposed(row_num, in.data(), vcache.data(),
+                                           output.data(), N, gqa, head_dim);
+
+  for (int n = 0; n < N; ++n)
+    for (int h = 0; h < gqa; ++h)
+      for (int d = 0; d < head_dim; ++d) {
+        float acc = 0.0f;
+        for (int j = 0; j <= row_num; ++j)
+          acc +=
+            inq[j * gqa * N + n * gqa + h] * vcq[(j * N + n) * head_dim + d];
+        float got = static_cast<float>(output[(n * gqa + h) * head_dim + d]);
+        EXPECT_NEAR(acc, got, 5e-3f);
+      }
+}
+#endif
+
 static void run_clamp_test(const unsigned int N, float lower_bound,
                            float upper_bound, bool print = false) {
   const int TEST_CNT = 20;

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1283,14 +1283,26 @@ static std::vector<float> softmax_row_ref(const std::vector<float> &qk,
 }
 
 static std::vector<float> to_f32(const std::vector<_FP16> &v) {
-  return std::vector<float>(v.begin(), v.end());
+  std::vector<float> out;
+  out.reserve(v.size());
+  for (_FP16 x : v)
+    out.push_back(static_cast<float>(x));
+  return out;
+}
+
+static std::vector<_FP16> to_f16(const std::vector<float> &v) {
+  std::vector<_FP16> out;
+  out.reserve(v.size());
+  for (float x : v)
+    out.push_back(static_cast<_FP16>(x));
+  return out;
 }
 } // namespace
 
 TEST(nntrainer_cpu_backend_standalone, compute_softmax_row_inplace_fp16_x86) {
   size_t start_row = 0, end_row = 3, num_heads = 10;
   auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
-  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
+  std::vector<_FP16> qk = to_f16(qk_f);
   auto ref =
     softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, nullptr);
 
@@ -1305,8 +1317,8 @@ TEST(nntrainer_cpu_backend_standalone,
   size_t start_row = 0, end_row = 2, num_heads = 10;
   auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
   auto sink_f = generate_random_vector<float>(num_heads, -8.0f, 8.0f);
-  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
-  std::vector<_FP16> sink(sink_f.begin(), sink_f.end());
+  std::vector<_FP16> qk = to_f16(qk_f);
+  std::vector<_FP16> sink = to_f16(sink_f);
   auto sink32 = to_f32(sink);
   auto ref =
     softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, &sink32);
@@ -1323,7 +1335,7 @@ TEST(nntrainer_cpu_backend_standalone,
   size_t start_row = 0, end_row = 2, num_heads = 10;
   auto qk_f = generate_random_vector<float>(num_heads * end_row, -8.0f, 8.0f);
   auto sink32 = generate_random_vector<float>(num_heads, -8.0f, 8.0f);
-  std::vector<_FP16> qk(qk_f.begin(), qk_f.end());
+  std::vector<_FP16> qk = to_f16(qk_f);
   auto ref =
     softmax_row_ref(to_f32(qk), start_row, end_row, num_heads, &sink32);
 
@@ -1334,13 +1346,54 @@ TEST(nntrainer_cpu_backend_standalone,
     EXPECT_NEAR(ref[i], static_cast<float>(qk[i]), 5e-3f);
 }
 
+TEST(nntrainer_cpu_backend_standalone,
+     compute_fp16vcache_fp32_transposed_x86_rem0_local_window_head_slice) {
+  int row_num = 5, N = 3, gqa = 4, head_dim = 64;
+  size_t local_window_size = 3;
+  int head_start = 1, head_end = 2;
+  int input_rows = static_cast<int>(local_window_size);
+  int cache_rows = row_num + 1;
+  int cache_start = row_num + 1 - input_rows;
+  auto in = generate_random_vector<float>(input_rows * gqa * N, -1.0f, 1.0f);
+  auto vc_f =
+    generate_random_vector<float>(cache_rows * N * head_dim, -1.0f, 1.0f);
+  std::vector<uint16_t> vcache = convert_vector_f32_to_f16_as_uint16(vc_f);
+  auto vcq = convert_vector_f16_as_uint16_to_f32(vcache);
+  std::vector<float> output((size_t)N * gqa * head_dim, -77.0f);
+
+  nntrainer::compute_fp16vcache_fp32_transposed(
+    row_num, in.data(), vcache.data(), output.data(), N, gqa, head_dim,
+    local_window_size, head_start, head_end);
+
+  for (int n = head_start; n < head_end; ++n)
+    for (int h = 0; h < gqa; ++h)
+      for (int d = 0; d < head_dim; ++d) {
+        float acc = 0.0f;
+        for (int local_j = 0; local_j < input_rows; ++local_j) {
+          int cache_j = cache_start + local_j;
+          acc += in[local_j * gqa * N + n * gqa + h] *
+                 vcq[(cache_j * N + n) * head_dim + d];
+        }
+        size_t out_idx = ((size_t)n * gqa + h) * head_dim + d;
+        EXPECT_NEAR(acc, output[out_idx], 1e-4f);
+      }
+
+  for (int n = 0; n < N; ++n)
+    if (n < head_start || n >= head_end)
+      for (int h = 0; h < gqa; ++h)
+        for (int d = 0; d < head_dim; ++d) {
+          size_t out_idx = ((size_t)n * gqa + h) * head_dim + d;
+          EXPECT_EQ(output[out_idx], -77.0f);
+        }
+}
+
 TEST(nntrainer_cpu_backend_standalone, compute_kcaches_fp16_x86) {
   int num_rows = 5, N = 2, head_dim = 10, gqa = 4, tile_size = 16;
   auto in_f = generate_random_vector<float>(N * gqa * head_dim, -1.0f, 1.0f);
   auto kc_f =
     generate_random_vector<float>(num_rows * N * head_dim, -1.0f, 1.0f);
-  std::vector<_FP16> in(in_f.begin(), in_f.end());
-  std::vector<_FP16> kcache(kc_f.begin(), kc_f.end());
+  std::vector<_FP16> in = to_f16(in_f);
+  std::vector<_FP16> kcache = to_f16(kc_f);
   std::vector<_FP16> output((size_t)num_rows * N * gqa, (_FP16)0.0f);
   auto inq = to_f32(in), kcq = to_f32(kcache);
 
@@ -1361,13 +1414,54 @@ TEST(nntrainer_cpu_backend_standalone, compute_kcaches_fp16_x86) {
       }
 }
 
+TEST(nntrainer_cpu_backend_standalone,
+     compute_kcaches_fp16_x86_rem0_local_window_head_slice) {
+  int num_rows = 6, N = 3, head_dim = 64, gqa = 4, tile_size = 4;
+  size_t local_window_size = 3;
+  int head_start = 1, head_end = 2;
+  int start_row = num_rows - static_cast<int>(local_window_size);
+  int row_cnt = static_cast<int>(local_window_size);
+  auto in_f = generate_random_vector<float>(N * gqa * head_dim, -1.0f, 1.0f);
+  auto kc_f =
+    generate_random_vector<float>(num_rows * N * head_dim, -1.0f, 1.0f);
+  std::vector<_FP16> in = to_f16(in_f);
+  std::vector<_FP16> kcache = to_f16(kc_f);
+  std::vector<_FP16> output((size_t)row_cnt * N * gqa, (_FP16)-77.0f);
+  auto inq = to_f32(in), kcq = to_f32(kcache);
+
+  nntrainer::compute_kcaches(in.data(), kcache.data(), output.data(), num_rows,
+                             N, head_dim, gqa, tile_size, local_window_size,
+                             head_start, head_end);
+
+  const float scale = 1.0f / std::sqrt((float)head_dim);
+  for (int row = start_row; row < num_rows; ++row)
+    for (int n = head_start; n < head_end; ++n)
+      for (int g = 0; g < gqa; ++g) {
+        float sum = 0.0f;
+        for (int i = 0; i < head_dim; ++i)
+          sum += inq[(n * gqa + g) * head_dim + i] *
+                 kcq[(row * N + n) * head_dim + i];
+        size_t out_idx =
+          (size_t)(row - start_row) * N * gqa + (size_t)n * gqa + g;
+        EXPECT_NEAR(sum * scale, static_cast<float>(output[out_idx]), 5e-3f);
+      }
+
+  for (int row = 0; row < row_cnt; ++row)
+    for (int n = 0; n < N; ++n)
+      if (n < head_start || n >= head_end)
+        for (int g = 0; g < gqa; ++g) {
+          size_t out_idx = (size_t)row * N * gqa + (size_t)n * gqa + g;
+          EXPECT_EQ(static_cast<float>(output[out_idx]), -77.0f);
+        }
+}
+
 TEST(nntrainer_cpu_backend_standalone, compute_fp16vcache_transposed_fp16_x86) {
   int row_num = 3, N = 2, gqa = 2, head_dim = 9;
   int rows = row_num + 1;
   auto in_f = generate_random_vector<float>(rows * gqa * N, -1.0f, 1.0f);
   auto vc_f = generate_random_vector<float>(rows * N * head_dim, -1.0f, 1.0f);
-  std::vector<_FP16> in(in_f.begin(), in_f.end());
-  std::vector<_FP16> vcache(vc_f.begin(), vc_f.end());
+  std::vector<_FP16> in = to_f16(in_f);
+  std::vector<_FP16> vcache = to_f16(vc_f);
   std::vector<_FP16> output((size_t)N * gqa * head_dim, (_FP16)0.0f);
   auto inq = to_f32(in), vcq = to_f32(vcache);
 
@@ -1384,6 +1478,48 @@ TEST(nntrainer_cpu_backend_standalone, compute_fp16vcache_transposed_fp16_x86) {
         float got = static_cast<float>(output[(n * gqa + h) * head_dim + d]);
         EXPECT_NEAR(acc, got, 5e-3f);
       }
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     compute_fp16vcache_transposed_fp16_x86_rem0_local_window_head_slice) {
+  int row_num = 5, N = 3, gqa = 4, head_dim = 64;
+  size_t local_window_size = 3;
+  int head_start = 1, head_end = 2;
+  int input_rows = static_cast<int>(local_window_size);
+  int cache_rows = row_num + 1;
+  int cache_start = row_num + 1 - input_rows;
+  auto in_f = generate_random_vector<float>(input_rows * gqa * N, -1.0f, 1.0f);
+  auto vc_f =
+    generate_random_vector<float>(cache_rows * N * head_dim, -1.0f, 1.0f);
+  std::vector<_FP16> in = to_f16(in_f);
+  std::vector<_FP16> vcache = to_f16(vc_f);
+  std::vector<_FP16> output((size_t)N * gqa * head_dim, (_FP16)-77.0f);
+  auto inq = to_f32(in), vcq = to_f32(vcache);
+
+  nntrainer::compute_fp16vcache_transposed(
+    row_num, in.data(), vcache.data(), output.data(), N, gqa, head_dim,
+    local_window_size, head_start, head_end);
+
+  for (int n = head_start; n < head_end; ++n)
+    for (int h = 0; h < gqa; ++h)
+      for (int d = 0; d < head_dim; ++d) {
+        float acc = 0.0f;
+        for (int local_j = 0; local_j < input_rows; ++local_j) {
+          int cache_j = cache_start + local_j;
+          acc += inq[local_j * gqa * N + n * gqa + h] *
+                 vcq[(cache_j * N + n) * head_dim + d];
+        }
+        size_t out_idx = ((size_t)n * gqa + h) * head_dim + d;
+        EXPECT_NEAR(acc, static_cast<float>(output[out_idx]), 5e-3f);
+      }
+
+  for (int n = 0; n < N; ++n)
+    if (n < head_start || n >= head_end)
+      for (int h = 0; h < gqa; ++h)
+        for (int d = 0; d < head_dim; ++d) {
+          size_t out_idx = ((size_t)n * gqa + h) * head_dim + d;
+          EXPECT_EQ(static_cast<float>(output[out_idx]), -77.0f);
+        }
 }
 #endif
 

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -15,6 +15,7 @@
 #include <fallback_internal.h>
 #include <fp16.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -2143,6 +2144,80 @@ TEST(nntrainer_cpu_backend_standalone, scopy_fp16_5) {
   }
 }
 
+TEST(nntrainer_cpu_backend_standalone, scopy_float_to_fp16_contiguous) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y(N, (_FP16)0);
+    std::vector<_FP16> Y_ref(N, (_FP16)0);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_to_float_contiguous) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<float> Y(N, 0.0F);
+    std::vector<float> Y_ref(N, 0.0F);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(Y[j], Y_ref[j]);
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_float_to_fp16_stride) {
+  const unsigned int N = 257;
+  const unsigned int incX = 2;
+  const unsigned int incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>(N * incX, -2.0f, 2.0f);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N * incY);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_scopy(N, X.data(), incX, Y_ref.data(), incY);
+    nntrainer::scopy(N, X.data(), incX, Y.data(), incY);
+
+    for (unsigned int j = 0; j < N * incY; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_to_float_stride) {
+  const unsigned int N = 257;
+  const unsigned int incX = 2;
+  const unsigned int incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<float> Y =
+      generate_random_vector<float, false>(N * incY, -2.0f, 2.0f);
+    std::vector<float> Y_ref = Y;
+
+    nntrainer::__fallback_scopy(N, X.data(), incX, Y_ref.data(), incY);
+    nntrainer::scopy(N, X.data(), incX, Y.data(), incY);
+
+    for (unsigned int j = 0; j < N * incY; j++) {
+      ASSERT_EQ(Y[j], Y_ref[j]);
+    }
+  }
+}
+
 TEST(nntrainer_cpu_backend_standalone, max_val_fp16_3072) {
   const unsigned int N = 3072;
   const int TEST_CNT = 20;
@@ -2384,6 +2459,28 @@ TEST(nntrainer_cpu_backend_standalone, isamax_fp16_5) {
   }
 }
 
+TEST(nntrainer_cpu_backend_standalone, is_valid_fp16_finite_and_nonfinite) {
+  std::vector<_FP16> finite = {(_FP16)0.0F, (_FP16)-1.0F, (_FP16)0.5F,
+                               (_FP16)2.0F, (_FP16)-3.0F};
+  EXPECT_TRUE(nntrainer::is_valid(static_cast<unsigned int>(finite.size()),
+                                  finite.data()));
+
+  std::vector<_FP16> with_nan = finite;
+  with_nan[2] = static_cast<_FP16>(std::numeric_limits<float>::quiet_NaN());
+  EXPECT_FALSE(nntrainer::is_valid(static_cast<unsigned int>(with_nan.size()),
+                                   with_nan.data()));
+
+  std::vector<_FP16> with_pos_inf = finite;
+  with_pos_inf[1] = static_cast<_FP16>(std::numeric_limits<float>::infinity());
+  EXPECT_FALSE(nntrainer::is_valid(
+    static_cast<unsigned int>(with_pos_inf.size()), with_pos_inf.data()));
+
+  std::vector<_FP16> with_neg_inf = finite;
+  with_neg_inf[3] = static_cast<_FP16>(-std::numeric_limits<float>::infinity());
+  EXPECT_FALSE(nntrainer::is_valid(
+    static_cast<unsigned int>(with_neg_inf.size()), with_neg_inf.data()));
+}
+
 TEST(nntrainer_cpu_backend_standalone, transpose_matrix_fp16) {
   const unsigned int M = 32;
   const unsigned int N = 64;
@@ -2482,6 +2579,75 @@ TEST(nntrainer_cpu_backend_standalone, scopy_int4_to_fp16) {
       ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
     }
   }
+}
+
+/// Exercises padded leading dimensions (lda > tight, ldb > tight, ldc > N) on
+/// the FP16 sgemm path. Each row of A / B / C is laid out with a gap; the gap
+/// bytes are touched by neither the FP32 reference nor the FP16 SUT, so the
+/// comparison window stays at [0..M, 0..N]. This guards against the regression
+/// where x86::hgemm recomputes strides from (M, N, K) instead of honoring the
+/// caller's lda/ldb/ldc.
+static void run_sgemm_fp16_strided_lda_test(unsigned int M, unsigned int N,
+                                            unsigned int K, bool TransA,
+                                            bool TransB, float alpha,
+                                            float beta, unsigned int lda_extra,
+                                            unsigned int ldb_extra,
+                                            unsigned int ldc_extra) {
+  nntrainer::init_backend();
+
+  const unsigned int lda = (TransA ? M : K) + lda_extra;
+  const unsigned int ldb = (TransB ? K : N) + ldb_extra;
+  const unsigned int ldc = N + ldc_extra;
+  const std::size_t a_size = static_cast<std::size_t>(TransA ? K : M) * lda;
+  const std::size_t b_size = static_cast<std::size_t>(TransB ? N : K) * ldb;
+  const std::size_t c_size = static_cast<std::size_t>(M) * ldc;
+
+  auto A_fp16 = generate_random_vector<_FP16>(a_size);
+  auto B_fp16 = generate_random_vector<_FP16>(b_size);
+  auto C_fp16 = generate_random_vector<_FP16>(c_size);
+
+  std::vector<float> A_fp32(a_size);
+  std::vector<float> B_fp32(b_size);
+  std::vector<float> C_fp32_ref(c_size);
+  nntrainer::scopy(a_size, A_fp16.data(), 1, A_fp32.data(), 1);
+  nntrainer::scopy(b_size, B_fp16.data(), 1, B_fp32.data(), 1);
+  nntrainer::scopy(c_size, C_fp16.data(), 1, C_fp32_ref.data(), 1);
+
+  nntrainer::sgemm(0, TransA, TransB, M, N, K, alpha, A_fp32.data(), lda,
+                   B_fp32.data(), ldb, beta, C_fp32_ref.data(), ldc);
+  nntrainer::sgemm(0, TransA, TransB, M, N, K, alpha, A_fp16.data(), lda,
+                   B_fp16.data(), ldb, beta, C_fp16.data(), ldc);
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t i = static_cast<std::size_t>(m) * ldc + n;
+      float got = static_cast<float>(C_fp16[i]);
+      float ref = C_fp32_ref[i];
+      EXPECT_NEAR(got, ref, 0.01f * (std::abs(ref) + 1.0f))
+        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
+        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
+        << " alpha=" << alpha << " beta=" << beta << " lda=" << lda
+        << " ldb=" << ldb << " ldc=" << ldc;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_noTrans_strided_lda_ldb_ldc_13x33x65) {
+  run_sgemm_fp16_strided_lda_test(13, 33, 65, false, false, 1.0F, 0.0F, 4, 7,
+                                  5);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_transA_strided_lda_ldb_ldc_13x33x65) {
+  run_sgemm_fp16_strided_lda_test(13, 33, 65, true, false, 0.75F, -0.25F, 3, 8,
+                                  4);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_transB_strided_lda_ldb_ldc_13x33x65) {
+  run_sgemm_fp16_strided_lda_test(13, 33, 65, false, true, -0.5F, 0.125F, 6, 2,
+                                  1);
 }
 
 #endif // ENABLE_FP16

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1746,6 +1746,751 @@ TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_template_float) {
        "separate PR)";
 }
 
+// ============================================================================
+// P2: AVX2+F16C replacement tests for formerly-fallback FP16 functions
+// ============================================================================
+#ifdef ENABLE_FP16
+
+static void run_ele_mul_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_mul(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_mul(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_istr_0) {
+  run_ele_mul_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_istr_1) {
+  run_ele_mul_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_7_istr_1) {
+  run_ele_mul_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_alpha_beta) {
+  run_ele_mul_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_alpha_beta_istr_0) {
+  run_ele_mul_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_ostr_2) {
+  run_ele_mul_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_add_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_add(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_add(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_istr_0) {
+  run_ele_add_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_istr_1) {
+  run_ele_add_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_7_istr_1) {
+  run_ele_add_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_alpha_beta) {
+  run_ele_add_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_alpha_beta_istr_0) {
+  run_ele_add_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_ostr_2) {
+  run_ele_add_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_sub_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_sub(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_sub(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_istr_0) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_istr_1) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_alpha1_beta0_istr_2) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 2, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_alpha_beta) {
+  run_ele_sub_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_alpha_beta_istr_0) {
+  run_ele_sub_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_7_istr_1) {
+  run_ele_sub_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_ostr_2) {
+  run_ele_sub_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_div_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride), 0.1f, 1.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_div(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_div(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_istr_0) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_istr_1) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_alpha1_beta0_istr_2) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 2, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_alpha_beta) {
+  run_ele_div_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_alpha_beta_istr_0) {
+  run_ele_div_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_7_istr_1) {
+  run_ele_div_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_ostr_2) {
+  run_ele_div_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_3072) {
+  const unsigned int N = 3072;
+  const float alpha = 2.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::saxpy(N, alpha, X.data(), 1, Y.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_7) {
+  const unsigned int N = 7;
+  const float alpha = 1.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::saxpy(N, alpha, X.data(), 1, Y.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_stride) {
+  const unsigned int N = 512;
+  const float alpha = 2.0f;
+  const unsigned int incX = 2, incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N * incY);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), incX, Y_ref.data(), incY);
+    nntrainer::saxpy(N, alpha, X.data(), incX, Y.data(), incY);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N * incY);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), 1, Y.data(), 1);
+    _FP16 result = nntrainer::sdot(N, X.data(), 1, Y.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), 1, Y.data(), 1);
+    _FP16 result = nntrainer::sdot(N, X.data(), 1, Y.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.01f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_stride) {
+  const unsigned int N = 512;
+  const unsigned int incX = 2, incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N * incY);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), incX, Y.data(), incY);
+    _FP16 result = nntrainer::sdot(N, X.data(), incX, Y.data(), incY);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), 1);
+    _FP16 result = nntrainer::snrm2(N, X.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), 1);
+    _FP16 result = nntrainer::snrm2(N, X.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.01f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_stride) {
+  const unsigned int N = 512;
+  const unsigned int incX = 2;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), incX);
+    _FP16 result = nntrainer::snrm2(N, X.data(), incX);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_3072) {
+  const unsigned int N = 3072;
+  const float alpha = 2.0f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), 1);
+    nntrainer::sscal(N, alpha, X.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_5) {
+  const unsigned int N = 5;
+  const float alpha = 3.0f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), 1);
+    nntrainer::sscal(N, alpha, X.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_stride) {
+  const unsigned int N = 512;
+  const float alpha = 2.0f;
+  const unsigned int incX = 2;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), incX);
+    nntrainer::sscal(N, alpha, X.data(), incX);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N * incX);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N, (_FP16)0);
+    std::vector<_FP16> Y_ref(N, (_FP16)0);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N, (_FP16)0);
+    std::vector<_FP16> Y_ref(N, (_FP16)0);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_max(N, X.data());
+    _FP16 result = nntrainer::max_val(N, X.data());
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_max(N, X.data());
+    _FP16 result = nntrainer::max_val(N, X.data());
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>(N, 0.01f, 10.0f);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_fp16_with_zeros) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>(N, 0.01f, 10.0f);
+    X[0] = (_FP16)0.0f;
+    X[7] = (_FP16)0.0f;
+    X[8] = (_FP16)0.0f;
+    X[N / 2] = (_FP16)0.0f;
+    X[N - 1] = (_FP16)0.0f;
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    for (unsigned int j = 0; j < N; j++) {
+      if (std::isinf(static_cast<float>(X_ref[j]))) {
+        ASSERT_TRUE(std::isinf(static_cast<float>(X[j])))
+          << "Expected inf at index " << j << ", got "
+          << static_cast<float>(X[j]);
+      } else {
+        ASSERT_FALSE(std::isnan(static_cast<float>(X[j])))
+          << "Unexpected NaN at index " << j;
+        ASSERT_NEAR(static_cast<float>(X[j]), static_cast<float>(X_ref[j]),
+                    0.01f);
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X(N), X_ref(N);
+    std::vector<_FP16> Y =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y_ref = Y, Z_ref = Z;
+
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X(N), X_ref(N);
+    std::vector<_FP16> Y =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y_ref = Y, Z_ref = Z;
+
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+static void run_rms_norm_fp16_test(size_t H, size_t W) {
+  const float epsilon = 1e-6f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(H * W);
+    std::vector<_FP16> Y(H * W);
+    std::vector<float> Y_ref(H * W);
+
+    // Compute reference in FP32
+    for (size_t h = 0; h < H; h++) {
+      float sum_sq = 0.0f;
+      for (size_t w = 0; w < W; w++) {
+        float val = static_cast<float>(X[h * W + w]);
+        sum_sq += val * val;
+      }
+      float scale = 1.0f / std::sqrt(sum_sq / W + epsilon);
+      for (size_t w = 0; w < W; w++) {
+        Y_ref[h * W + w] = static_cast<float>(X[h * W + w]) * scale;
+      }
+    }
+
+    nntrainer::rms_norm_wrt_width_fp16_intrinsic<_FP16>(X.data(), Y.data(), H,
+                                                        W, epsilon);
+
+    auto mse_val = mse<_FP16, float>(Y.data(), Y_ref.data(), H * W);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_3072) {
+  run_rms_norm_fp16_test(4, 3072);
+}
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_13) {
+  run_rms_norm_fp16_test(4, 13);
+}
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_100) {
+  run_rms_norm_fp16_test(4, 100);
+}
+
+static void run_rotary_emb_fp16_test(unsigned int dim, unsigned int half_) {
+  const unsigned int w = 0;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> in =
+      generate_random_vector<_FP16, false>(dim, -1.0f, 1.0f);
+    std::vector<float> cos_half =
+      generate_random_vector<float, false>(half_, -1.0f, 1.0f);
+    std::vector<float> sin_half =
+      generate_random_vector<float, false>(half_, -1.0f, 1.0f);
+    std::vector<float> cos_v(dim), sin_v(dim);
+    for (unsigned int k = 0; k < half_; k++) {
+      cos_v[k] = cos_half[k];
+      cos_v[k + half_] = cos_half[k];
+      sin_v[k] = sin_half[k];
+      sin_v[k + half_] = sin_half[k];
+    }
+    std::vector<_FP16> out(dim), out_ref(dim);
+
+    nntrainer::__fallback_compute_rotary_embedding_value(
+      dim, half_, w, in.data(), out_ref.data(), cos_v.data(), sin_v.data());
+    nntrainer::compute_rotary_embedding_value(dim, half_, w, in.data(),
+                                              out.data(), cos_v.data(),
+                                              sin_v.data());
+
+    auto mse_val = mse<_FP16, _FP16>(out_ref.data(), out.data(), dim);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_avx2) {
+  run_rotary_emb_fp16_test(64, 32);
+}
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_non_aligned) {
+  run_rotary_emb_fp16_test(26, 13);
+}
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_128) {
+  run_rotary_emb_fp16_test(128, 64);
+}
+
+TEST(nntrainer_cpu_backend_standalone, isamax_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    unsigned int ref = nntrainer::__fallback_isamax(N, X.data(), 1);
+    unsigned int result = nntrainer::isamax(N, X.data(), 1);
+
+    ASSERT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, isamax_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    unsigned int ref = nntrainer::__fallback_isamax(N, X.data(), 1);
+    unsigned int result = nntrainer::isamax(N, X.data(), 1);
+
+    ASSERT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, transpose_matrix_fp16) {
+  const unsigned int M = 32;
+  const unsigned int N = 64;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> src = generate_random_vector<_FP16, false>(M * N);
+    std::vector<_FP16> dst(M * N), dst_ref(M * N);
+
+    nntrainer::__fallback_transpose_matrix(M, N, src.data(), N, dst_ref.data(),
+                                           M);
+    nntrainer::transpose_matrix(M, N, src.data(), N, dst.data(), M);
+
+    for (unsigned int j = 0; j < M * N; j++) {
+      ASSERT_EQ(static_cast<float>(dst[j]), static_cast<float>(dst_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, transpose_matrix_fp16_small) {
+  const unsigned int M = 3;
+  const unsigned int N = 5;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> src = generate_random_vector<_FP16, false>(M * N);
+    std::vector<_FP16> dst(M * N), dst_ref(M * N);
+
+    nntrainer::__fallback_transpose_matrix(M, N, src.data(), N, dst_ref.data(),
+                                           M);
+    nntrainer::transpose_matrix(M, N, src.data(), N, dst.data(), M);
+
+    for (unsigned int j = 0; j < M * N; j++) {
+      ASSERT_EQ(static_cast<float>(dst[j]), static_cast<float>(dst_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int8_to_fp16_uint8) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<uint8_t> X(N);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto &v : X)
+      v = static_cast<uint8_t>(dist(gen));
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_scopy_int8_to_float16(N, X.data(), 1, Y_ref.data(),
+                                                1);
+    nntrainer::scopy_int8_to_float16(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int8_to_fp16_int8) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<int8_t> X(N);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(-128, 127);
+    for (auto &v : X)
+      v = static_cast<int8_t>(dist(gen));
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_scopy_int8_to_float16(N, X.data(), 1, Y_ref.data(),
+                                                1);
+    nntrainer::scopy_int8_to_float16(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int4_to_fp16) {
+  const unsigned int N_bytes = 1536;
+  const unsigned int N_out = 2 * N_bytes;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<uint8_t> X(N_bytes);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto &v : X)
+      v = static_cast<uint8_t>(dist(gen));
+    std::vector<_FP16> Y(N_out), Y_ref(N_out);
+
+    nntrainer::__fallback_scopy_int4_to_float16(N_bytes, X.data(), 1,
+                                                Y_ref.data(), 1);
+    nntrainer::scopy_int4_to_float16(N_bytes, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N_out; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+#endif // ENABLE_FP16
+
 int main(int argc, char **argv) {
   int result = -1;
 

--- a/test/unittest/unittest_nntrainer_cpu_backend_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend_fp16.cpp
@@ -9,15 +9,29 @@
  */
 
 #include "int4_utils.h"
+#ifdef __ANDROID__
+// KleidiAI interface is only wired in via Android.mk; on Linux/meson the
+// header (and its qsi8d32p/qsi4c32p backend) is unavailable.
 #include "kleidiai_interface.h"
+#endif
 #include "nntrainer_test_util.h"
+#if defined(ENABLE_TEST) && (defined(__x86_64__) || defined(_M_X64))
+#include <hgemm_common.h>
+#include <hgemm_pack.h>
+#include <hgemm_test.h>
+#define X86_HGEMM_WORKSPACE_STATS_AVAILABLE 1
+#endif
+#include <algorithm>
 #include <cfloat>
+#include <cmath>
 #include <cpu_backend.h>
 #include <fallback_internal.h>
 #include <gtest/gtest.h>
 #include <numeric>
 #include <random>
+#include <string>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include <chrono>
@@ -174,16 +188,14 @@ void run_quant_test_fp16(const uint32_t M, const uint32_t K, const uint32_t N,
 
   // GROUND TRUTH TRANSB SGEMM for reference
   auto t1 = high_resolution_clock::now();
-  for (int tc = 0; tc < 20; ++tc) {
-    nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
-                     weight_fp16.data(), K, 0.F, ref_dst.data(), N);
-  }
+  nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
+                   weight_fp16.data(), K, 0.F, ref_dst.data(), N);
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] hgemm :    " << dt.count() / 20 << " ns "
-              << dt.count() / 20 / 1'000 << " us "
-              << dt.count() / 20 / 1'000'000 << " ms " << std::endl;
+    std::cout << "[INFO] hgemm :    " << dt.count() << " ns "
+              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
+              << " ms " << std::endl;
   }
   q4_0_mse = test_gemm_q4_0_fp16(M, K, N, weight.data(), activation.data(),
                                  ref_dst, print);
@@ -202,10 +214,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x1024x1024) {
   const unsigned int M = 457;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 1024;
+  const unsigned int N = 1024;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -213,10 +225,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x1024x1024) {
   const unsigned int M = 458;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 1024;
+  const unsigned int N = 1024;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -224,10 +236,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x1024x1024) {
   const unsigned int M = 459;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 1024;
+  const unsigned int N = 1024;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -235,10 +247,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1024x1024) {
   const unsigned int M = 1024;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 1024;
+  const unsigned int N = 1024;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -257,10 +269,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1024x1024) {
   const unsigned int M = 1;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 1024;
+  const unsigned int N = 1024;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -268,6 +280,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
+#ifdef __ANDROID__
+// nntrainer::sine / cosine have no _FP16 instantiation in the x86 backend
+// (FP32-only). The helper and TEST below stay Android-only until the x86
+// backend grows an FP16 sine/cosine path.
 static void run_trigonometric_values_test(const unsigned int N,
                                           bool print = false) {
   const int TEST_CNT = 20;
@@ -668,6 +684,11 @@ TEST(nntrainer_cpu_backend_standalone, qai8dxp_qsi4cxp_3072x512x512_CMP) {
   ASSERT_LE(qai8dxp_qsi4cxp_mse_packed, eps * M * K * N);
 }
 
+#ifdef __ANDROID__
+// The qsi8d32p_qsi4c32p path is only exposed on Android via KleidiAI; the
+// x86 cpu_backend does not provide nntr_quant_qs4c32_f32 /
+// nntr_*_qsi8d32p_qsi4c32p_*, so these helpers and TESTs are excluded on
+// Linux/meson builds.
 std::tuple<float, uint32_t> test_gemm_qsi8d32p_qsi4c32p_unpacked(
   const uint32_t M, const uint32_t K, const uint32_t N, const float *weights,
   const float *activations, std::vector<float> &ref_dst, bool transB = true,
@@ -1058,13 +1079,19 @@ DECLARE_transform_osv32_to_qsi4c32p_test(512, 256);
 DECLARE_transform_osv32_to_qsi4c32p_test(512, 512);
 DECLARE_transform_osv32_to_qsi4c32p_test(1024, 512);
 DECLARE_transform_osv32_to_qsi4c32p_test(1024, 1024);
+#endif // __ANDROID__ (end of qsi8d32p_qsi4c32p region)
 
 TEST(nntrainer_cpu_backend_standalone, trigonometric_values_test) {
 
   const unsigned int N = 3072;
   run_trigonometric_values_test(N);
 }
+#endif // __ANDROID__ (end of trigonometric_values_test region)
 
+#ifdef __ANDROID__
+// gemm_benchmark_comparison mixes the qai8dxp path (x86-available) with the
+// qsi8d32p path (KleidiAI-only); both are needed for the three-way comparison,
+// so the whole benchmark is gated to Android.
 /**
  * @brief Benchmark comparison of three GEMM implementations
  *
@@ -1271,6 +1298,953 @@ TEST(nntrainer_cpu_backend_standalone, gemm_benchmark_comparison_32x1024x4096) {
 
 TEST(nntrainer_cpu_backend_standalone, gemm_benchmark_comparison_1x3072x512) {
   run_gemm_benchmark_comparison(1, 3072, 512);
+}
+#endif // __ANDROID__ (end of gemm_benchmark_comparison region)
+
+/// FP16 sgemm path: exercises the x86 cache-blocked GEMM.
+/// Reference is a local FP32 GEMM loop to avoid using the optimized backend as
+/// the oracle for this backend test.
+static void run_sgemm_fp16_hgemm_test(unsigned int M, unsigned int N,
+                                      unsigned int K, bool TransA = false,
+                                      bool TransB = false, float alpha = 1.0F,
+                                      float beta = 0.0F,
+                                      unsigned int lda_extra = 0,
+                                      unsigned int ldb_extra = 0,
+                                      unsigned int ldc_extra = 0) {
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
+  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
+  const unsigned int ldc = std::max(1u, N + ldc_extra);
+  const unsigned int a_rows = TransA ? K : M;
+  const unsigned int b_rows = TransB ? N : K;
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
+  const std::size_t b_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
+  const std::size_t c_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
+
+  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
+  auto B_fp16 = generate_random_vector<_FP16>(b_size, -0.25F, 0.25F);
+  auto C_fp16 = generate_random_vector<_FP16>(c_size, -0.25F, 0.25F);
+  auto C_before = C_fp16;
+
+  std::vector<float> C_fp32_ref(c_size);
+  for (std::size_t i = 0; i < c_size; ++i) {
+    C_fp32_ref[i] = static_cast<float>(C_before[i]);
+  }
+
+  if (M != 0 && N != 0) {
+    for (unsigned int m = 0; m < M; ++m) {
+      for (unsigned int n = 0; n < N; ++n) {
+        float acc = 0.0F;
+        for (unsigned int k = 0; k < K; ++k) {
+          const float a = static_cast<float>(TransA ? A_fp16[k * lda + m]
+                                                    : A_fp16[m * lda + k]);
+          const float b = static_cast<float>(TransB ? B_fp16[n * ldb + k]
+                                                    : B_fp16[k * ldb + n]);
+          acc += a * b;
+        }
+        const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+        C_fp32_ref[idx] = alpha * acc + beta * C_fp32_ref[idx];
+      }
+    }
+  }
+
+  // System under test: FP16 sgemm, routed to x86::hgemm_fp16 by the x86
+  // backend dispatcher for row-major inputs.
+  nntrainer::sgemm(0, TransA, TransB, M, N, K, alpha, A_fp16.data(), lda,
+                   B_fp16.data(), ldb, beta, C_fp16.data(), ldc);
+
+  if (M == 0 || N == 0) {
+    for (std::size_t i = 0; i < c_size; ++i) {
+      EXPECT_EQ(static_cast<float>(C_fp16[i]), static_cast<float>(C_before[i]))
+        << "zero-dimension GEMM touched C at i=" << i << " M=" << M
+        << " N=" << N << " K=" << K << " TransA=" << TransA
+        << " TransB=" << TransB;
+    }
+    return;
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      const float got = static_cast<float>(C_fp16[idx]);
+      const float ref = C_fp32_ref[idx];
+      const float abs_diff = std::abs(got - ref);
+      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+      EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
+        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
+        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
+        << " alpha=" << alpha << " beta=" << beta << " lda=" << lda
+        << " ldb=" << ldb << " ldc=" << ldc << " got=" << got << " ref=" << ref
+        << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
+    }
+
+    for (unsigned int n = N; n < ldc; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      EXPECT_EQ(static_cast<float>(C_fp16[idx]),
+                static_cast<float>(C_before[idx]))
+        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_12x32x32) {
+  run_sgemm_fp16_hgemm_test(12, 32, 32);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_256x512x128) {
+  run_sgemm_fp16_hgemm_test(256, 512, 128);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_64x64x64) {
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+}
+
+// Large shapes that exceed the 8M-FLOP parallel threshold and force the blocked
+// path's panel subdivision: square (N-subdivision) and tall-thin
+// (M-subdivision). Run the whole binary under NNTR_NUM_THREADS>1 to exercise
+// the multi-threaded panel grid.
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_square_512x512x512) {
+  run_sgemm_fp16_hgemm_test(512, 512, 512);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_tall_thin_1024x96x256) {
+  run_sgemm_fp16_hgemm_test(1024, 96, 256);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_wide_96x1024x256) {
+  run_sgemm_fp16_hgemm_test(96, 1024, 256);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_square_alpha_beta_640x384x320) {
+  run_sgemm_fp16_hgemm_test(640, 384, 320, false, false, 0.75F, 0.5F);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_transAB_384x320x512) {
+  run_sgemm_fp16_hgemm_test(384, 320, 512, true, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_7x17x33) {
+  // Exercises both M-edge (7 = 6 + 1) and N-edge (17 = 16 + 1) cleanup.
+  run_sgemm_fp16_hgemm_test(7, 17, 33);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_alpha_beta_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, -0.75F, 0.25F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transA_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, true, false, 0.5F, -0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transB_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, true, 1.25F, 0.5F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transAB_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, true, true, -1.0F, 0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_alpha_beta_boundary_cases) {
+  struct Case {
+    float alpha;
+    float beta;
+  };
+
+  const std::vector<Case> cases = {
+    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
+                 " beta=" + std::to_string(tc.beta));
+    run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, tc.alpha, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_dimension_cases) {
+  run_sgemm_fp16_hgemm_test(0, 17, 33, false, false, 1.0F, 0.0F);
+  run_sgemm_fp16_hgemm_test(7, 0, 33, false, false, 1.0F, 0.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_k_beta_cases) {
+  struct Case {
+    float beta;
+  };
+
+  const std::vector<Case> cases = {{0.0F}, {1.0F}, {-0.5F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("K=0 beta=" + std::to_string(tc.beta));
+    run_sgemm_fp16_hgemm_test(7, 17, 0, false, false, 1.0F, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_prime_size_all_transposes) {
+  struct Case {
+    bool trans_a;
+    bool trans_b;
+  };
+
+  const std::vector<Case> cases = {
+    {false, false}, {false, true}, {true, false}, {true, true}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(97, 53, 71, tc.trans_a, tc.trans_b, 0.75F,
+                              -0.25F);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_small_tile_cases) {
+  run_sgemm_fp16_hgemm_test(1, 1, 1, false, false, 1.0F, 0.0F);
+  run_sgemm_fp16_hgemm_test(5, 15, 7, false, false, 1.25F, -0.5F);
+  run_sgemm_fp16_hgemm_test(5, 15, 7, true, true, -0.75F, 1.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_fast_path_cases) {
+  run_sgemm_fp16_hgemm_test(1, 257, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(1, 257, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_small_k_notrans_large_padded) {
+  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(129, 257, 4, true, false, 0.5F, -0.125F, 2, 6, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_skinny_direct_cases) {
+  run_sgemm_fp16_hgemm_test(129, 1, 67, false, false, 1.25F, -0.5F, 5, 3, 2);
+  run_sgemm_fp16_hgemm_test(97, 2, 71, true, true, -0.75F, 0.25F, 4, 6, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_skinny_fast_path_all_transposes) {
+  struct Case {
+    unsigned int n;
+    bool trans_a;
+    bool trans_b;
+  };
+
+  const std::vector<Case> cases = {
+    {1, false, false}, {1, false, true}, {1, true, false}, {1, true, true},
+    {2, false, false}, {2, false, true}, {2, true, false}, {2, true, true}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("N=" + std::to_string(tc.n) +
+                 " TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(131, tc.n, 67, tc.trans_a, tc.trans_b, 0.75F,
+                              -0.25F, 3, 5, 7);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_transB_fast_path_cases) {
+  run_sgemm_fp16_hgemm_test(1, 257, 129, false, true, 0.75F, -0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(1, 257, 129, true, true, -0.5F, 0.125F, 2, 4, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_padded_lda_ldb_ldc_all_transposes) {
+  struct Case {
+    bool trans_a;
+    bool trans_b;
+    float alpha;
+    float beta;
+    unsigned int lda_extra;
+    unsigned int ldb_extra;
+    unsigned int ldc_extra;
+  };
+
+  const std::vector<Case> cases = {
+    {false, false, 1.0F, 0.0F, 4, 7, 5},
+    {false, true, -0.5F, 0.125F, 6, 2, 1},
+    {true, false, 0.75F, -0.25F, 3, 8, 4},
+    {true, true, -1.25F, 0.5F, 5, 3, 6},
+  };
+
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(13, 33, 65, tc.trans_a, tc.trans_b, tc.alpha,
+                              tc.beta, tc.lda_extra, tc.ldb_extra,
+                              tc.ldc_extra);
+  }
+}
+
+#ifdef X86_HGEMM_WORKSPACE_STATS_AVAILABLE
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_reuse_warmed_shape) {
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+  auto same_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(same_stats.total_realloc_count, 0u);
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(7, 17, 33);
+  auto smaller_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(smaller_stats.total_realloc_count, 0u);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_uses_c32_panel_and_packed_panels) {
+  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
+
+  const auto &block = nntrainer::avx2::internal::get_hgemm_block_sizes();
+  const unsigned int M = block.m + 1;
+  const unsigned int N = block.n + 1;
+  const unsigned int K = 5;
+
+  run_sgemm_fp16_hgemm_test(M, N, K, false, false, 0.75F, 0.25F);
+  const auto stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+
+  const auto round_up_to = [](unsigned int value, unsigned int tile) {
+    return ((value + tile - 1) / tile) * tile;
+  };
+
+  const unsigned int panel_m = std::min<unsigned int>(M, block.m);
+  const unsigned int panel_n = std::min<unsigned int>(N, block.n);
+  const unsigned int k_block = std::min<unsigned int>(K, block.k);
+  const unsigned int tile_m =
+    std::min<unsigned int>(panel_m, std::min(block.m, block.c_m));
+
+  const std::size_t expected_c32_capacity =
+    static_cast<std::size_t>(round_up_to(panel_m, X86_HGEMM_MR)) *
+    round_up_to(panel_n, X86_HGEMM_NR);
+  const std::size_t full_c32_capacity =
+    static_cast<std::size_t>(round_up_to(M, X86_HGEMM_MR)) *
+    round_up_to(N, X86_HGEMM_NR);
+  const std::size_t expected_pack_a_capacity =
+    static_cast<std::size_t>(round_up_to(tile_m, X86_HGEMM_MR)) * k_block;
+  const std::size_t expected_pack_b_capacity =
+    static_cast<std::size_t>(k_block) * round_up_to(panel_n, X86_HGEMM_NR);
+
+  EXPECT_EQ(stats.c32_capacity, expected_c32_capacity);
+  EXPECT_LT(stats.c32_capacity, full_c32_capacity);
+  EXPECT_EQ(stats.pack_a_capacity, expected_pack_a_capacity);
+  EXPECT_EQ(stats.pack_b_capacity, expected_pack_b_capacity);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes,
+            (stats.c32_capacity + stats.pack_a_capacity +
+             stats.pack_b_capacity + stats.scratch_capacity) *
+              sizeof(float));
+  EXPECT_EQ(stats.total_realloc_count,
+            stats.c32_realloc_count + stats.pack_a_realloc_count +
+              stats.pack_b_realloc_count + stats.scratch_realloc_count);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_row_fast_path_uses_scratch_only) {
+  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
+
+  const unsigned int N = 257;
+  run_sgemm_fp16_hgemm_test(1, N, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
+  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, N);
+  EXPECT_EQ(stats.c32_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
+  EXPECT_EQ(stats.scratch_realloc_count, 1u);
+  EXPECT_EQ(stats.total_realloc_count, 1u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(1, N, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
+  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, N);
+  EXPECT_EQ(stats.scratch_realloc_count, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_row_transB_fast_path_uses_scratch_only) {
+  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
+
+  const unsigned int K = 129;
+  run_sgemm_fp16_hgemm_test(1, 257, K, false, true, 0.75F, -0.25F, 3, 5, 7);
+  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, K);
+  EXPECT_EQ(stats.c32_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
+  EXPECT_EQ(stats.scratch_realloc_count, 1u);
+  EXPECT_EQ(stats.total_realloc_count, 1u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(1, 257, K, true, true, -0.5F, 0.125F, 2, 4, 3);
+  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, K);
+  EXPECT_EQ(stats.scratch_realloc_count, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_no_allocation_for_fast_small_shapes) {
+  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
+  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
+  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+
+  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
+  run_sgemm_fp16_hgemm_test(131, 2, 67, true, true, 0.75F, -0.25F, 3, 5, 7);
+  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+}
+
+template <typename SrcT> static void run_packing_B_N16_trans_test() {
+  const unsigned int K = 13;
+  const unsigned int N = X86_HGEMM_NR;
+  const unsigned int stride = K + 5;
+  auto src = generate_random_vector<SrcT>(static_cast<std::size_t>(N) * stride,
+                                          -1.0F, 1.0F);
+  std::vector<float> dst(static_cast<std::size_t>(K) * X86_HGEMM_NR, -123.0F);
+
+  nntrainer::avx2::internal::packing_B_N16_trans(K, N, src.data(), stride,
+                                                 dst.data());
+
+  for (unsigned int k = 0; k < K; ++k) {
+    for (unsigned int n = 0; n < N; ++n) {
+      EXPECT_FLOAT_EQ(
+        dst[static_cast<std::size_t>(k) * X86_HGEMM_NR + n],
+        static_cast<float>(src[static_cast<std::size_t>(n) * stride + k]))
+        << "mismatch at k=" << k << " n=" << n;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_fp16) {
+  run_packing_B_N16_trans_test<_FP16>();
+}
+
+TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_float) {
+  run_packing_B_N16_trans_test<float>();
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_no_allocation_for_degenerate_paths) {
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, 0.0F, 0.5F);
+  auto alpha_zero_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(alpha_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 33, 0, false, false, 1.0F, -0.5F);
+  auto k_zero_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(k_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(0, 33, 65, false, false, 1.0F, 0.0F);
+  auto m_zero_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(m_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 0, 65, false, false, 1.0F, 0.0F);
+  auto n_zero_stats =
+    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(n_zero_stats.total_realloc_count, 0u);
+}
+#endif
+
+/// FP16 sgemv path: exercises the x86 AVX2 hgemv kernel.
+/// Reference is a local FP32 GEMV loop to avoid using the optimized backend
+/// as the oracle for this backend test.
+static void run_sgemv_fp16_hgemv_test(unsigned int M, unsigned int N,
+                                      bool TransA = false, float alpha = 1.0F,
+                                      float beta = 0.0F,
+                                      unsigned int lda_extra = 0,
+                                      unsigned int incX = 1,
+                                      unsigned int incY = 1) {
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, N + lda_extra);
+  const unsigned int lenX = TransA ? M : N;
+  const unsigned int lenY = TransA ? N : M;
+
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
+  const std::size_t x_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
+  const std::size_t y_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
+
+  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
+  auto X_fp16 = generate_random_vector<_FP16>(x_size, -0.25F, 0.25F);
+  auto Y_fp16 = generate_random_vector<_FP16>(y_size, -0.25F, 0.25F);
+  auto Y_before = Y_fp16;
+
+  std::vector<float> Y_fp32_ref(y_size);
+  for (std::size_t i = 0; i < y_size; ++i) {
+    Y_fp32_ref[i] = static_cast<float>(Y_before[i]);
+  }
+
+  if (M != 0 && N != 0) {
+    if (!TransA) {
+      for (unsigned int i = 0; i < M; ++i) {
+        float acc = 0.0F;
+        for (unsigned int j = 0; j < N; ++j) {
+          acc += static_cast<float>(A_fp16[i * lda + j]) *
+                 static_cast<float>(X_fp16[j * incX]);
+        }
+        const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
+        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
+      }
+    } else {
+      for (unsigned int j = 0; j < N; ++j) {
+        float acc = 0.0F;
+        for (unsigned int i = 0; i < M; ++i) {
+          acc += static_cast<float>(A_fp16[i * lda + j]) *
+                 static_cast<float>(X_fp16[i * incX]);
+        }
+        const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
+        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
+      }
+    }
+  }
+
+  // System under test: FP16 sgemv, routed to x86::hgemv by the x86 backend
+  // dispatcher for row-major inputs.
+  nntrainer::sgemv(0, TransA, M, N, alpha, A_fp16.data(), lda, X_fp16.data(),
+                   incX, beta, Y_fp16.data(), incY);
+
+  if (M == 0 || N == 0) {
+    for (std::size_t i = 0; i < y_size; ++i) {
+      EXPECT_EQ(static_cast<float>(Y_fp16[i]), static_cast<float>(Y_before[i]))
+        << "zero-dimension GEMV touched Y at i=" << i << " M=" << M
+        << " N=" << N << " TransA=" << TransA;
+    }
+    return;
+  }
+
+  for (unsigned int k = 0; k < lenY; ++k) {
+    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
+    const float got = static_cast<float>(Y_fp16[y_idx]);
+    const float ref = Y_fp32_ref[y_idx];
+    const float abs_diff = std::abs(got - ref);
+    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+    EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
+      << "mismatch at k=" << k << " M=" << M << " N=" << N
+      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
+      << " lda=" << lda << " incX=" << incX << " incY=" << incY
+      << " got=" << got << " ref=" << ref << " abs_diff=" << abs_diff
+      << " rel_diff=" << rel_diff;
+  }
+
+  // Y gap slots (only present when incY > 1) must be untouched.
+  if (incY > 1) {
+    for (unsigned int k = 0; k < lenY; ++k) {
+      const std::size_t base = static_cast<std::size_t>(k) * incY;
+      for (unsigned int g = 1; g < incY; ++g) {
+        const std::size_t gap_idx = base + g;
+        if (gap_idx >= y_size) {
+          break;
+        }
+        EXPECT_EQ(static_cast<float>(Y_fp16[gap_idx]),
+                  static_cast<float>(Y_before[gap_idx]))
+          << "Y gap was modified at idx=" << gap_idx << " k=" << k << " g=" << g
+          << " incY=" << incY;
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_8x64) {
+  // N multiple of 16: 16-element main loop only, no tails.
+  run_sgemv_fp16_hgemv_test(8, 64);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_16x128) {
+  run_sgemv_fp16_hgemv_test(16, 128);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_n8_tail_5x24) {
+  // N=24 = 16 + 8: exercises the 8-element tail after the 16-element loop.
+  run_sgemv_fp16_hgemv_test(5, 24);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_scalar_tail_7x31) {
+  // N=31 = 16 + 8 + 7: exercises 16-loop, 8-tail, then scalar tail of 7.
+  run_sgemv_fp16_hgemv_test(7, 31);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemv_fp16_noTrans_scalar_tail_only_5x9) {
+  // N=9: skips 16-loop and 8-tail, scalar tail of 9.
+  run_sgemv_fp16_hgemv_test(5, 9);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_aligned_16x64) {
+  run_sgemv_fp16_hgemv_test(16, 64, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_unaligned_13x33) {
+  // M=13 (AXPY row sweep tail), N=33 (8-element tail + scalar tail in
+  // the FP32-scratch axpy update).
+  run_sgemv_fp16_hgemv_test(13, 33, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_alpha_beta_13x33) {
+  run_sgemv_fp16_hgemv_test(13, 33, false, -0.75F, 0.25F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_alpha_beta_13x33) {
+  run_sgemv_fp16_hgemv_test(13, 33, true, 0.5F, -0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_noTrans_7x17) {
+  // lda = N + 7: row-padded A.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 7);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_transA_7x17) {
+  run_sgemv_fp16_hgemv_test(7, 17, true, 1.0F, 0.0F, 7);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incX_noTrans_7x17) {
+  // incX=2 forces the non-contiguous X path.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 2, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incY_noTrans_7x17) {
+  // incY=3 exercises Y-gap preservation in the writeback path.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 1, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemv_fp16_strided_lda_incX_incY_transA_7x17) {
+  // All three strides at once on the TransA path (non-contiguous Y32 init,
+  // non-contiguous incX read, non-contiguous incY writeback).
+  run_sgemv_fp16_hgemv_test(7, 17, true, 0.5F, -0.25F, 3, 2, 4);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_alpha_beta_boundary_cases) {
+  struct Case {
+    float alpha;
+    float beta;
+  };
+
+  const std::vector<Case> cases = {
+    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
+                 " beta=" + std::to_string(tc.beta));
+    run_sgemv_fp16_hgemv_test(13, 33, false, tc.alpha, tc.beta);
+    run_sgemv_fp16_hgemv_test(13, 33, true, tc.alpha, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_zero_dimension_cases) {
+  run_sgemv_fp16_hgemv_test(0, 17, false, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(7, 0, false, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(0, 17, true, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(7, 0, true, 1.0F, 0.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_single_row_or_col) {
+  run_sgemv_fp16_hgemv_test(1, 33, false);
+  run_sgemv_fp16_hgemv_test(33, 1, false);
+  run_sgemv_fp16_hgemv_test(1, 33, true);
+  run_sgemv_fp16_hgemv_test(33, 1, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_beta_zero_does_not_read_Y) {
+  // BLAS rule: when beta == 0, Y must not be read. Seed Y with NaN; if the
+  // kernel reads it, NaN propagates into the result.
+  nntrainer::init_backend();
+
+  const _FP16 nan_v = static_cast<_FP16>(std::nan(""));
+
+  auto check_path = [&](bool TransA) {
+    const unsigned int M = 7;
+    const unsigned int N = 17;
+    const unsigned int lenY = TransA ? N : M;
+
+    auto A = generate_random_vector<_FP16>(M * N, -0.25F, 0.25F);
+    auto X = generate_random_vector<_FP16>(TransA ? M : N, -0.25F, 0.25F);
+    std::vector<_FP16> Y(lenY, nan_v);
+
+    nntrainer::sgemv(0, TransA, M, N, 1.0F, A.data(), N, X.data(), 1, 0.0F,
+                     Y.data(), 1);
+
+    for (unsigned int k = 0; k < lenY; ++k) {
+      const float yv = static_cast<float>(Y[k]);
+      EXPECT_FALSE(std::isnan(yv)) << "beta=0 path read NaN-seeded Y at k=" << k
+                                   << " TransA=" << TransA << " value=" << yv;
+    }
+  };
+
+  check_path(false);
+  check_path(true);
+}
+
+/// Mixed-precision GEMM path (shgemm: A=FP32,B=FP16 / hsgemm: A=FP16,B=FP32),
+/// FP32 output. Reference accumulates in double so the only approximation
+/// under test is the kernel's FP32 blocked summation; both sides read the
+/// identical generated operands, so operand rounding is not a discrepancy.
+template <typename AType, typename BType>
+static void run_mixed_sgemm_test(unsigned int M, unsigned int N, unsigned int K,
+                                 bool TransA = false, bool TransB = false,
+                                 float alpha = 1.0F, float beta = 0.0F,
+                                 unsigned int lda_extra = 0,
+                                 unsigned int ldb_extra = 0,
+                                 unsigned int ldc_extra = 0) {
+  static_assert(std::is_same_v<AType, float> != std::is_same_v<BType, float>,
+                "exactly one operand must be FP32 for mixed-precision GEMM");
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
+  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
+  const unsigned int ldc = std::max(1u, N + ldc_extra);
+  const unsigned int a_rows = TransA ? K : M;
+  const unsigned int b_rows = TransB ? N : K;
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
+  const std::size_t b_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
+  const std::size_t c_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
+
+  auto A = generate_random_vector<AType>(a_size, -0.25F, 0.25F);
+  auto B = generate_random_vector<BType>(b_size, -0.25F, 0.25F);
+  auto C = generate_random_vector<float>(c_size, -0.25F, 0.25F);
+  auto C_before = C;
+
+  std::vector<float> C_ref(c_size);
+  for (std::size_t i = 0; i < c_size; ++i) {
+    C_ref[i] = C_before[i];
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      double acc = 0.0;
+      for (unsigned int k = 0; k < K; ++k) {
+        const double a = static_cast<double>(
+          static_cast<float>(TransA ? A[k * lda + m] : A[m * lda + k]));
+        const double b = static_cast<double>(
+          static_cast<float>(TransB ? B[n * ldb + k] : B[k * ldb + n]));
+        acc += a * b;
+      }
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      C_ref[idx] = static_cast<float>(static_cast<double>(alpha) * acc +
+                                      static_cast<double>(beta) * C_ref[idx]);
+    }
+  }
+
+  if constexpr (std::is_same_v<AType, float>) {
+    nntrainer::shgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
+                      B.data(), ldb, beta, C.data(), ldc);
+  } else {
+    nntrainer::hsgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
+                      B.data(), ldb, beta, C.data(), ldc);
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      const float got = C[idx];
+      const float ref = C_ref[idx];
+      const float abs_diff = std::abs(got - ref);
+      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+      EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
+        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
+        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
+        << " alpha=" << alpha << " beta=" << beta << " got=" << got
+        << " ref=" << ref << " abs_diff=" << abs_diff
+        << " rel_diff=" << rel_diff;
+    }
+    for (unsigned int n = N; n < ldc; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      EXPECT_FLOAT_EQ(C[idx], C_before[idx])
+        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_64x64x64) {
+  run_mixed_sgemm_test<float, _FP16>(64, 64, 64);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_256x512x128) {
+  run_mixed_sgemm_test<float, _FP16>(256, 512, 128);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_unaligned_13x33x65) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     shgemm_fp32xfp16_all_transposes_13x33x65) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, false);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, true);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_alpha_beta_padded) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
+                                     7, 5);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
+                                     6);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_64x64x64) {
+  run_mixed_sgemm_test<_FP16, float>(64, 64, 64);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_256x512x128) {
+  run_mixed_sgemm_test<_FP16, float>(256, 512, 128);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_unaligned_13x33x65) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemm_fp16xfp32_all_transposes_13x33x65) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, false);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, true);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_alpha_beta_padded) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
+                                     7, 5);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
+                                     6);
+}
+
+/// Mixed-precision GEMV path (shgemv: A=FP32,X=FP16 / hsgemv: A=FP16,X=FP32),
+/// FP32 output. Reference accumulates in double; see run_mixed_sgemm_test.
+template <typename MatT, typename VecT>
+static void run_mixed_sgemv_test(unsigned int M, unsigned int N,
+                                 bool TransA = false, float alpha = 1.0F,
+                                 float beta = 0.0F, unsigned int lda_extra = 0,
+                                 unsigned int incX = 1, unsigned int incY = 1) {
+  static_assert(std::is_same_v<MatT, float> != std::is_same_v<VecT, float>,
+                "exactly one operand must be FP32 for mixed-precision GEMV");
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, N + lda_extra);
+  const unsigned int lenX = TransA ? M : N;
+  const unsigned int lenY = TransA ? N : M;
+
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
+  const std::size_t x_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
+  const std::size_t y_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
+
+  auto A = generate_random_vector<MatT>(a_size, -0.25F, 0.25F);
+  auto X = generate_random_vector<VecT>(x_size, -0.25F, 0.25F);
+  auto Y = generate_random_vector<float>(y_size, -0.25F, 0.25F);
+  auto Y_before = Y;
+
+  std::vector<float> Y_ref(y_size);
+  for (std::size_t i = 0; i < y_size; ++i) {
+    Y_ref[i] = Y_before[i];
+  }
+
+  if (!TransA) {
+    for (unsigned int i = 0; i < M; ++i) {
+      double acc = 0.0;
+      for (unsigned int j = 0; j < N; ++j) {
+        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
+               static_cast<double>(static_cast<float>(X[j * incX]));
+      }
+      const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
+      Y_ref[y_idx] =
+        static_cast<float>(static_cast<double>(alpha) * acc +
+                           static_cast<double>(beta) * Y_ref[y_idx]);
+    }
+  } else {
+    for (unsigned int j = 0; j < N; ++j) {
+      double acc = 0.0;
+      for (unsigned int i = 0; i < M; ++i) {
+        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
+               static_cast<double>(static_cast<float>(X[i * incX]));
+      }
+      const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
+      Y_ref[y_idx] =
+        static_cast<float>(static_cast<double>(alpha) * acc +
+                           static_cast<double>(beta) * Y_ref[y_idx]);
+    }
+  }
+
+  if constexpr (std::is_same_v<MatT, float>) {
+    nntrainer::shgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
+                      beta, Y.data(), incY);
+  } else {
+    nntrainer::hsgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
+                      beta, Y.data(), incY);
+  }
+
+  for (unsigned int k = 0; k < lenY; ++k) {
+    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
+    const float got = Y[y_idx];
+    const float ref = Y_ref[y_idx];
+    const float abs_diff = std::abs(got - ref);
+    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+    EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
+      << "mismatch at k=" << k << " M=" << M << " N=" << N
+      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
+      << " incX=" << incX << " incY=" << incY << " got=" << got
+      << " ref=" << ref << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_noTrans_16x128) {
+  run_mixed_sgemv_test<float, _FP16>(16, 128);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     shgemv_fp32xfp16_transA_unaligned_13x33) {
+  run_mixed_sgemv_test<float, _FP16>(13, 33, true);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_alpha_beta_13x33) {
+  run_mixed_sgemv_test<float, _FP16>(13, 33, false, 0.5F, 0.25F);
+  run_mixed_sgemv_test<float, _FP16>(13, 33, true, 0.5F, 0.25F);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemv_fp16xfp32_noTrans_16x128) {
+  run_mixed_sgemv_test<_FP16, float>(16, 128);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemv_fp16xfp32_transA_unaligned_13x33) {
+  run_mixed_sgemv_test<_FP16, float>(13, 33, true);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemv_fp16xfp32_strided_incX_incY_7x17) {
+  run_mixed_sgemv_test<_FP16, float>(7, 17, false, 1.0F, 0.0F, 3, 2, 2);
+  run_mixed_sgemv_test<float, _FP16>(7, 17, true, 0.75F, 0.5F, 0, 2, 2);
 }
 
 int main(int argc, char **argv) {

--- a/test/unittest/unittest_nntrainer_cpu_backend_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend_fp16.cpp
@@ -9,29 +9,15 @@
  */
 
 #include "int4_utils.h"
-#ifdef __ANDROID__
-// KleidiAI interface is only wired in via Android.mk; on Linux/meson the
-// header (and its qsi8d32p/qsi4c32p backend) is unavailable.
 #include "kleidiai_interface.h"
-#endif
 #include "nntrainer_test_util.h"
-#if defined(ENABLE_TEST) && (defined(__x86_64__) || defined(_M_X64))
-#include <hgemm_common.h>
-#include <hgemm_pack.h>
-#include <hgemm_test.h>
-#define X86_HGEMM_WORKSPACE_STATS_AVAILABLE 1
-#endif
-#include <algorithm>
 #include <cfloat>
-#include <cmath>
 #include <cpu_backend.h>
 #include <fallback_internal.h>
 #include <gtest/gtest.h>
 #include <numeric>
 #include <random>
-#include <string>
 #include <tuple>
-#include <type_traits>
 #include <vector>
 
 #include <chrono>
@@ -188,14 +174,16 @@ void run_quant_test_fp16(const uint32_t M, const uint32_t K, const uint32_t N,
 
   // GROUND TRUTH TRANSB SGEMM for reference
   auto t1 = high_resolution_clock::now();
-  nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
-                   weight_fp16.data(), K, 0.F, ref_dst.data(), N);
+  for (int tc = 0; tc < 20; ++tc) {
+    nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
+                     weight_fp16.data(), K, 0.F, ref_dst.data(), N);
+  }
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] hgemm :    " << dt.count() << " ns "
-              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
-              << " ms " << std::endl;
+    std::cout << "[INFO] hgemm :    " << dt.count() / 20 << " ns "
+              << dt.count() / 20 / 1'000 << " us "
+              << dt.count() / 20 / 1'000'000 << " ms " << std::endl;
   }
   q4_0_mse = test_gemm_q4_0_fp16(M, K, N, weight.data(), activation.data(),
                                  ref_dst, print);
@@ -214,10 +202,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x1024x1024) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   const unsigned int M = 457;
-  const unsigned int K = 1024;
-  const unsigned int N = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -225,10 +213,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x1024x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x1024x1024) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   const unsigned int M = 458;
-  const unsigned int K = 1024;
-  const unsigned int N = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -236,10 +224,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x1024x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x1024x1024) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   const unsigned int M = 459;
-  const unsigned int K = 1024;
-  const unsigned int N = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -247,10 +235,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x1024x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1024x1024) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
   const unsigned int M = 1024;
-  const unsigned int K = 1024;
-  const unsigned int N = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -269,10 +257,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1024x1024) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x3072x3072) {
   const unsigned int M = 1;
-  const unsigned int K = 1024;
-  const unsigned int N = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
   float q4_0_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test_fp16(M, K, N, q4_0_mse, q6_k_mse, false);
@@ -280,10 +268,6 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1024x1024) {
   ASSERT_LE(q6_k_mse, q4_0_mse);
 }
 
-#ifdef __ANDROID__
-// nntrainer::sine / cosine have no _FP16 instantiation in the x86 backend
-// (FP32-only). The helper and TEST below stay Android-only until the x86
-// backend grows an FP16 sine/cosine path.
 static void run_trigonometric_values_test(const unsigned int N,
                                           bool print = false) {
   const int TEST_CNT = 20;
@@ -684,11 +668,6 @@ TEST(nntrainer_cpu_backend_standalone, qai8dxp_qsi4cxp_3072x512x512_CMP) {
   ASSERT_LE(qai8dxp_qsi4cxp_mse_packed, eps * M * K * N);
 }
 
-#ifdef __ANDROID__
-// The qsi8d32p_qsi4c32p path is only exposed on Android via KleidiAI; the
-// x86 cpu_backend does not provide nntr_quant_qs4c32_f32 /
-// nntr_*_qsi8d32p_qsi4c32p_*, so these helpers and TESTs are excluded on
-// Linux/meson builds.
 std::tuple<float, uint32_t> test_gemm_qsi8d32p_qsi4c32p_unpacked(
   const uint32_t M, const uint32_t K, const uint32_t N, const float *weights,
   const float *activations, std::vector<float> &ref_dst, bool transB = true,
@@ -1079,19 +1058,13 @@ DECLARE_transform_osv32_to_qsi4c32p_test(512, 256);
 DECLARE_transform_osv32_to_qsi4c32p_test(512, 512);
 DECLARE_transform_osv32_to_qsi4c32p_test(1024, 512);
 DECLARE_transform_osv32_to_qsi4c32p_test(1024, 1024);
-#endif // __ANDROID__ (end of qsi8d32p_qsi4c32p region)
 
 TEST(nntrainer_cpu_backend_standalone, trigonometric_values_test) {
 
   const unsigned int N = 3072;
   run_trigonometric_values_test(N);
 }
-#endif // __ANDROID__ (end of trigonometric_values_test region)
 
-#ifdef __ANDROID__
-// gemm_benchmark_comparison mixes the qai8dxp path (x86-available) with the
-// qsi8d32p path (KleidiAI-only); both are needed for the three-way comparison,
-// so the whole benchmark is gated to Android.
 /**
  * @brief Benchmark comparison of three GEMM implementations
  *
@@ -1298,953 +1271,6 @@ TEST(nntrainer_cpu_backend_standalone, gemm_benchmark_comparison_32x1024x4096) {
 
 TEST(nntrainer_cpu_backend_standalone, gemm_benchmark_comparison_1x3072x512) {
   run_gemm_benchmark_comparison(1, 3072, 512);
-}
-#endif // __ANDROID__ (end of gemm_benchmark_comparison region)
-
-/// FP16 sgemm path: exercises the x86 cache-blocked GEMM.
-/// Reference is a local FP32 GEMM loop to avoid using the optimized backend as
-/// the oracle for this backend test.
-static void run_sgemm_fp16_hgemm_test(unsigned int M, unsigned int N,
-                                      unsigned int K, bool TransA = false,
-                                      bool TransB = false, float alpha = 1.0F,
-                                      float beta = 0.0F,
-                                      unsigned int lda_extra = 0,
-                                      unsigned int ldb_extra = 0,
-                                      unsigned int ldc_extra = 0) {
-  nntrainer::init_backend();
-
-  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
-  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
-  const unsigned int ldc = std::max(1u, N + ldc_extra);
-  const unsigned int a_rows = TransA ? K : M;
-  const unsigned int b_rows = TransB ? N : K;
-  const std::size_t a_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
-  const std::size_t b_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
-  const std::size_t c_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
-
-  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
-  auto B_fp16 = generate_random_vector<_FP16>(b_size, -0.25F, 0.25F);
-  auto C_fp16 = generate_random_vector<_FP16>(c_size, -0.25F, 0.25F);
-  auto C_before = C_fp16;
-
-  std::vector<float> C_fp32_ref(c_size);
-  for (std::size_t i = 0; i < c_size; ++i) {
-    C_fp32_ref[i] = static_cast<float>(C_before[i]);
-  }
-
-  if (M != 0 && N != 0) {
-    for (unsigned int m = 0; m < M; ++m) {
-      for (unsigned int n = 0; n < N; ++n) {
-        float acc = 0.0F;
-        for (unsigned int k = 0; k < K; ++k) {
-          const float a = static_cast<float>(TransA ? A_fp16[k * lda + m]
-                                                    : A_fp16[m * lda + k]);
-          const float b = static_cast<float>(TransB ? B_fp16[n * ldb + k]
-                                                    : B_fp16[k * ldb + n]);
-          acc += a * b;
-        }
-        const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-        C_fp32_ref[idx] = alpha * acc + beta * C_fp32_ref[idx];
-      }
-    }
-  }
-
-  // System under test: FP16 sgemm, routed to x86::hgemm_fp16 by the x86
-  // backend dispatcher for row-major inputs.
-  nntrainer::sgemm(0, TransA, TransB, M, N, K, alpha, A_fp16.data(), lda,
-                   B_fp16.data(), ldb, beta, C_fp16.data(), ldc);
-
-  if (M == 0 || N == 0) {
-    for (std::size_t i = 0; i < c_size; ++i) {
-      EXPECT_EQ(static_cast<float>(C_fp16[i]), static_cast<float>(C_before[i]))
-        << "zero-dimension GEMM touched C at i=" << i << " M=" << M
-        << " N=" << N << " K=" << K << " TransA=" << TransA
-        << " TransB=" << TransB;
-    }
-    return;
-  }
-
-  for (unsigned int m = 0; m < M; ++m) {
-    for (unsigned int n = 0; n < N; ++n) {
-      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-      const float got = static_cast<float>(C_fp16[idx]);
-      const float ref = C_fp32_ref[idx];
-      const float abs_diff = std::abs(got - ref);
-      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
-      EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
-        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
-        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
-        << " alpha=" << alpha << " beta=" << beta << " lda=" << lda
-        << " ldb=" << ldb << " ldc=" << ldc << " got=" << got << " ref=" << ref
-        << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
-    }
-
-    for (unsigned int n = N; n < ldc; ++n) {
-      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-      EXPECT_EQ(static_cast<float>(C_fp16[idx]),
-                static_cast<float>(C_before[idx]))
-        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
-    }
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_12x32x32) {
-  run_sgemm_fp16_hgemm_test(12, 32, 32);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_256x512x128) {
-  run_sgemm_fp16_hgemm_test(256, 512, 128);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_64x64x64) {
-  run_sgemm_fp16_hgemm_test(64, 64, 64);
-}
-
-// Large shapes that exceed the 8M-FLOP parallel threshold and force the blocked
-// path's panel subdivision: square (N-subdivision) and tall-thin
-// (M-subdivision). Run the whole binary under NNTR_NUM_THREADS>1 to exercise
-// the multi-threaded panel grid.
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_square_512x512x512) {
-  run_sgemm_fp16_hgemm_test(512, 512, 512);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_parallel_tall_thin_1024x96x256) {
-  run_sgemm_fp16_hgemm_test(1024, 96, 256);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_wide_96x1024x256) {
-  run_sgemm_fp16_hgemm_test(96, 1024, 256);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_parallel_square_alpha_beta_640x384x320) {
-  run_sgemm_fp16_hgemm_test(640, 384, 320, false, false, 0.75F, 0.5F);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_parallel_transAB_384x320x512) {
-  run_sgemm_fp16_hgemm_test(384, 320, 512, true, true);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_7x17x33) {
-  // Exercises both M-edge (7 = 6 + 1) and N-edge (17 = 16 + 1) cleanup.
-  run_sgemm_fp16_hgemm_test(7, 17, 33);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_13x33x65) {
-  run_sgemm_fp16_hgemm_test(13, 33, 65);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_alpha_beta_13x33x65) {
-  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, -0.75F, 0.25F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transA_unaligned_13x33x65) {
-  run_sgemm_fp16_hgemm_test(13, 33, 65, true, false, 0.5F, -0.125F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transB_unaligned_13x33x65) {
-  run_sgemm_fp16_hgemm_test(13, 33, 65, false, true, 1.25F, 0.5F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transAB_unaligned_13x33x65) {
-  run_sgemm_fp16_hgemm_test(13, 33, 65, true, true, -1.0F, 0.125F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_alpha_beta_boundary_cases) {
-  struct Case {
-    float alpha;
-    float beta;
-  };
-
-  const std::vector<Case> cases = {
-    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
-                 " beta=" + std::to_string(tc.beta));
-    run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, tc.alpha, tc.beta);
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_dimension_cases) {
-  run_sgemm_fp16_hgemm_test(0, 17, 33, false, false, 1.0F, 0.0F);
-  run_sgemm_fp16_hgemm_test(7, 0, 33, false, false, 1.0F, 0.0F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_k_beta_cases) {
-  struct Case {
-    float beta;
-  };
-
-  const std::vector<Case> cases = {{0.0F}, {1.0F}, {-0.5F}};
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("K=0 beta=" + std::to_string(tc.beta));
-    run_sgemm_fp16_hgemm_test(7, 17, 0, false, false, 1.0F, tc.beta);
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_prime_size_all_transposes) {
-  struct Case {
-    bool trans_a;
-    bool trans_b;
-  };
-
-  const std::vector<Case> cases = {
-    {false, false}, {false, true}, {true, false}, {true, true}};
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
-                 " TransB=" + std::to_string(tc.trans_b));
-    run_sgemm_fp16_hgemm_test(97, 53, 71, tc.trans_a, tc.trans_b, 0.75F,
-                              -0.25F);
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_small_tile_cases) {
-  run_sgemm_fp16_hgemm_test(1, 1, 1, false, false, 1.0F, 0.0F);
-  run_sgemm_fp16_hgemm_test(5, 15, 7, false, false, 1.25F, -0.5F);
-  run_sgemm_fp16_hgemm_test(5, 15, 7, true, true, -0.75F, 1.0F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_fast_path_cases) {
-  run_sgemm_fp16_hgemm_test(1, 257, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
-  run_sgemm_fp16_hgemm_test(1, 257, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_small_k_notrans_large_padded) {
-  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
-  run_sgemm_fp16_hgemm_test(129, 257, 4, true, false, 0.5F, -0.125F, 2, 6, 3);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_skinny_direct_cases) {
-  run_sgemm_fp16_hgemm_test(129, 1, 67, false, false, 1.25F, -0.5F, 5, 3, 2);
-  run_sgemm_fp16_hgemm_test(97, 2, 71, true, true, -0.75F, 0.25F, 4, 6, 3);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_skinny_fast_path_all_transposes) {
-  struct Case {
-    unsigned int n;
-    bool trans_a;
-    bool trans_b;
-  };
-
-  const std::vector<Case> cases = {
-    {1, false, false}, {1, false, true}, {1, true, false}, {1, true, true},
-    {2, false, false}, {2, false, true}, {2, true, false}, {2, true, true}};
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("N=" + std::to_string(tc.n) +
-                 " TransA=" + std::to_string(tc.trans_a) +
-                 " TransB=" + std::to_string(tc.trans_b));
-    run_sgemm_fp16_hgemm_test(131, tc.n, 67, tc.trans_a, tc.trans_b, 0.75F,
-                              -0.25F, 3, 5, 7);
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_transB_fast_path_cases) {
-  run_sgemm_fp16_hgemm_test(1, 257, 129, false, true, 0.75F, -0.25F, 3, 5, 7);
-  run_sgemm_fp16_hgemm_test(1, 257, 129, true, true, -0.5F, 0.125F, 2, 4, 3);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_padded_lda_ldb_ldc_all_transposes) {
-  struct Case {
-    bool trans_a;
-    bool trans_b;
-    float alpha;
-    float beta;
-    unsigned int lda_extra;
-    unsigned int ldb_extra;
-    unsigned int ldc_extra;
-  };
-
-  const std::vector<Case> cases = {
-    {false, false, 1.0F, 0.0F, 4, 7, 5},
-    {false, true, -0.5F, 0.125F, 6, 2, 1},
-    {true, false, 0.75F, -0.25F, 3, 8, 4},
-    {true, true, -1.25F, 0.5F, 5, 3, 6},
-  };
-
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
-                 " TransB=" + std::to_string(tc.trans_b));
-    run_sgemm_fp16_hgemm_test(13, 33, 65, tc.trans_a, tc.trans_b, tc.alpha,
-                              tc.beta, tc.lda_extra, tc.ldb_extra,
-                              tc.ldc_extra);
-  }
-}
-
-#ifdef X86_HGEMM_WORKSPACE_STATS_AVAILABLE
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_reuse_warmed_shape) {
-  run_sgemm_fp16_hgemm_test(64, 64, 64);
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(64, 64, 64);
-  auto same_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(same_stats.total_realloc_count, 0u);
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(7, 17, 33);
-  auto smaller_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(smaller_stats.total_realloc_count, 0u);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_uses_c32_panel_and_packed_panels) {
-  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
-
-  const auto &block = nntrainer::avx2::internal::get_hgemm_block_sizes();
-  const unsigned int M = block.m + 1;
-  const unsigned int N = block.n + 1;
-  const unsigned int K = 5;
-
-  run_sgemm_fp16_hgemm_test(M, N, K, false, false, 0.75F, 0.25F);
-  const auto stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-
-  const auto round_up_to = [](unsigned int value, unsigned int tile) {
-    return ((value + tile - 1) / tile) * tile;
-  };
-
-  const unsigned int panel_m = std::min<unsigned int>(M, block.m);
-  const unsigned int panel_n = std::min<unsigned int>(N, block.n);
-  const unsigned int k_block = std::min<unsigned int>(K, block.k);
-  const unsigned int tile_m =
-    std::min<unsigned int>(panel_m, std::min(block.m, block.c_m));
-
-  const std::size_t expected_c32_capacity =
-    static_cast<std::size_t>(round_up_to(panel_m, X86_HGEMM_MR)) *
-    round_up_to(panel_n, X86_HGEMM_NR);
-  const std::size_t full_c32_capacity =
-    static_cast<std::size_t>(round_up_to(M, X86_HGEMM_MR)) *
-    round_up_to(N, X86_HGEMM_NR);
-  const std::size_t expected_pack_a_capacity =
-    static_cast<std::size_t>(round_up_to(tile_m, X86_HGEMM_MR)) * k_block;
-  const std::size_t expected_pack_b_capacity =
-    static_cast<std::size_t>(k_block) * round_up_to(panel_n, X86_HGEMM_NR);
-
-  EXPECT_EQ(stats.c32_capacity, expected_c32_capacity);
-  EXPECT_LT(stats.c32_capacity, full_c32_capacity);
-  EXPECT_EQ(stats.pack_a_capacity, expected_pack_a_capacity);
-  EXPECT_EQ(stats.pack_b_capacity, expected_pack_b_capacity);
-  EXPECT_EQ(stats.scratch_capacity, 0u);
-  EXPECT_EQ(stats.total_capacity_bytes,
-            (stats.c32_capacity + stats.pack_a_capacity +
-             stats.pack_b_capacity + stats.scratch_capacity) *
-              sizeof(float));
-  EXPECT_EQ(stats.total_realloc_count,
-            stats.c32_realloc_count + stats.pack_a_realloc_count +
-              stats.pack_b_realloc_count + stats.scratch_realloc_count);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_row_fast_path_uses_scratch_only) {
-  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
-
-  const unsigned int N = 257;
-  run_sgemm_fp16_hgemm_test(1, N, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
-  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, N);
-  EXPECT_EQ(stats.c32_realloc_count, 0u);
-  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
-  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
-  EXPECT_EQ(stats.scratch_realloc_count, 1u);
-  EXPECT_EQ(stats.total_realloc_count, 1u);
-  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(1, N, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
-  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, N);
-  EXPECT_EQ(stats.scratch_realloc_count, 0u);
-  EXPECT_EQ(stats.total_realloc_count, 0u);
-  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_row_transB_fast_path_uses_scratch_only) {
-  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
-
-  const unsigned int K = 129;
-  run_sgemm_fp16_hgemm_test(1, 257, K, false, true, 0.75F, -0.25F, 3, 5, 7);
-  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, K);
-  EXPECT_EQ(stats.c32_realloc_count, 0u);
-  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
-  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
-  EXPECT_EQ(stats.scratch_realloc_count, 1u);
-  EXPECT_EQ(stats.total_realloc_count, 1u);
-  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(1, 257, K, true, true, -0.5F, 0.125F, 2, 4, 3);
-  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, K);
-  EXPECT_EQ(stats.scratch_realloc_count, 0u);
-  EXPECT_EQ(stats.total_realloc_count, 0u);
-  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_no_allocation_for_fast_small_shapes) {
-  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
-  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
-  auto stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, 0u);
-  EXPECT_EQ(stats.total_realloc_count, 0u);
-
-  nntrainer::avx2::internal::testing::clear_hgemm_workspace();
-  run_sgemm_fp16_hgemm_test(131, 2, 67, true, true, 0.75F, -0.25F, 3, 5, 7);
-  stats = nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(stats.c32_capacity, 0u);
-  EXPECT_EQ(stats.pack_a_capacity, 0u);
-  EXPECT_EQ(stats.pack_b_capacity, 0u);
-  EXPECT_EQ(stats.scratch_capacity, 0u);
-  EXPECT_EQ(stats.total_realloc_count, 0u);
-}
-
-template <typename SrcT> static void run_packing_B_N16_trans_test() {
-  const unsigned int K = 13;
-  const unsigned int N = X86_HGEMM_NR;
-  const unsigned int stride = K + 5;
-  auto src = generate_random_vector<SrcT>(static_cast<std::size_t>(N) * stride,
-                                          -1.0F, 1.0F);
-  std::vector<float> dst(static_cast<std::size_t>(K) * X86_HGEMM_NR, -123.0F);
-
-  nntrainer::avx2::internal::packing_B_N16_trans(K, N, src.data(), stride,
-                                                 dst.data());
-
-  for (unsigned int k = 0; k < K; ++k) {
-    for (unsigned int n = 0; n < N; ++n) {
-      EXPECT_FLOAT_EQ(
-        dst[static_cast<std::size_t>(k) * X86_HGEMM_NR + n],
-        static_cast<float>(src[static_cast<std::size_t>(n) * stride + k]))
-        << "mismatch at k=" << k << " n=" << n;
-    }
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_fp16) {
-  run_packing_B_N16_trans_test<_FP16>();
-}
-
-TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_float) {
-  run_packing_B_N16_trans_test<float>();
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemm_fp16_workspace_no_allocation_for_degenerate_paths) {
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, 0.0F, 0.5F);
-  auto alpha_zero_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(alpha_zero_stats.total_realloc_count, 0u);
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(13, 33, 0, false, false, 1.0F, -0.5F);
-  auto k_zero_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(k_zero_stats.total_realloc_count, 0u);
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(0, 33, 65, false, false, 1.0F, 0.0F);
-  auto m_zero_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(m_zero_stats.total_realloc_count, 0u);
-
-  nntrainer::avx2::internal::testing::reset_hgemm_workspace_stats();
-  run_sgemm_fp16_hgemm_test(13, 0, 65, false, false, 1.0F, 0.0F);
-  auto n_zero_stats =
-    nntrainer::avx2::internal::testing::get_hgemm_workspace_stats();
-  EXPECT_EQ(n_zero_stats.total_realloc_count, 0u);
-}
-#endif
-
-/// FP16 sgemv path: exercises the x86 AVX2 hgemv kernel.
-/// Reference is a local FP32 GEMV loop to avoid using the optimized backend
-/// as the oracle for this backend test.
-static void run_sgemv_fp16_hgemv_test(unsigned int M, unsigned int N,
-                                      bool TransA = false, float alpha = 1.0F,
-                                      float beta = 0.0F,
-                                      unsigned int lda_extra = 0,
-                                      unsigned int incX = 1,
-                                      unsigned int incY = 1) {
-  nntrainer::init_backend();
-
-  const unsigned int lda = std::max(1u, N + lda_extra);
-  const unsigned int lenX = TransA ? M : N;
-  const unsigned int lenY = TransA ? N : M;
-
-  const std::size_t a_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
-  const std::size_t x_size = std::max<std::size_t>(
-    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
-  const std::size_t y_size = std::max<std::size_t>(
-    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
-
-  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
-  auto X_fp16 = generate_random_vector<_FP16>(x_size, -0.25F, 0.25F);
-  auto Y_fp16 = generate_random_vector<_FP16>(y_size, -0.25F, 0.25F);
-  auto Y_before = Y_fp16;
-
-  std::vector<float> Y_fp32_ref(y_size);
-  for (std::size_t i = 0; i < y_size; ++i) {
-    Y_fp32_ref[i] = static_cast<float>(Y_before[i]);
-  }
-
-  if (M != 0 && N != 0) {
-    if (!TransA) {
-      for (unsigned int i = 0; i < M; ++i) {
-        float acc = 0.0F;
-        for (unsigned int j = 0; j < N; ++j) {
-          acc += static_cast<float>(A_fp16[i * lda + j]) *
-                 static_cast<float>(X_fp16[j * incX]);
-        }
-        const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
-        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
-      }
-    } else {
-      for (unsigned int j = 0; j < N; ++j) {
-        float acc = 0.0F;
-        for (unsigned int i = 0; i < M; ++i) {
-          acc += static_cast<float>(A_fp16[i * lda + j]) *
-                 static_cast<float>(X_fp16[i * incX]);
-        }
-        const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
-        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
-      }
-    }
-  }
-
-  // System under test: FP16 sgemv, routed to x86::hgemv by the x86 backend
-  // dispatcher for row-major inputs.
-  nntrainer::sgemv(0, TransA, M, N, alpha, A_fp16.data(), lda, X_fp16.data(),
-                   incX, beta, Y_fp16.data(), incY);
-
-  if (M == 0 || N == 0) {
-    for (std::size_t i = 0; i < y_size; ++i) {
-      EXPECT_EQ(static_cast<float>(Y_fp16[i]), static_cast<float>(Y_before[i]))
-        << "zero-dimension GEMV touched Y at i=" << i << " M=" << M
-        << " N=" << N << " TransA=" << TransA;
-    }
-    return;
-  }
-
-  for (unsigned int k = 0; k < lenY; ++k) {
-    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
-    const float got = static_cast<float>(Y_fp16[y_idx]);
-    const float ref = Y_fp32_ref[y_idx];
-    const float abs_diff = std::abs(got - ref);
-    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
-    EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
-      << "mismatch at k=" << k << " M=" << M << " N=" << N
-      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
-      << " lda=" << lda << " incX=" << incX << " incY=" << incY
-      << " got=" << got << " ref=" << ref << " abs_diff=" << abs_diff
-      << " rel_diff=" << rel_diff;
-  }
-
-  // Y gap slots (only present when incY > 1) must be untouched.
-  if (incY > 1) {
-    for (unsigned int k = 0; k < lenY; ++k) {
-      const std::size_t base = static_cast<std::size_t>(k) * incY;
-      for (unsigned int g = 1; g < incY; ++g) {
-        const std::size_t gap_idx = base + g;
-        if (gap_idx >= y_size) {
-          break;
-        }
-        EXPECT_EQ(static_cast<float>(Y_fp16[gap_idx]),
-                  static_cast<float>(Y_before[gap_idx]))
-          << "Y gap was modified at idx=" << gap_idx << " k=" << k << " g=" << g
-          << " incY=" << incY;
-      }
-    }
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_8x64) {
-  // N multiple of 16: 16-element main loop only, no tails.
-  run_sgemv_fp16_hgemv_test(8, 64);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_16x128) {
-  run_sgemv_fp16_hgemv_test(16, 128);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_n8_tail_5x24) {
-  // N=24 = 16 + 8: exercises the 8-element tail after the 16-element loop.
-  run_sgemv_fp16_hgemv_test(5, 24);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_scalar_tail_7x31) {
-  // N=31 = 16 + 8 + 7: exercises 16-loop, 8-tail, then scalar tail of 7.
-  run_sgemv_fp16_hgemv_test(7, 31);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemv_fp16_noTrans_scalar_tail_only_5x9) {
-  // N=9: skips 16-loop and 8-tail, scalar tail of 9.
-  run_sgemv_fp16_hgemv_test(5, 9);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_aligned_16x64) {
-  run_sgemv_fp16_hgemv_test(16, 64, true);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_unaligned_13x33) {
-  // M=13 (AXPY row sweep tail), N=33 (8-element tail + scalar tail in
-  // the FP32-scratch axpy update).
-  run_sgemv_fp16_hgemv_test(13, 33, true);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_alpha_beta_13x33) {
-  run_sgemv_fp16_hgemv_test(13, 33, false, -0.75F, 0.25F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_alpha_beta_13x33) {
-  run_sgemv_fp16_hgemv_test(13, 33, true, 0.5F, -0.125F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_noTrans_7x17) {
-  // lda = N + 7: row-padded A.
-  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 7);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_transA_7x17) {
-  run_sgemv_fp16_hgemv_test(7, 17, true, 1.0F, 0.0F, 7);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incX_noTrans_7x17) {
-  // incX=2 forces the non-contiguous X path.
-  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 2, 1);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incY_noTrans_7x17) {
-  // incY=3 exercises Y-gap preservation in the writeback path.
-  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 1, 3);
-}
-
-TEST(nntrainer_cpu_backend_standalone,
-     sgemv_fp16_strided_lda_incX_incY_transA_7x17) {
-  // All three strides at once on the TransA path (non-contiguous Y32 init,
-  // non-contiguous incX read, non-contiguous incY writeback).
-  run_sgemv_fp16_hgemv_test(7, 17, true, 0.5F, -0.25F, 3, 2, 4);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_alpha_beta_boundary_cases) {
-  struct Case {
-    float alpha;
-    float beta;
-  };
-
-  const std::vector<Case> cases = {
-    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
-  for (const auto &tc : cases) {
-    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
-                 " beta=" + std::to_string(tc.beta));
-    run_sgemv_fp16_hgemv_test(13, 33, false, tc.alpha, tc.beta);
-    run_sgemv_fp16_hgemv_test(13, 33, true, tc.alpha, tc.beta);
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_zero_dimension_cases) {
-  run_sgemv_fp16_hgemv_test(0, 17, false, 1.0F, 0.0F);
-  run_sgemv_fp16_hgemv_test(7, 0, false, 1.0F, 0.0F);
-  run_sgemv_fp16_hgemv_test(0, 17, true, 1.0F, 0.0F);
-  run_sgemv_fp16_hgemv_test(7, 0, true, 1.0F, 0.0F);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_single_row_or_col) {
-  run_sgemv_fp16_hgemv_test(1, 33, false);
-  run_sgemv_fp16_hgemv_test(33, 1, false);
-  run_sgemv_fp16_hgemv_test(1, 33, true);
-  run_sgemv_fp16_hgemv_test(33, 1, true);
-}
-
-TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_beta_zero_does_not_read_Y) {
-  // BLAS rule: when beta == 0, Y must not be read. Seed Y with NaN; if the
-  // kernel reads it, NaN propagates into the result.
-  nntrainer::init_backend();
-
-  const _FP16 nan_v = static_cast<_FP16>(std::nan(""));
-
-  auto check_path = [&](bool TransA) {
-    const unsigned int M = 7;
-    const unsigned int N = 17;
-    const unsigned int lenY = TransA ? N : M;
-
-    auto A = generate_random_vector<_FP16>(M * N, -0.25F, 0.25F);
-    auto X = generate_random_vector<_FP16>(TransA ? M : N, -0.25F, 0.25F);
-    std::vector<_FP16> Y(lenY, nan_v);
-
-    nntrainer::sgemv(0, TransA, M, N, 1.0F, A.data(), N, X.data(), 1, 0.0F,
-                     Y.data(), 1);
-
-    for (unsigned int k = 0; k < lenY; ++k) {
-      const float yv = static_cast<float>(Y[k]);
-      EXPECT_FALSE(std::isnan(yv)) << "beta=0 path read NaN-seeded Y at k=" << k
-                                   << " TransA=" << TransA << " value=" << yv;
-    }
-  };
-
-  check_path(false);
-  check_path(true);
-}
-
-/// Mixed-precision GEMM path (shgemm: A=FP32,B=FP16 / hsgemm: A=FP16,B=FP32),
-/// FP32 output. Reference accumulates in double so the only approximation
-/// under test is the kernel's FP32 blocked summation; both sides read the
-/// identical generated operands, so operand rounding is not a discrepancy.
-template <typename AType, typename BType>
-static void run_mixed_sgemm_test(unsigned int M, unsigned int N, unsigned int K,
-                                 bool TransA = false, bool TransB = false,
-                                 float alpha = 1.0F, float beta = 0.0F,
-                                 unsigned int lda_extra = 0,
-                                 unsigned int ldb_extra = 0,
-                                 unsigned int ldc_extra = 0) {
-  static_assert(std::is_same_v<AType, float> != std::is_same_v<BType, float>,
-                "exactly one operand must be FP32 for mixed-precision GEMM");
-  nntrainer::init_backend();
-
-  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
-  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
-  const unsigned int ldc = std::max(1u, N + ldc_extra);
-  const unsigned int a_rows = TransA ? K : M;
-  const unsigned int b_rows = TransB ? N : K;
-  const std::size_t a_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
-  const std::size_t b_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
-  const std::size_t c_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
-
-  auto A = generate_random_vector<AType>(a_size, -0.25F, 0.25F);
-  auto B = generate_random_vector<BType>(b_size, -0.25F, 0.25F);
-  auto C = generate_random_vector<float>(c_size, -0.25F, 0.25F);
-  auto C_before = C;
-
-  std::vector<float> C_ref(c_size);
-  for (std::size_t i = 0; i < c_size; ++i) {
-    C_ref[i] = C_before[i];
-  }
-
-  for (unsigned int m = 0; m < M; ++m) {
-    for (unsigned int n = 0; n < N; ++n) {
-      double acc = 0.0;
-      for (unsigned int k = 0; k < K; ++k) {
-        const double a = static_cast<double>(
-          static_cast<float>(TransA ? A[k * lda + m] : A[m * lda + k]));
-        const double b = static_cast<double>(
-          static_cast<float>(TransB ? B[n * ldb + k] : B[k * ldb + n]));
-        acc += a * b;
-      }
-      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-      C_ref[idx] = static_cast<float>(static_cast<double>(alpha) * acc +
-                                      static_cast<double>(beta) * C_ref[idx]);
-    }
-  }
-
-  if constexpr (std::is_same_v<AType, float>) {
-    nntrainer::shgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
-                      B.data(), ldb, beta, C.data(), ldc);
-  } else {
-    nntrainer::hsgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
-                      B.data(), ldb, beta, C.data(), ldc);
-  }
-
-  for (unsigned int m = 0; m < M; ++m) {
-    for (unsigned int n = 0; n < N; ++n) {
-      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-      const float got = C[idx];
-      const float ref = C_ref[idx];
-      const float abs_diff = std::abs(got - ref);
-      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
-      EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
-        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
-        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
-        << " alpha=" << alpha << " beta=" << beta << " got=" << got
-        << " ref=" << ref << " abs_diff=" << abs_diff
-        << " rel_diff=" << rel_diff;
-    }
-    for (unsigned int n = N; n < ldc; ++n) {
-      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
-      EXPECT_FLOAT_EQ(C[idx], C_before[idx])
-        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
-    }
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_64x64x64) {
-  run_mixed_sgemm_test<float, _FP16>(64, 64, 64);
-}
-TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_256x512x128) {
-  run_mixed_sgemm_test<float, _FP16>(256, 512, 128);
-}
-TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_unaligned_13x33x65) {
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65);
-}
-TEST(nntrainer_cpu_backend_standalone,
-     shgemm_fp32xfp16_all_transposes_13x33x65) {
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, false);
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, true);
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true);
-}
-TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_alpha_beta_padded) {
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
-                                     7, 5);
-  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
-                                     6);
-}
-TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_64x64x64) {
-  run_mixed_sgemm_test<_FP16, float>(64, 64, 64);
-}
-TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_256x512x128) {
-  run_mixed_sgemm_test<_FP16, float>(256, 512, 128);
-}
-TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_unaligned_13x33x65) {
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65);
-}
-TEST(nntrainer_cpu_backend_standalone,
-     hsgemm_fp16xfp32_all_transposes_13x33x65) {
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, false);
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, true);
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true);
-}
-TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_alpha_beta_padded) {
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
-                                     7, 5);
-  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
-                                     6);
-}
-
-/// Mixed-precision GEMV path (shgemv: A=FP32,X=FP16 / hsgemv: A=FP16,X=FP32),
-/// FP32 output. Reference accumulates in double; see run_mixed_sgemm_test.
-template <typename MatT, typename VecT>
-static void run_mixed_sgemv_test(unsigned int M, unsigned int N,
-                                 bool TransA = false, float alpha = 1.0F,
-                                 float beta = 0.0F, unsigned int lda_extra = 0,
-                                 unsigned int incX = 1, unsigned int incY = 1) {
-  static_assert(std::is_same_v<MatT, float> != std::is_same_v<VecT, float>,
-                "exactly one operand must be FP32 for mixed-precision GEMV");
-  nntrainer::init_backend();
-
-  const unsigned int lda = std::max(1u, N + lda_extra);
-  const unsigned int lenX = TransA ? M : N;
-  const unsigned int lenY = TransA ? N : M;
-
-  const std::size_t a_size =
-    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
-  const std::size_t x_size = std::max<std::size_t>(
-    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
-  const std::size_t y_size = std::max<std::size_t>(
-    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
-
-  auto A = generate_random_vector<MatT>(a_size, -0.25F, 0.25F);
-  auto X = generate_random_vector<VecT>(x_size, -0.25F, 0.25F);
-  auto Y = generate_random_vector<float>(y_size, -0.25F, 0.25F);
-  auto Y_before = Y;
-
-  std::vector<float> Y_ref(y_size);
-  for (std::size_t i = 0; i < y_size; ++i) {
-    Y_ref[i] = Y_before[i];
-  }
-
-  if (!TransA) {
-    for (unsigned int i = 0; i < M; ++i) {
-      double acc = 0.0;
-      for (unsigned int j = 0; j < N; ++j) {
-        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
-               static_cast<double>(static_cast<float>(X[j * incX]));
-      }
-      const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
-      Y_ref[y_idx] =
-        static_cast<float>(static_cast<double>(alpha) * acc +
-                           static_cast<double>(beta) * Y_ref[y_idx]);
-    }
-  } else {
-    for (unsigned int j = 0; j < N; ++j) {
-      double acc = 0.0;
-      for (unsigned int i = 0; i < M; ++i) {
-        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
-               static_cast<double>(static_cast<float>(X[i * incX]));
-      }
-      const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
-      Y_ref[y_idx] =
-        static_cast<float>(static_cast<double>(alpha) * acc +
-                           static_cast<double>(beta) * Y_ref[y_idx]);
-    }
-  }
-
-  if constexpr (std::is_same_v<MatT, float>) {
-    nntrainer::shgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
-                      beta, Y.data(), incY);
-  } else {
-    nntrainer::hsgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
-                      beta, Y.data(), incY);
-  }
-
-  for (unsigned int k = 0; k < lenY; ++k) {
-    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
-    const float got = Y[y_idx];
-    const float ref = Y_ref[y_idx];
-    const float abs_diff = std::abs(got - ref);
-    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
-    EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
-      << "mismatch at k=" << k << " M=" << M << " N=" << N
-      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
-      << " incX=" << incX << " incY=" << incY << " got=" << got
-      << " ref=" << ref << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
-  }
-}
-
-TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_noTrans_16x128) {
-  run_mixed_sgemv_test<float, _FP16>(16, 128);
-}
-TEST(nntrainer_cpu_backend_standalone,
-     shgemv_fp32xfp16_transA_unaligned_13x33) {
-  run_mixed_sgemv_test<float, _FP16>(13, 33, true);
-}
-TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_alpha_beta_13x33) {
-  run_mixed_sgemv_test<float, _FP16>(13, 33, false, 0.5F, 0.25F);
-  run_mixed_sgemv_test<float, _FP16>(13, 33, true, 0.5F, 0.25F);
-}
-TEST(nntrainer_cpu_backend_standalone, hsgemv_fp16xfp32_noTrans_16x128) {
-  run_mixed_sgemv_test<_FP16, float>(16, 128);
-}
-TEST(nntrainer_cpu_backend_standalone,
-     hsgemv_fp16xfp32_transA_unaligned_13x33) {
-  run_mixed_sgemv_test<_FP16, float>(13, 33, true);
-}
-TEST(nntrainer_cpu_backend_standalone,
-     hsgemv_fp16xfp32_strided_incX_incY_7x17) {
-  run_mixed_sgemv_test<_FP16, float>(7, 17, false, 1.0F, 0.0F, 3, 2, 2);
-  run_mixed_sgemv_test<float, _FP16>(7, 17, true, 0.75F, 0.5F, 0, 2, 2);
 }
 
 int main(int argc, char **argv) {

--- a/test/unittest/unittest_nntrainer_cpu_backend_fp16_x86.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend_fp16_x86.cpp
@@ -1,0 +1,1027 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	unittest_nntrainer_cpu_backend_fp16_x86.cpp
+ * @date	16 June 2026
+ * @brief	x86-only unit tests for the cache-blocked FP16 GEMM/GEMV backend
+ * @see		https://github.com/nntrainer/nntrainer
+ * @author	Yonghyeon Cho <dyddyd8574@gmail.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * @note Split out of unittest_nntrainer_cpu_backend_fp16.cpp (which is built
+ * for Android only) so the x86 cache-blocked GEMM/GEMV tests build under meson
+ * without touching that file. The whole body is gated on x86, so the target is
+ * harmless to build on other architectures.
+ */
+
+#include "nntrainer_test_util.h"
+
+#include <cpu_backend.h>
+#include <fallback_internal.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <hgemm_common.h>
+#include <hgemm_pack.h>
+#ifdef ENABLE_TEST
+#include <hgemm_test.h>
+#define X86_HGEMM_WORKSPACE_STATS_AVAILABLE 1
+#endif
+
+template <typename T>
+static inline double find_max_diff(T *src, T *src2, int M, int N) {
+  float max_diff = 0;
+  double err_sum = 0;
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      max_diff = std::max(max_diff, std::abs(static_cast<float>(
+                                      src[i * N + j] - src2[i * N + j])));
+      err_sum += std::abs(static_cast<float>(src[i * N + j] - src2[i * N + j]));
+    }
+  }
+  return max_diff;
+}
+
+/// FP16 sgemm path: exercises the x86 cache-blocked GEMM.
+/// Reference is a local FP32 GEMM loop to avoid using the optimized backend as
+/// the oracle for this backend test.
+static void run_sgemm_fp16_hgemm_test(unsigned int M, unsigned int N,
+                                      unsigned int K, bool TransA = false,
+                                      bool TransB = false, float alpha = 1.0F,
+                                      float beta = 0.0F,
+                                      unsigned int lda_extra = 0,
+                                      unsigned int ldb_extra = 0,
+                                      unsigned int ldc_extra = 0) {
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
+  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
+  const unsigned int ldc = std::max(1u, N + ldc_extra);
+  const unsigned int a_rows = TransA ? K : M;
+  const unsigned int b_rows = TransB ? N : K;
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
+  const std::size_t b_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
+  const std::size_t c_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
+
+  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
+  auto B_fp16 = generate_random_vector<_FP16>(b_size, -0.25F, 0.25F);
+  auto C_fp16 = generate_random_vector<_FP16>(c_size, -0.25F, 0.25F);
+  auto C_before = C_fp16;
+
+  std::vector<float> C_fp32_ref(c_size);
+  for (std::size_t i = 0; i < c_size; ++i) {
+    C_fp32_ref[i] = static_cast<float>(C_before[i]);
+  }
+
+  if (M != 0 && N != 0) {
+    for (unsigned int m = 0; m < M; ++m) {
+      for (unsigned int n = 0; n < N; ++n) {
+        float acc = 0.0F;
+        for (unsigned int k = 0; k < K; ++k) {
+          const float a = static_cast<float>(TransA ? A_fp16[k * lda + m]
+                                                    : A_fp16[m * lda + k]);
+          const float b = static_cast<float>(TransB ? B_fp16[n * ldb + k]
+                                                    : B_fp16[k * ldb + n]);
+          acc += a * b;
+        }
+        const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+        C_fp32_ref[idx] = alpha * acc + beta * C_fp32_ref[idx];
+      }
+    }
+  }
+
+  // System under test: FP16 sgemm, routed to x86::hgemm_fp16 by the x86
+  // backend dispatcher for row-major inputs.
+  nntrainer::sgemm(0, TransA, TransB, M, N, K, alpha, A_fp16.data(), lda,
+                   B_fp16.data(), ldb, beta, C_fp16.data(), ldc);
+
+  if (M == 0 || N == 0) {
+    for (std::size_t i = 0; i < c_size; ++i) {
+      EXPECT_EQ(static_cast<float>(C_fp16[i]), static_cast<float>(C_before[i]))
+        << "zero-dimension GEMM touched C at i=" << i << " M=" << M
+        << " N=" << N << " K=" << K << " TransA=" << TransA
+        << " TransB=" << TransB;
+    }
+    return;
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      const float got = static_cast<float>(C_fp16[idx]);
+      const float ref = C_fp32_ref[idx];
+      const float abs_diff = std::abs(got - ref);
+      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+      EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
+        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
+        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
+        << " alpha=" << alpha << " beta=" << beta << " lda=" << lda
+        << " ldb=" << ldb << " ldc=" << ldc << " got=" << got << " ref=" << ref
+        << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
+    }
+
+    for (unsigned int n = N; n < ldc; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      EXPECT_EQ(static_cast<float>(C_fp16[idx]),
+                static_cast<float>(C_before[idx]))
+        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_12x32x32) {
+  run_sgemm_fp16_hgemm_test(12, 32, 32);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_256x512x128) {
+  run_sgemm_fp16_hgemm_test(256, 512, 128);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_aligned_64x64x64) {
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+}
+
+// Large shapes that exceed the 8M-FLOP parallel threshold and force the blocked
+// path's panel subdivision: square (N-subdivision) and tall-thin
+// (M-subdivision). Run the whole binary under NNTR_NUM_THREADS>1 to exercise
+// the multi-threaded panel grid.
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_square_512x512x512) {
+  run_sgemm_fp16_hgemm_test(512, 512, 512);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_tall_thin_1024x96x256) {
+  run_sgemm_fp16_hgemm_test(1024, 96, 256);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_parallel_wide_96x1024x256) {
+  run_sgemm_fp16_hgemm_test(96, 1024, 256);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_square_alpha_beta_640x384x320) {
+  run_sgemm_fp16_hgemm_test(640, 384, 320, false, false, 0.75F, 0.5F);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_parallel_transAB_384x320x512) {
+  run_sgemm_fp16_hgemm_test(384, 320, 512, true, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_7x17x33) {
+  // Exercises both M-edge (7 = 6 + 1) and N-edge (17 = 16 + 1) cleanup.
+  run_sgemm_fp16_hgemm_test(7, 17, 33);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_noTrans_alpha_beta_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, -0.75F, 0.25F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transA_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, true, false, 0.5F, -0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transB_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, true, 1.25F, 0.5F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_transAB_unaligned_13x33x65) {
+  run_sgemm_fp16_hgemm_test(13, 33, 65, true, true, -1.0F, 0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_alpha_beta_boundary_cases) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    float alpha;
+    float beta;
+  };
+
+  const std::vector<Case> cases = {
+    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
+                 " beta=" + std::to_string(tc.beta));
+    run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, tc.alpha, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_dimension_cases) {
+  run_sgemm_fp16_hgemm_test(0, 17, 33, false, false, 1.0F, 0.0F);
+  run_sgemm_fp16_hgemm_test(7, 0, 33, false, false, 1.0F, 0.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_zero_k_beta_cases) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    float beta;
+  };
+
+  const std::vector<Case> cases = {{0.0F}, {1.0F}, {-0.5F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("K=0 beta=" + std::to_string(tc.beta));
+    run_sgemm_fp16_hgemm_test(7, 17, 0, false, false, 1.0F, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_prime_size_all_transposes) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    bool trans_a;
+    bool trans_b;
+  };
+
+  const std::vector<Case> cases = {
+    {false, false}, {false, true}, {true, false}, {true, true}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(97, 53, 71, tc.trans_a, tc.trans_b, 0.75F,
+                              -0.25F);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_small_tile_cases) {
+  run_sgemm_fp16_hgemm_test(1, 1, 1, false, false, 1.0F, 0.0F);
+  run_sgemm_fp16_hgemm_test(5, 15, 7, false, false, 1.25F, -0.5F);
+  run_sgemm_fp16_hgemm_test(5, 15, 7, true, true, -0.75F, 1.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_fast_path_cases) {
+  run_sgemm_fp16_hgemm_test(1, 257, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(1, 257, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_small_k_notrans_large_padded) {
+  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(129, 257, 4, true, false, 0.5F, -0.125F, 2, 6, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_skinny_direct_cases) {
+  run_sgemm_fp16_hgemm_test(129, 1, 67, false, false, 1.25F, -0.5F, 5, 3, 2);
+  run_sgemm_fp16_hgemm_test(97, 2, 71, true, true, -0.75F, 0.25F, 4, 6, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_skinny_fast_path_all_transposes) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    unsigned int n;
+    bool trans_a;
+    bool trans_b;
+  };
+
+  const std::vector<Case> cases = {
+    {1, false, false}, {1, false, true}, {1, true, false}, {1, true, true},
+    {2, false, false}, {2, false, true}, {2, true, false}, {2, true, true}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("N=" + std::to_string(tc.n) +
+                 " TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(131, tc.n, 67, tc.trans_a, tc.trans_b, 0.75F,
+                              -0.25F, 3, 5, 7);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemm_fp16_row_transB_fast_path_cases) {
+  run_sgemm_fp16_hgemm_test(1, 257, 129, false, true, 0.75F, -0.25F, 3, 5, 7);
+  run_sgemm_fp16_hgemm_test(1, 257, 129, true, true, -0.5F, 0.125F, 2, 4, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_padded_lda_ldb_ldc_all_transposes) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    bool trans_a;
+    bool trans_b;
+    float alpha;
+    float beta;
+    unsigned int lda_extra;
+    unsigned int ldb_extra;
+    unsigned int ldc_extra;
+  };
+
+  const std::vector<Case> cases = {
+    {false, false, 1.0F, 0.0F, 4, 7, 5},
+    {false, true, -0.5F, 0.125F, 6, 2, 1},
+    {true, false, 0.75F, -0.25F, 3, 8, 4},
+    {true, true, -1.25F, 0.5F, 5, 3, 6},
+  };
+
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("TransA=" + std::to_string(tc.trans_a) +
+                 " TransB=" + std::to_string(tc.trans_b));
+    run_sgemm_fp16_hgemm_test(13, 33, 65, tc.trans_a, tc.trans_b, tc.alpha,
+                              tc.beta, tc.lda_extra, tc.ldb_extra,
+                              tc.ldc_extra);
+  }
+}
+
+#ifdef X86_HGEMM_WORKSPACE_STATS_AVAILABLE
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_reuse_warmed_shape) {
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(64, 64, 64);
+  auto same_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(same_stats.total_realloc_count, 0u);
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(7, 17, 33);
+  auto smaller_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(smaller_stats.total_realloc_count, 0u);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_uses_c32_panel_and_packed_panels) {
+  nntrainer::hgemm::internal::testing::clear_hgemm_workspace();
+
+  const auto &block = nntrainer::hgemm::internal::get_hgemm_block_sizes();
+  const unsigned int M = block.m + 1;
+  const unsigned int N = block.n + 1;
+  const unsigned int K = 5;
+
+  run_sgemm_fp16_hgemm_test(M, N, K, false, false, 0.75F, 0.25F);
+  const auto stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+
+  const auto round_up_to = [](unsigned int value, unsigned int tile) {
+    return ((value + tile - 1) / tile) * tile;
+  };
+
+  const unsigned int panel_m = std::min<unsigned int>(M, block.m);
+  const unsigned int panel_n = std::min<unsigned int>(N, block.n);
+  const unsigned int k_block = std::min<unsigned int>(K, block.k);
+  const unsigned int tile_m =
+    std::min<unsigned int>(panel_m, std::min(block.m, block.c_m));
+
+  const std::size_t expected_c32_capacity =
+    static_cast<std::size_t>(round_up_to(panel_m, X86_HGEMM_MR)) *
+    round_up_to(panel_n, X86_HGEMM_NR);
+  const std::size_t full_c32_capacity =
+    static_cast<std::size_t>(round_up_to(M, X86_HGEMM_MR)) *
+    round_up_to(N, X86_HGEMM_NR);
+  const std::size_t expected_pack_a_capacity =
+    static_cast<std::size_t>(round_up_to(tile_m, X86_HGEMM_MR)) * k_block;
+  const std::size_t expected_pack_b_capacity =
+    static_cast<std::size_t>(k_block) * round_up_to(panel_n, X86_HGEMM_NR);
+
+  EXPECT_EQ(stats.c32_capacity, expected_c32_capacity);
+  EXPECT_LT(stats.c32_capacity, full_c32_capacity);
+  EXPECT_EQ(stats.pack_a_capacity, expected_pack_a_capacity);
+  EXPECT_EQ(stats.pack_b_capacity, expected_pack_b_capacity);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes,
+            (stats.c32_capacity + stats.pack_a_capacity +
+             stats.pack_b_capacity + stats.scratch_capacity) *
+              sizeof(float));
+  EXPECT_EQ(stats.total_realloc_count,
+            stats.c32_realloc_count + stats.pack_a_realloc_count +
+              stats.pack_b_realloc_count + stats.scratch_realloc_count);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_row_fast_path_uses_scratch_only) {
+  nntrainer::hgemm::internal::testing::clear_hgemm_workspace();
+
+  const unsigned int N = 257;
+  run_sgemm_fp16_hgemm_test(1, N, 129, false, false, 0.75F, -0.25F, 3, 5, 7);
+  auto stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, N);
+  EXPECT_EQ(stats.c32_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
+  EXPECT_EQ(stats.scratch_realloc_count, 1u);
+  EXPECT_EQ(stats.total_realloc_count, 1u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(1, N, 129, true, false, -0.5F, 0.125F, 2, 4, 3);
+  stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, N);
+  EXPECT_EQ(stats.scratch_realloc_count, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_row_transB_fast_path_uses_scratch_only) {
+  nntrainer::hgemm::internal::testing::clear_hgemm_workspace();
+
+  const unsigned int K = 129;
+  run_sgemm_fp16_hgemm_test(1, 257, K, false, true, 0.75F, -0.25F, 3, 5, 7);
+  auto stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, K);
+  EXPECT_EQ(stats.c32_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_a_realloc_count, 0u);
+  EXPECT_EQ(stats.pack_b_realloc_count, 0u);
+  EXPECT_EQ(stats.scratch_realloc_count, 1u);
+  EXPECT_EQ(stats.total_realloc_count, 1u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(1, 257, K, true, true, -0.5F, 0.125F, 2, 4, 3);
+  stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, K);
+  EXPECT_EQ(stats.scratch_realloc_count, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+  EXPECT_EQ(stats.total_capacity_bytes, stats.scratch_capacity * sizeof(float));
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_no_allocation_for_fast_small_shapes) {
+  nntrainer::hgemm::internal::testing::clear_hgemm_workspace();
+  run_sgemm_fp16_hgemm_test(129, 257, 4, false, false, -0.75F, 0.25F, 3, 5, 7);
+  auto stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+
+  nntrainer::hgemm::internal::testing::clear_hgemm_workspace();
+  run_sgemm_fp16_hgemm_test(131, 2, 67, true, true, 0.75F, -0.25F, 3, 5, 7);
+  stats = nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(stats.c32_capacity, 0u);
+  EXPECT_EQ(stats.pack_a_capacity, 0u);
+  EXPECT_EQ(stats.pack_b_capacity, 0u);
+  EXPECT_EQ(stats.scratch_capacity, 0u);
+  EXPECT_EQ(stats.total_realloc_count, 0u);
+}
+
+template <typename SrcT> static void run_packing_B_N16_trans_test() {
+  const unsigned int K = 13;
+  const unsigned int N = X86_HGEMM_NR;
+  const unsigned int stride = K + 5;
+  auto src = generate_random_vector<SrcT>(static_cast<std::size_t>(N) * stride,
+                                          -1.0F, 1.0F);
+  std::vector<float> dst(static_cast<std::size_t>(K) * X86_HGEMM_NR, -123.0F);
+
+  nntrainer::hgemm::internal::packing_B_N16_trans(K, N, src.data(), stride,
+                                                  dst.data());
+
+  for (unsigned int k = 0; k < K; ++k) {
+    for (unsigned int n = 0; n < N; ++n) {
+      EXPECT_FLOAT_EQ(
+        dst[static_cast<std::size_t>(k) * X86_HGEMM_NR + n],
+        static_cast<float>(src[static_cast<std::size_t>(n) * stride + k]))
+        << "mismatch at k=" << k << " n=" << n;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_fp16) {
+  run_packing_B_N16_trans_test<_FP16>();
+}
+
+TEST(nntrainer_cpu_backend_standalone, hgemm_pack_B_N16_trans_float) {
+  run_packing_B_N16_trans_test<float>();
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemm_fp16_workspace_no_allocation_for_degenerate_paths) {
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 33, 65, false, false, 0.0F, 0.5F);
+  auto alpha_zero_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(alpha_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 33, 0, false, false, 1.0F, -0.5F);
+  auto k_zero_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(k_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(0, 33, 65, false, false, 1.0F, 0.0F);
+  auto m_zero_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(m_zero_stats.total_realloc_count, 0u);
+
+  nntrainer::hgemm::internal::testing::reset_hgemm_workspace_stats();
+  run_sgemm_fp16_hgemm_test(13, 0, 65, false, false, 1.0F, 0.0F);
+  auto n_zero_stats =
+    nntrainer::hgemm::internal::testing::get_hgemm_workspace_stats();
+  EXPECT_EQ(n_zero_stats.total_realloc_count, 0u);
+}
+#endif
+
+/// FP16 sgemv path: exercises the x86 AVX2 hgemv kernel.
+/// Reference is a local FP32 GEMV loop to avoid using the optimized backend
+/// as the oracle for this backend test.
+static void run_sgemv_fp16_hgemv_test(unsigned int M, unsigned int N,
+                                      bool TransA = false, float alpha = 1.0F,
+                                      float beta = 0.0F,
+                                      unsigned int lda_extra = 0,
+                                      unsigned int incX = 1,
+                                      unsigned int incY = 1) {
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, N + lda_extra);
+  const unsigned int lenX = TransA ? M : N;
+  const unsigned int lenY = TransA ? N : M;
+
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
+  const std::size_t x_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
+  const std::size_t y_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
+
+  auto A_fp16 = generate_random_vector<_FP16>(a_size, -0.25F, 0.25F);
+  auto X_fp16 = generate_random_vector<_FP16>(x_size, -0.25F, 0.25F);
+  auto Y_fp16 = generate_random_vector<_FP16>(y_size, -0.25F, 0.25F);
+  auto Y_before = Y_fp16;
+
+  std::vector<float> Y_fp32_ref(y_size);
+  for (std::size_t i = 0; i < y_size; ++i) {
+    Y_fp32_ref[i] = static_cast<float>(Y_before[i]);
+  }
+
+  if (M != 0 && N != 0) {
+    if (!TransA) {
+      for (unsigned int i = 0; i < M; ++i) {
+        float acc = 0.0F;
+        for (unsigned int j = 0; j < N; ++j) {
+          acc += static_cast<float>(A_fp16[i * lda + j]) *
+                 static_cast<float>(X_fp16[j * incX]);
+        }
+        const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
+        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
+      }
+    } else {
+      for (unsigned int j = 0; j < N; ++j) {
+        float acc = 0.0F;
+        for (unsigned int i = 0; i < M; ++i) {
+          acc += static_cast<float>(A_fp16[i * lda + j]) *
+                 static_cast<float>(X_fp16[i * incX]);
+        }
+        const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
+        Y_fp32_ref[y_idx] = alpha * acc + beta * Y_fp32_ref[y_idx];
+      }
+    }
+  }
+
+  // System under test: FP16 sgemv, routed to x86::hgemv by the x86 backend
+  // dispatcher for row-major inputs.
+  nntrainer::sgemv(0, TransA, M, N, alpha, A_fp16.data(), lda, X_fp16.data(),
+                   incX, beta, Y_fp16.data(), incY);
+
+  if (M == 0 || N == 0) {
+    for (std::size_t i = 0; i < y_size; ++i) {
+      EXPECT_EQ(static_cast<float>(Y_fp16[i]), static_cast<float>(Y_before[i]))
+        << "zero-dimension GEMV touched Y at i=" << i << " M=" << M
+        << " N=" << N << " TransA=" << TransA;
+    }
+    return;
+  }
+
+  for (unsigned int k = 0; k < lenY; ++k) {
+    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
+    const float got = static_cast<float>(Y_fp16[y_idx]);
+    const float ref = Y_fp32_ref[y_idx];
+    const float abs_diff = std::abs(got - ref);
+    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+    EXPECT_TRUE(abs_diff <= 1e-2F || rel_diff <= 1e-2F)
+      << "mismatch at k=" << k << " M=" << M << " N=" << N
+      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
+      << " lda=" << lda << " incX=" << incX << " incY=" << incY
+      << " got=" << got << " ref=" << ref << " abs_diff=" << abs_diff
+      << " rel_diff=" << rel_diff;
+  }
+
+  // Y gap slots (only present when incY > 1) must be untouched.
+  if (incY > 1) {
+    for (unsigned int k = 0; k < lenY; ++k) {
+      const std::size_t base = static_cast<std::size_t>(k) * incY;
+      for (unsigned int g = 1; g < incY; ++g) {
+        const std::size_t gap_idx = base + g;
+        if (gap_idx >= y_size) {
+          break;
+        }
+        EXPECT_EQ(static_cast<float>(Y_fp16[gap_idx]),
+                  static_cast<float>(Y_before[gap_idx]))
+          << "Y gap was modified at idx=" << gap_idx << " k=" << k << " g=" << g
+          << " incY=" << incY;
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_8x64) {
+  // N multiple of 16: 16-element main loop only, no tails.
+  run_sgemv_fp16_hgemv_test(8, 64);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_aligned_16x128) {
+  run_sgemv_fp16_hgemv_test(16, 128);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_n8_tail_5x24) {
+  // N=24 = 16 + 8: exercises the 8-element tail after the 16-element loop.
+  run_sgemv_fp16_hgemv_test(5, 24);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_scalar_tail_7x31) {
+  // N=31 = 16 + 8 + 7: exercises 16-loop, 8-tail, then scalar tail of 7.
+  run_sgemv_fp16_hgemv_test(7, 31);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemv_fp16_noTrans_scalar_tail_only_5x9) {
+  // N=9: skips 16-loop and 8-tail, scalar tail of 9.
+  run_sgemv_fp16_hgemv_test(5, 9);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_aligned_16x64) {
+  run_sgemv_fp16_hgemv_test(16, 64, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_unaligned_13x33) {
+  // M=13 (AXPY row sweep tail), N=33 (8-element tail + scalar tail in
+  // the FP32-scratch axpy update).
+  run_sgemv_fp16_hgemv_test(13, 33, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_noTrans_alpha_beta_13x33) {
+  run_sgemv_fp16_hgemv_test(13, 33, false, -0.75F, 0.25F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_transA_alpha_beta_13x33) {
+  run_sgemv_fp16_hgemv_test(13, 33, true, 0.5F, -0.125F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_noTrans_7x17) {
+  // lda = N + 7: row-padded A.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 7);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_lda_transA_7x17) {
+  run_sgemv_fp16_hgemv_test(7, 17, true, 1.0F, 0.0F, 7);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incX_noTrans_7x17) {
+  // incX=2 forces the non-contiguous X path.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 2, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_strided_incY_noTrans_7x17) {
+  // incY=3 exercises Y-gap preservation in the writeback path.
+  run_sgemv_fp16_hgemv_test(7, 17, false, 1.0F, 0.0F, 0, 1, 3);
+}
+
+TEST(nntrainer_cpu_backend_standalone,
+     sgemv_fp16_strided_lda_incX_incY_transA_7x17) {
+  // All three strides at once on the TransA path (non-contiguous Y32 init,
+  // non-contiguous incX read, non-contiguous incY writeback).
+  run_sgemv_fp16_hgemv_test(7, 17, true, 0.5F, -0.25F, 3, 2, 4);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_alpha_beta_boundary_cases) {
+  /// @brief parameter set for one sub-case of this test
+  struct Case {
+    float alpha;
+    float beta;
+  };
+
+  const std::vector<Case> cases = {
+    {0.0F, 0.0F}, {0.0F, 1.0F}, {1.0F, 0.0F}, {1.0F, 1.0F}, {2.5F, -1.0F}};
+  for (const auto &tc : cases) {
+    SCOPED_TRACE("alpha=" + std::to_string(tc.alpha) +
+                 " beta=" + std::to_string(tc.beta));
+    run_sgemv_fp16_hgemv_test(13, 33, false, tc.alpha, tc.beta);
+    run_sgemv_fp16_hgemv_test(13, 33, true, tc.alpha, tc.beta);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_zero_dimension_cases) {
+  run_sgemv_fp16_hgemv_test(0, 17, false, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(7, 0, false, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(0, 17, true, 1.0F, 0.0F);
+  run_sgemv_fp16_hgemv_test(7, 0, true, 1.0F, 0.0F);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_single_row_or_col) {
+  run_sgemv_fp16_hgemv_test(1, 33, false);
+  run_sgemv_fp16_hgemv_test(33, 1, false);
+  run_sgemv_fp16_hgemv_test(1, 33, true);
+  run_sgemv_fp16_hgemv_test(33, 1, true);
+}
+
+TEST(nntrainer_cpu_backend_standalone, sgemv_fp16_beta_zero_does_not_read_Y) {
+  // BLAS rule: when beta == 0, Y must not be read. Seed Y with NaN; if the
+  // kernel reads it, NaN propagates into the result.
+  nntrainer::init_backend();
+
+  const _FP16 nan_v = static_cast<_FP16>(std::nan(""));
+
+  auto check_path = [&](bool TransA) {
+    const unsigned int M = 7;
+    const unsigned int N = 17;
+    const unsigned int lenY = TransA ? N : M;
+
+    auto A = generate_random_vector<_FP16>(M * N, -0.25F, 0.25F);
+    auto X = generate_random_vector<_FP16>(TransA ? M : N, -0.25F, 0.25F);
+    std::vector<_FP16> Y(lenY, nan_v);
+
+    nntrainer::sgemv(0, TransA, M, N, 1.0F, A.data(), N, X.data(), 1, 0.0F,
+                     Y.data(), 1);
+
+    for (unsigned int k = 0; k < lenY; ++k) {
+      const float yv = static_cast<float>(Y[k]);
+      EXPECT_FALSE(std::isnan(yv)) << "beta=0 path read NaN-seeded Y at k=" << k
+                                   << " TransA=" << TransA << " value=" << yv;
+    }
+  };
+
+  check_path(false);
+  check_path(true);
+}
+
+/// Mixed-precision GEMM path (shgemm: A=FP32,B=FP16 / hsgemm: A=FP16,B=FP32),
+/// FP32 output. Reference accumulates in double so the only approximation
+/// under test is the kernel's FP32 blocked summation; both sides read the
+/// identical generated operands, so operand rounding is not a discrepancy.
+template <typename AType, typename BType>
+static void run_mixed_sgemm_test(unsigned int M, unsigned int N, unsigned int K,
+                                 bool TransA = false, bool TransB = false,
+                                 float alpha = 1.0F, float beta = 0.0F,
+                                 unsigned int lda_extra = 0,
+                                 unsigned int ldb_extra = 0,
+                                 unsigned int ldc_extra = 0) {
+  static_assert(std::is_same_v<AType, float> != std::is_same_v<BType, float>,
+                "exactly one operand must be FP32 for mixed-precision GEMM");
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, (TransA ? M : K) + lda_extra);
+  const unsigned int ldb = std::max(1u, (TransB ? K : N) + ldb_extra);
+  const unsigned int ldc = std::max(1u, N + ldc_extra);
+  const unsigned int a_rows = TransA ? K : M;
+  const unsigned int b_rows = TransB ? N : K;
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(a_rows) * lda);
+  const std::size_t b_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(b_rows) * ldb);
+  const std::size_t c_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * ldc);
+
+  auto A = generate_random_vector<AType>(a_size, -0.25F, 0.25F);
+  auto B = generate_random_vector<BType>(b_size, -0.25F, 0.25F);
+  auto C = generate_random_vector<float>(c_size, -0.25F, 0.25F);
+  auto C_before = C;
+
+  std::vector<float> C_ref(c_size);
+  for (std::size_t i = 0; i < c_size; ++i) {
+    C_ref[i] = C_before[i];
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      double acc = 0.0;
+      for (unsigned int k = 0; k < K; ++k) {
+        const double a = static_cast<double>(
+          static_cast<float>(TransA ? A[k * lda + m] : A[m * lda + k]));
+        const double b = static_cast<double>(
+          static_cast<float>(TransB ? B[n * ldb + k] : B[k * ldb + n]));
+        acc += a * b;
+      }
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      C_ref[idx] = static_cast<float>(static_cast<double>(alpha) * acc +
+                                      static_cast<double>(beta) * C_ref[idx]);
+    }
+  }
+
+  if constexpr (std::is_same_v<AType, float>) {
+    nntrainer::shgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
+                      B.data(), ldb, beta, C.data(), ldc);
+  } else {
+    nntrainer::hsgemm(0, TransA, TransB, M, N, K, alpha, A.data(), lda,
+                      B.data(), ldb, beta, C.data(), ldc);
+  }
+
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      const float got = C[idx];
+      const float ref = C_ref[idx];
+      const float abs_diff = std::abs(got - ref);
+      const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+      EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
+        << "mismatch at m=" << m << " n=" << n << " M=" << M << " N=" << N
+        << " K=" << K << " TransA=" << TransA << " TransB=" << TransB
+        << " alpha=" << alpha << " beta=" << beta << " got=" << got
+        << " ref=" << ref << " abs_diff=" << abs_diff
+        << " rel_diff=" << rel_diff;
+    }
+    for (unsigned int n = N; n < ldc; ++n) {
+      const std::size_t idx = static_cast<std::size_t>(m) * ldc + n;
+      EXPECT_FLOAT_EQ(C[idx], C_before[idx])
+        << "C padding was modified at m=" << m << " n=" << n << " ldc=" << ldc;
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_64x64x64) {
+  run_mixed_sgemm_test<float, _FP16>(64, 64, 64);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_noTrans_256x512x128) {
+  run_mixed_sgemm_test<float, _FP16>(256, 512, 128);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_unaligned_13x33x65) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     shgemm_fp32xfp16_all_transposes_13x33x65) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, false);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, true);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemm_fp32xfp16_alpha_beta_padded) {
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
+                                     7, 5);
+  run_mixed_sgemm_test<float, _FP16>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
+                                     6);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_64x64x64) {
+  run_mixed_sgemm_test<_FP16, float>(64, 64, 64);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_noTrans_256x512x128) {
+  run_mixed_sgemm_test<_FP16, float>(256, 512, 128);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_unaligned_13x33x65) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemm_fp16xfp32_all_transposes_13x33x65) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, false);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, true);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemm_fp16xfp32_alpha_beta_padded) {
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, false, false, 0.5F, 0.25F, 4,
+                                     7, 5);
+  run_mixed_sgemm_test<_FP16, float>(13, 33, 65, true, true, -1.25F, 0.5F, 5, 3,
+                                     6);
+}
+
+/// Mixed-precision GEMV path (shgemv: A=FP32,X=FP16 / hsgemv: A=FP16,X=FP32),
+/// FP32 output. Reference accumulates in double; see run_mixed_sgemm_test.
+template <typename MatT, typename VecT>
+static void run_mixed_sgemv_test(unsigned int M, unsigned int N,
+                                 bool TransA = false, float alpha = 1.0F,
+                                 float beta = 0.0F, unsigned int lda_extra = 0,
+                                 unsigned int incX = 1, unsigned int incY = 1) {
+  static_assert(std::is_same_v<MatT, float> != std::is_same_v<VecT, float>,
+                "exactly one operand must be FP32 for mixed-precision GEMV");
+  nntrainer::init_backend();
+
+  const unsigned int lda = std::max(1u, N + lda_extra);
+  const unsigned int lenX = TransA ? M : N;
+  const unsigned int lenY = TransA ? N : M;
+
+  const std::size_t a_size =
+    std::max<std::size_t>(1, static_cast<std::size_t>(M) * lda);
+  const std::size_t x_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenX) * std::max(incX, 1u));
+  const std::size_t y_size = std::max<std::size_t>(
+    1, static_cast<std::size_t>(lenY) * std::max(incY, 1u));
+
+  auto A = generate_random_vector<MatT>(a_size, -0.25F, 0.25F);
+  auto X = generate_random_vector<VecT>(x_size, -0.25F, 0.25F);
+  auto Y = generate_random_vector<float>(y_size, -0.25F, 0.25F);
+  auto Y_before = Y;
+
+  std::vector<float> Y_ref(y_size);
+  for (std::size_t i = 0; i < y_size; ++i) {
+    Y_ref[i] = Y_before[i];
+  }
+
+  if (!TransA) {
+    for (unsigned int i = 0; i < M; ++i) {
+      double acc = 0.0;
+      for (unsigned int j = 0; j < N; ++j) {
+        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
+               static_cast<double>(static_cast<float>(X[j * incX]));
+      }
+      const std::size_t y_idx = static_cast<std::size_t>(i) * incY;
+      Y_ref[y_idx] =
+        static_cast<float>(static_cast<double>(alpha) * acc +
+                           static_cast<double>(beta) * Y_ref[y_idx]);
+    }
+  } else {
+    for (unsigned int j = 0; j < N; ++j) {
+      double acc = 0.0;
+      for (unsigned int i = 0; i < M; ++i) {
+        acc += static_cast<double>(static_cast<float>(A[i * lda + j])) *
+               static_cast<double>(static_cast<float>(X[i * incX]));
+      }
+      const std::size_t y_idx = static_cast<std::size_t>(j) * incY;
+      Y_ref[y_idx] =
+        static_cast<float>(static_cast<double>(alpha) * acc +
+                           static_cast<double>(beta) * Y_ref[y_idx]);
+    }
+  }
+
+  if constexpr (std::is_same_v<MatT, float>) {
+    nntrainer::shgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
+                      beta, Y.data(), incY);
+  } else {
+    nntrainer::hsgemv(0, TransA, M, N, alpha, A.data(), lda, X.data(), incX,
+                      beta, Y.data(), incY);
+  }
+
+  for (unsigned int k = 0; k < lenY; ++k) {
+    const std::size_t y_idx = static_cast<std::size_t>(k) * incY;
+    const float got = Y[y_idx];
+    const float ref = Y_ref[y_idx];
+    const float abs_diff = std::abs(got - ref);
+    const float rel_diff = abs_diff / std::max(1.0F, std::abs(ref));
+    EXPECT_TRUE(abs_diff <= 1e-3F || rel_diff <= 1e-3F)
+      << "mismatch at k=" << k << " M=" << M << " N=" << N
+      << " TransA=" << TransA << " alpha=" << alpha << " beta=" << beta
+      << " incX=" << incX << " incY=" << incY << " got=" << got
+      << " ref=" << ref << " abs_diff=" << abs_diff << " rel_diff=" << rel_diff;
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_noTrans_16x128) {
+  run_mixed_sgemv_test<float, _FP16>(16, 128);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     shgemv_fp32xfp16_transA_unaligned_13x33) {
+  run_mixed_sgemv_test<float, _FP16>(13, 33, true);
+}
+TEST(nntrainer_cpu_backend_standalone, shgemv_fp32xfp16_alpha_beta_13x33) {
+  run_mixed_sgemv_test<float, _FP16>(13, 33, false, 0.5F, 0.25F);
+  run_mixed_sgemv_test<float, _FP16>(13, 33, true, 0.5F, 0.25F);
+}
+TEST(nntrainer_cpu_backend_standalone, hsgemv_fp16xfp32_noTrans_16x128) {
+  run_mixed_sgemv_test<_FP16, float>(16, 128);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemv_fp16xfp32_transA_unaligned_13x33) {
+  run_mixed_sgemv_test<_FP16, float>(13, 33, true);
+}
+TEST(nntrainer_cpu_backend_standalone,
+     hsgemv_fp16xfp32_strided_incX_incY_7x17) {
+  run_mixed_sgemv_test<_FP16, float>(7, 17, false, 1.0F, 0.0F, 3, 2, 2);
+  run_mixed_sgemv_test<float, _FP16>(7, 17, true, 0.75F, 0.5F, 0, 2, 2);
+}
+
+#endif // defined(__x86_64__) || defined(_M_X64)
+
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Dependency of the PR

- Depends on: #3967
- Benchmark tooling: #3820

## Summary

This PR (1) removes all per-call heap allocations from the existing **FP32-input** x86 attention kernels and (2) adds the missing **FP16-input** x86 attention kernels, so FP16-mode LLM (CausalLM) inference runs on x86 — it previously did not, because these kernels existed only on ARM (`neon_impl_fp16.cpp`).

Key properties:

1. **Zero per-call allocations** in the FP32-input kernels. `compute_kcaches`, `compute_fp16vcache_fp32_transposed`, and `softmax_row(_with_sink)_inplace` replaced their per-call `std::vector` / `new[]` / `new __m256[]` scratch with reusable `static thread_local` buffers (one allocation per worker thread, amortised to 0). Measured: **1 / 2 / 2 → 0** allocations per call (and a per-head `sumRem` site, **10 → 0** for `head_dim % 8 != 0`).
2. **Conversion fused into the dot product.** `compute_kcaches` widens the FP16 key row to FP32 8 lanes at a time inside the FMA loop (F16C), instead of staging the whole row in a `tmp_fp32` buffer first — ~1.6–1.8× faster.
3. **Hot-loop scratch pointers cached into locals.** The thread_local buffers' `.data()` pointers are resolved once per call so the inner FMA loops do plain pointer arithmetic (no per-access TLS/vector indirection) — required to keep the vcache kernel competitive (see commit 3 / Performance).
4. **New FP16-input AVX2+F16C kernels** under `nntrainer::avx2`: `compute_kcaches(const _FP16*)`, `compute_fp16vcache_transposed(const _FP16*)`, and `softmax_row_inplace(_FP16*)` (FP16 and FP32 sink overloads). x86 has no native FP16 arithmetic, so all math accumulates in **FP32** (F16C widen on load, narrow on store) — functionally matching the ARM kernels, more accurate than FP16 accumulation.
5. **Same 3-layer dispatch as ARM** (`x86_compute_backend.h` decls → thin wrappers in `x86_compute_backend_fp16.cpp` → `avx2::` impls), gated by plain `#ifdef ENABLE_FP16`; the shared `cpu_backend.h` is untouched.

## Commits to be reviewed in this PR

<details><summary>feat: add x86 FP16-input attention kernels and remove kernel allocations (1afe91e0)</summary><br />

- Remove per-call allocations from the FP32-input kernels in `avx2_impl.cpp` (fold FP16→FP32 widening into `compute_kcaches`' dot loop; reusable `static thread_local` scratch for the vcache + softmax kernels; drop the non-RAII `new __m256[]`)
- Add FP16-input AVX2+F16C kernels in `avx2_impl_fp16.cpp` accumulating in FP32
- Public `nntrainer::` overloads in `x86_compute_backend.h`, delegating wrappers in `x86_compute_backend_fp16.cpp`, decls in `avx2_impl.h` (mirrors ARM layering)
- x86 attention unit tests vs an in-test FP32 software reference (5e-3 tol)

**Self evaluation:** 1. Build [X]Passed  2. Run [X]Passed

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>
</details>

<details><summary>fix: harden x86 attention remainder and scale paths (8ab7f7a7)</summary><br />

- Guard the `rem == 0` remainder handling in the vcache kernels against empty scratch; precompute `1 / sqrt(head_dim)` once for the QK kernels
- Add `rem == 0` local-window / head-slice tests for the FP16 QK, FP16 vcache, and FP32-input vcache paths

**Self evaluation:** 1. Build [X]Passed  2. Run [X]Passed

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>
</details>

<details><summary>fix: cache x86 attention vcache scratch pointers to avoid TLS indirection (e21b39ed)</summary><br />

- The compiler did not hoist the `static thread_local std::vector` data pointers out of the vcache hot loop, so the inner FMA loop paid per-access TLS/vector indirection — regressing `compute_fp16vcache_fp32_transposed` by ~20% for `gqa=1` (MHA) while `gqa>1` improved
- Resolve each thread_local `.data()` pointer once into a local; hot loops then do plain pointer arithmetic (matching the pre-rewrite local-buffer access), 0 per-call allocations preserved. Applied to the FP16-input vcache kernel too

**Self evaluation:** 1. Build [X]Passed  2. Run [X]Passed

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>
</details>

## Performance Improvements

Intel Core i5-12400F (6C/12T, AVX2+F16C), WSL2, GCC 12.3, `enable-fp16=true`, single-thread. One iteration = one full **causal** attention forward for a token block of length `seq_len` (`num_cache_head = 8`). Baseline = the pre-PR kernels on
#3967's head (`f26a5d3e`).

> Latency before/after is measured by **same-session interleaved A/B** (one bench binary, `LD_LIBRARY_PATH`-swapped `libnntrainer.so`, min-of-N): cross-session runs on this box drift up to ~2× and are not comparable.

### Allocation elimination (measured, per call)

| Kernel | before | after |
|:--|--:|--:|
| `compute_kcaches` (head_dim=128) | 1 | **0** |
| `compute_fp16vcache` (head_dim=128, rem=0) | 2 | **0** |
| `compute_fp16vcache` (head_dim=130, rem=2, 8 heads) | 10 | **0** |
| `softmax_row_inplace` (num_heads=64) | 2 | **0** |

### FP32-input `compute_kcaches` (Q·Kᵀ) — before → after

| seq_len, gqa, head_dim | speedup |
|:--|--:|
| 128, 1, 64 | **1.83×** |
| 512, 1, 64 | **1.84×** |
| 512, 4, 128 | **1.84×** |
| 1024, 1, 128 | **1.59×** |
| 1024, 4, 128 | **1.70×** |

`softmax_row_inplace` (FP32): parity (alloc-only change).

### FP32-input `compute_fp16vcache` (softmax·V) — before → after (final)

| seq_len, gqa, head_dim | speedup |
|:--|--:|
| 512, 1, 64 (MHA) | **1.19×** |
| 1024, 1, 128 (MHA) | ~parity |
| 512, 4, 128 (GQA) | **1.22×** |
| 1024, 4, 128 (GQA) | **1.16×** |

The initial commits regressed `gqa=1` to ~0.8×; commit `e21b39ed` (scratch-pointer caching) recovers it to parity-or-better and is 1.1–1.4× faster than the unfixed version — see the benchmark file for the full A/B.

### FP16-input vs FP32-input on x86 (both P4 kernels, same binary)

- `compute_fp16vcache_transposed` (softmax·V): **1.7–2.5× faster** than FP32-input at `gqa=1` (memory-bound; halved weight+output I/O), ~1.05× at `gqa=4`.
- `compute_kcaches`: ~1.5× faster at small `seq_len`, ~0.82–0.87× for `seq_len ≥ 512` (x86 must F16C-widen both Q and K). `softmax_row`: ~parity.

### Highlights

- **FP16-mode LLM inference on x86: non-functional → working** (the headline).
- **Per-call allocations eliminated** for every FP32-input attention kernel.
- **`compute_kcaches` 1.6–1.8× faster**; **`compute_fp16vcache` parity-to-1.2×** (after the TLS-caching fix); **FP16-input vcache 1.7–2.5× faster** than FP32-input.

## Known Limitations

- **`sum / sqrt(head_dim)` → `sum * (1/sqrt(head_dim))`** is not bit-exact vs the pre-PR FP32 output (within the 1e-4 test tolerance); deliberate, applied to both QK kernels.
- x86 FP16-input kernels accumulate in FP32, so they are numerically close to but not bit-identical to the ARM FP16-accumulate kernels (compared at 5e-3).
- `compute_kcaches` FP16-input is slower than FP32-input for `seq_len ≥ 512` (no native FP16 FMA on x86 → both operands need F16C widening); it is kept for functionality + model-level FP16 KV-cache memory savings.

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>
