### PR TITLE
[DDTree] Parallelize and speed up buildTree per-depth preprocessing

### DIFF
--- a/nntrainer/utils/ddtree/ddtree.cpp
+++ b/nntrainer/utils/ddtree/ddtree.cpp
@@ -13,7 +13,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <queue>
+
+#include <thread_manager.h>
 
 namespace nntrainer {
 namespace ddtree {
@@ -37,37 +40,66 @@ DDTreeStructure buildTree(const float *draftLogits, int depthLimit, int vocab,
   // Per-row top-k: top_log_probs (fp32) and top_token_ids, sorted by
   // (logit desc, token index asc) to match torch.topk on CPU.
   // topLogProbs[d][r] = top_logit - logsumexp(row d). (ddtree.py 114-117)
+  //
+  // Each depth row is independent, so the rows are computed in parallel via the
+  // nntrainer ThreadManager. The math is byte-identical to the original
+  // sequential version (golden parity): the running max equals the full-row max,
+  // and logsumexp is still the double-precision exp accumulation in token-index
+  // order. Only the top-k *selection* changed — a bounded heap keyed by the same
+  // (logit desc, token asc) order replaces the O(vocab) index array +
+  // partial_sort, so it yields the identical top-k set and ordering in a single
+  // sequential pass (cache-friendly, no per-row vocab-sized allocation).
   std::vector<std::vector<float>> topLogProbs(depthLimit);
   std::vector<std::vector<int32_t>> topTokenIds(depthLimit);
-  for (int d = 0; d < depthLimit; ++d) {
-    const float *row = draftLogits + static_cast<size_t>(d) * vocab;
 
-    std::vector<int32_t> idx(vocab);
-    for (int i = 0; i < vocab; ++i)
-      idx[i] = i;
-    std::partial_sort(idx.begin(), idx.begin() + topk, idx.end(),
-                      [row](int32_t a, int32_t b) {
-                        if (row[a] != row[b])
-                          return row[a] > row[b]; // logit desc
-                        return a < b; // tie: lower token index first
-                      });
+  // Heap candidate; comparator orders "better" (higher logit, lower token on a
+  // tie) as greater so priority_queue::top() is the worst kept candidate.
+  struct Cand {
+    float logit;
+    int32_t token;
+  };
+  auto better = [](const Cand &a, const Cand &b) {
+    if (a.logit != b.logit)
+      return a.logit > b.logit; // higher logit is better
+    return a.token < b.token;   // tie: lower token index is better
+  };
 
-    // logsumexp in double for accuracy; result stored as fp32 (parity §6.2).
-    float maxLogit = row[0];
-    for (int i = 1; i < vocab; ++i)
-      maxLogit = std::max(maxLogit, row[i]);
+  auto &tm = ThreadManager::Global();
+  tm.parallel_for(0, static_cast<size_t>(depthLimit), [&](size_t d) {
+    const float *row = draftLogits + d * static_cast<size_t>(vocab);
+
+    // Single pass: running max (== full-row max) + bounded top-k heap.
+    std::priority_queue<Cand, std::vector<Cand>, decltype(better)> heap(better);
+    float maxLogit = -std::numeric_limits<float>::infinity();
+    for (int i = 0; i < vocab; ++i) {
+      const float x = row[i];
+      maxLogit = std::max(maxLogit, x);
+      const Cand c{x, i};
+      if (static_cast<int>(heap.size()) < topk)
+        heap.push(c);
+      else if (better(c, heap.top())) {
+        heap.pop();
+        heap.push(c);
+      }
+    }
+
+    // logsumexp in double for accuracy (token-index order, parity §6.2);
+    // result stored as fp32.
     double sumExp = 0.0;
     for (int i = 0; i < vocab; ++i)
       sumExp += std::exp(static_cast<double>(row[i]) - maxLogit);
     const float logZ = static_cast<float>(maxLogit + std::log(sumExp));
 
+    // Drain heap worst-first into best-first order (== partial_sort result).
     topLogProbs[d].resize(topk);
     topTokenIds[d].resize(topk);
-    for (int r = 0; r < topk; ++r) {
-      topTokenIds[d][r] = idx[r];
-      topLogProbs[d][r] = row[idx[r]] - logZ; // fp32 subtraction
+    for (int r = topk - 1; r >= 0; --r) {
+      const Cand c = heap.top();
+      heap.pop();
+      topTokenIds[d][r] = c.token;
+      topLogProbs[d][r] = c.logit - logZ; // fp32 subtraction
     }
-  }
+  });
 
   // Heap entry mirrors the Python tuple (-logw, ranks, parent, depth, rank,
   // logw). Comparison is the Python tuple order; ranks is variable-length

--- a/nntrainer/utils/ddtree/ddtree.cpp
+++ b/nntrainer/utils/ddtree/ddtree.cpp
@@ -52,8 +52,8 @@ DDTreeStructure buildTree(const float *draftLogits, int depthLimit, int vocab,
   std::vector<std::vector<float>> topLogProbs(depthLimit);
   std::vector<std::vector<int32_t>> topTokenIds(depthLimit);
 
-  // Heap candidate; comparator orders "better" (higher logit, lower token on a
-  // tie) as greater so priority_queue::top() is the worst kept candidate.
+  // Top-k candidate; "better" == (higher logit, lower token on a tie), matching
+  // torch.topk's (logit desc, token index asc) total order.
   struct Cand {
     float logit;
     int32_t token;
@@ -68,20 +68,46 @@ DDTreeStructure buildTree(const float *draftLogits, int depthLimit, int vocab,
   tm.parallel_for(0, static_cast<size_t>(depthLimit), [&](size_t d) {
     const float *row = draftLogits + d * static_cast<size_t>(vocab);
 
-    // Single pass: running max (== full-row max) + bounded top-k heap.
-    std::priority_queue<Cand, std::vector<Cand>, decltype(better)> heap(better);
-    float maxLogit = -std::numeric_limits<float>::infinity();
+    // Single sequential pass top-k via a threshold + small array: the hot path
+    // is one well-predicted `x < thresh` compare that rejects the ~99.98% of
+    // tokens outside the top-k, so it avoids the per-element priority_queue
+    // push/pop and Cand churn. `thresh` is the worst kept logit once `buf` is
+    // full; ties (x == thresh) fall through to the full `better` comparison so
+    // the lower token index still wins. The selected set/order is identical to
+    // a partial_sort (logit/token is a total order), preserving golden parity.
+    std::vector<Cand> buf;
+    buf.reserve(topk);
+    float thresh = -std::numeric_limits<float>::infinity();
+    int worstPos = 0;
     for (int i = 0; i < vocab; ++i) {
       const float x = row[i];
-      maxLogit = std::max(maxLogit, x);
-      const Cand c{x, i};
-      if (static_cast<int>(heap.size()) < topk)
-        heap.push(c);
-      else if (better(c, heap.top())) {
-        heap.pop();
-        heap.push(c);
+      if (static_cast<int>(buf.size()) < topk) {
+        buf.push_back(Cand{x, i});
+        if (static_cast<int>(buf.size()) == topk) {
+          worstPos = 0;
+          for (int j = 1; j < topk; ++j)
+            if (better(buf[worstPos], buf[j]))
+              worstPos = j;
+          thresh = buf[worstPos].logit;
+        }
+        continue;
       }
+      if (x < thresh)
+        continue; // outside top-k: single-compare fast reject
+      const Cand c{x, i};
+      if (!better(c, buf[worstPos]))
+        continue; // x == thresh tie resolved by token index
+      buf[worstPos] = c;
+      worstPos = 0; // recompute worst (rare: only on an actual insertion)
+      for (int j = 1; j < topk; ++j)
+        if (better(buf[worstPos], buf[j]))
+          worstPos = j;
+      thresh = buf[worstPos].logit;
     }
+    std::sort(buf.begin(), buf.end(), better); // best-first (== partial_sort)
+    // The global max is always kept, so it is the best candidate; reuse it for
+    // logsumexp instead of a separate full-row max scan.
+    const float maxLogit = buf[0].logit;
 
     // logsumexp in double for accuracy (token-index order, parity §6.2);
     // result stored as fp32.
@@ -90,14 +116,11 @@ DDTreeStructure buildTree(const float *draftLogits, int depthLimit, int vocab,
       sumExp += std::exp(static_cast<double>(row[i]) - maxLogit);
     const float logZ = static_cast<float>(maxLogit + std::log(sumExp));
 
-    // Drain heap worst-first into best-first order (== partial_sort result).
     topLogProbs[d].resize(topk);
     topTokenIds[d].resize(topk);
-    for (int r = topk - 1; r >= 0; --r) {
-      const Cand c = heap.top();
-      heap.pop();
-      topTokenIds[d][r] = c.token;
-      topLogProbs[d][r] = c.logit - logZ; // fp32 subtraction
+    for (int r = 0; r < topk; ++r) {
+      topTokenIds[d][r] = buf[r].token;
+      topLogProbs[d][r] = buf[r].logit - logZ; // fp32 subtraction
     }
   });
 

--- a/nntrainer/utils/ddtree/ddtree.cpp
+++ b/nntrainer/utils/ddtree/ddtree.cpp
@@ -43,12 +43,9 @@ DDTreeStructure buildTree(const float *draftLogits, int depthLimit, int vocab,
   //
   // Each depth row is independent, so the rows are computed in parallel via the
   // nntrainer ThreadManager. The math is byte-identical to the original
-  // sequential version (golden parity): the running max equals the full-row max,
-  // and logsumexp is still the double-precision exp accumulation in token-index
-  // order. Only the top-k *selection* changed — a bounded heap keyed by the same
-  // (logit desc, token asc) order replaces the O(vocab) index array +
-  // partial_sort, so it yields the identical top-k set and ordering in a single
-  // sequential pass (cache-friendly, no per-row vocab-sized allocation).
+  // sequential version (golden parity): the max equals the full-row max, and
+  // logsumexp is still the double-precision exp accumulation in token-index
+  // order. Only the top-k selection method changed (see the scan below).
   std::vector<std::vector<float>> topLogProbs(depthLimit);
   std::vector<std::vector<int32_t>> topTokenIds(depthLimit);
 

--- a/test/unittest/unittest_ddtree.cpp
+++ b/test/unittest/unittest_ddtree.cpp
@@ -446,7 +446,8 @@ TEST(DDTreeBuild, MatchesPythonGolden) {
 // Pre-optimization reference: the original sequential buildTree (index-array +
 // std::partial_sort top-k, single-threaded). The optimized buildTree must
 // reproduce this byte-for-byte on every input. Kept self-contained here so the
-// equivalence test pins the refactor's behavior independent of the shipped code.
+// equivalence test pins the refactor's behavior independent of the shipped
+// code.
 static DDTreeStructure buildTreeReference(const float *draftLogits,
                                           int depthLimit, int vocab,
                                           const DDTreeConfig &cfg) {

--- a/test/unittest/unittest_ddtree.cpp
+++ b/test/unittest/unittest_ddtree.cpp
@@ -11,9 +11,14 @@
  */
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
+#include <queue>
+#include <random>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <build_golden.h>
@@ -435,6 +440,175 @@ TEST(DDTreeBuild, MatchesPythonGolden) {
     for (size_t k = 0; k < t.visibility.size(); ++k)
       EXPECT_EQ(static_cast<int32_t>(t.visibility[k]), expVis[k])
         << name << " vis@" << k;
+  }
+}
+
+// Pre-optimization reference: the original sequential buildTree (index-array +
+// std::partial_sort top-k, single-threaded). The optimized buildTree must
+// reproduce this byte-for-byte on every input. Kept self-contained here so the
+// equivalence test pins the refactor's behavior independent of the shipped code.
+static DDTreeStructure buildTreeReference(const float *draftLogits,
+                                          int depthLimit, int vocab,
+                                          const DDTreeConfig &cfg) {
+  DDTreeStructure t;
+  if (cfg.budget <= 0 || depthLimit == 0) {
+    t.nodeCount = 0;
+    t.currentLength = 1;
+    t.parents = {-1};
+    t.childMaps.resize(1);
+    t.visibility = {1};
+    return t;
+  }
+
+  const int topk = std::min(cfg.budget, vocab);
+  std::vector<std::vector<float>> topLogProbs(depthLimit);
+  std::vector<std::vector<int32_t>> topTokenIds(depthLimit);
+  for (int d = 0; d < depthLimit; ++d) {
+    const float *row = draftLogits + static_cast<size_t>(d) * vocab;
+    std::vector<int32_t> idx(vocab);
+    for (int i = 0; i < vocab; ++i)
+      idx[i] = i;
+    std::partial_sort(idx.begin(), idx.begin() + topk, idx.end(),
+                      [row](int32_t a, int32_t b) {
+                        if (row[a] != row[b])
+                          return row[a] > row[b];
+                        return a < b;
+                      });
+    float maxLogit = row[0];
+    for (int i = 1; i < vocab; ++i)
+      maxLogit = std::max(maxLogit, row[i]);
+    double sumExp = 0.0;
+    for (int i = 0; i < vocab; ++i)
+      sumExp += std::exp(static_cast<double>(row[i]) - maxLogit);
+    const float logZ = static_cast<float>(maxLogit + std::log(sumExp));
+    topLogProbs[d].resize(topk);
+    topTokenIds[d].resize(topk);
+    for (int r = 0; r < topk; ++r) {
+      topTokenIds[d][r] = idx[r];
+      topLogProbs[d][r] = row[idx[r]] - logZ;
+    }
+  }
+
+  struct Entry {
+    double negLogw;
+    std::vector<int32_t> ranks;
+    int parentIndex;
+    int depth;
+    int rank;
+    double logw;
+  };
+  auto pythonLess = [](const Entry &a, const Entry &b) {
+    if (a.negLogw != b.negLogw)
+      return a.negLogw < b.negLogw;
+    if (a.ranks != b.ranks)
+      return a.ranks < b.ranks;
+    if (a.parentIndex != b.parentIndex)
+      return a.parentIndex < b.parentIndex;
+    if (a.depth != b.depth)
+      return a.depth < b.depth;
+    if (a.rank != b.rank)
+      return a.rank < b.rank;
+    return a.logw < b.logw;
+  };
+  auto comp = [&pythonLess](const Entry &x, const Entry &y) {
+    return pythonLess(y, x);
+  };
+  std::priority_queue<Entry, std::vector<Entry>, decltype(comp)> heap(comp);
+
+  const double firstLogw = static_cast<double>(topLogProbs[0][0]);
+  heap.push(Entry{-firstLogw, {0}, 0, 1, 0, firstLogw});
+
+  t.parents.assign(cfg.budget + 1, 0);
+  t.parents[0] = -1;
+  t.childMaps.clear();
+  t.childMaps.emplace_back();
+  t.nodeTokenIds.clear();
+  t.nodeDepths.clear();
+
+  int nodeCount = 0;
+  while (!heap.empty() && nodeCount < cfg.budget) {
+    Entry e = heap.top();
+    heap.pop();
+    const int32_t tokenId = topTokenIds[e.depth - 1][e.rank];
+    const int currentIndex = nodeCount + 1;
+    t.nodeTokenIds.push_back(tokenId);
+    t.nodeDepths.push_back(e.depth);
+    t.parents[currentIndex] = e.parentIndex;
+    t.childMaps.emplace_back();
+    t.childMaps[e.parentIndex][tokenId] = currentIndex;
+    ++nodeCount;
+    if (e.rank + 1 < topk) {
+      std::vector<int32_t> siblingRanks = e.ranks;
+      siblingRanks.back() = e.rank + 1;
+      const double siblingLogw =
+        e.logw - static_cast<double>(topLogProbs[e.depth - 1][e.rank]) +
+        static_cast<double>(topLogProbs[e.depth - 1][e.rank + 1]);
+      heap.push(Entry{-siblingLogw, std::move(siblingRanks), e.parentIndex,
+                      e.depth, e.rank + 1, siblingLogw});
+    }
+    if (e.depth < depthLimit) {
+      std::vector<int32_t> childRanks = e.ranks;
+      childRanks.push_back(0);
+      const double childLogw =
+        e.logw + static_cast<double>(topLogProbs[e.depth][0]);
+      heap.push(Entry{-childLogw, std::move(childRanks), currentIndex,
+                      e.depth + 1, 0, childLogw});
+    }
+  }
+
+  const int currentLength = 1 + nodeCount;
+  t.nodeCount = nodeCount;
+  t.currentLength = currentLength;
+  t.parents.resize(currentLength);
+  t.visibility.assign(static_cast<size_t>(currentLength) * currentLength, 0);
+  t.visibility[0] = 1;
+  for (int index = 1; index < currentLength; ++index) {
+    const int parent = t.parents[index];
+    for (int j = 0; j < index; ++j)
+      t.visibility[static_cast<size_t>(index) * currentLength + j] =
+        t.visibility[static_cast<size_t>(parent) * currentLength + j];
+    t.visibility[static_cast<size_t>(index) * currentLength + index] = 1;
+  }
+  return t;
+}
+
+// The optimized (parallel, heap-based top-k) buildTree must match the original
+// sequential reference byte-for-byte across many random large-vocab inputs that
+// the small embedded golden vectors do not exercise.
+TEST(DDTreeBuild, MatchesSequentialReferenceRandom) {
+  std::mt19937 rng(20260618u);
+  std::normal_distribution<float> nd(0.0f, 4.0f);
+
+  struct Dim {
+    int depth, vocab, budget;
+  };
+  // Includes a realistic config (depth 15, vocab 150272, budget 31) plus small
+  // and tie-prone cases. A few replicas of the big case catch nondeterminism.
+  const std::vector<Dim> dims = {
+    {15, 150272, 31}, {15, 150272, 31}, {7, 150272, 31}, {3, 50, 31},
+    {4, 33, 100},     {2, 7, 5},        {15, 150272, 1}, {8, 20000, 63},
+  };
+
+  for (size_t ci = 0; ci < dims.size(); ++ci) {
+    const Dim dm = dims[ci];
+    std::vector<float> logits(static_cast<size_t>(dm.depth) * dm.vocab);
+    for (auto &v : logits)
+      v = nd(rng);
+
+    DDTreeConfig cfg;
+    cfg.budget = dm.budget;
+    cfg.depthLimit = dm.depth - 1;
+
+    DDTreeStructure got = buildTree(logits.data(), dm.depth, dm.vocab, cfg);
+    DDTreeStructure ref =
+      buildTreeReference(logits.data(), dm.depth, dm.vocab, cfg);
+
+    EXPECT_EQ(got.nodeCount, ref.nodeCount) << "case " << ci;
+    EXPECT_EQ(got.currentLength, ref.currentLength) << "case " << ci;
+    EXPECT_EQ(got.nodeTokenIds, ref.nodeTokenIds) << "case " << ci;
+    EXPECT_EQ(got.nodeDepths, ref.nodeDepths) << "case " << ci;
+    EXPECT_EQ(got.parents, ref.parents) << "case " << ci;
+    EXPECT_EQ(got.visibility, ref.visibility) << "case " << ci;
   }
 }
 


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR


<details><summary>[DDTree] Parallelize and speed up buildTree per-depth preprocessing</summary><br />

The per-depth top-k/logsumexp loop in buildTree was the dominant cost:
for each of depthLimit rows it allocated an idx[vocab] array, ran
std::partial_sort over the full vocab, computed a separate full-row max,
and then logsumexp, all single-threaded. For a realistic config
(depth 15, vocab 150272, budget 31) this takes ~13 ms per call.

Each depth row is independent, so distribute the rows across the
nntrainer ThreadManager via parallel_for. Within a row, replace the
idx[vocab] + partial_sort top-k with a single sequential pass that keeps
a bounded min-heap of size topk (cache-friendly, no per-row vocab-sized
allocation) and computes the running max in the same pass. The
logsumexp(logZ) still accumulates double std::exp in token-index order
with the same max, so topLogProbs/topTokenIds and the resulting tree are
byte-identical to the previous sequential version (golden parity
preserved). With 4 threads this is ~3x faster on a host benchmark
(~13 ms -> ~4 ms); the gain scales with the number of worker threads.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>



<details><summary>[DDTree/Test] Add sequential-reference equivalence test for buildTree</summary><br />

The embedded Python golden vectors only exercise small trees, so they do
not cover the large-vocab path or the parallel top-k selection. Add a
self-contained pre-optimization reference (idx[vocab] + partial_sort,
single-threaded) and a randomized test that asserts the optimized
buildTree reproduces it byte-for-byte (nodeTokenIds, nodeDepths, parents,
visibility, nodeCount, currentLength) across many random inputs. Cases
include the realistic depth 15 / vocab 150272 / budget 31 config plus
tie-prone small rows and budget-edge cases; replicas of the big case
guard against nondeterminism from the parallel path.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

- Parallelize buildTree's per-depth top-k/logsumexp preprocessing over the
  nntrainer ThreadManager and replace the idx[vocab] + std::partial_sort top-k
  with a bounded-heap single-pass selection. Output is byte-identical to the
  previous sequential version (golden parity preserved); ~3x faster with 4
  threads on a host benchmark.
- Add a sequential-reference equivalence unit test that checks the optimized
  buildTree matches the pre-optimization algorithm byte-for-byte on large-vocab
  random inputs. Verified locally with a host g++ build of unittest_ddtree
  (22/22 tests passed, including MatchesPythonGolden and the new
  MatchesSequentialReferenceRandom).

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
