### PR TITLE
[tensor] reduce peak memory

### DIFF
--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -63,7 +63,7 @@ void HalfTensor::allocate() {
     /// allocate new memory for the tensor data
     MemoryData *mem_data;
 
-    mem_data = new MemoryData((void *)(new _FP16[dim.getDataLen()]{}));
+    mem_data = new MemoryData((void *)(new _FP16[dim.getDataLen()]));
     data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
       delete[] mem_data->template getAddr<_FP16>();
       delete mem_data;

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -155,7 +155,7 @@ template <typename T> void UIntTensor<T>::allocate() {
 
     mem_data = new MemoryData(
       (void *)(new T[dim.getDataLen() + (sizeof(float) + sizeof(unsigned int)) /
-                                          sizeof(T) * scale_size()]{}));
+                                          sizeof(T) * scale_size()]));
     data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
       delete[] mem_data->template getAddr<T>();
       delete mem_data;
@@ -297,12 +297,22 @@ template <typename T> void UIntTensor<T>::initialize() {
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {
-  case Initializer::ZEROS:
+  case Initializer::ZEROS: {
     setZero();
+    float *scale = (float *)getScale();
+    std::fill(scale, scale + scale_size(), 1.0f);
+    unsigned int *zerop = getZeroPoint();
+    std::fill(zerop, zerop + scale_size(), 0u);
     break;
-  case Initializer::ONES:
+  }
+  case Initializer::ONES: {
     setValue(1.0f);
+    float *scale = (float *)getScale();
+    std::fill(scale, scale + scale_size(), 1.0f);
+    unsigned int *zerop = getZeroPoint();
+    std::fill(zerop, zerop + scale_size(), 0u);
     break;
+  }
   case Initializer::NONE:
     break;
   default:


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>{commit-1}</summary><br />

[tensor] reduce peak memory

This commit removes default initialization list for fp16 and uint8 tensor.
This logic should have included in PR #3986, but it didn't.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
This PR adds missing logic from #3986.
Now the peak memory reduces correctly.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped