### PR TITLE
[Application] Add YOLOv11m model (inference only)

### DIFF
--- a/Applications/CausalLM/models/YOLOv11/PyTorch/compare_safetensors_q40.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/compare_safetensors_q40.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+@file   compare_safetensors_q40.py
+@brief  Byte-equivalence check between two nntrainer safetensors files.
+
+Verifies that the C++ `nntr_quantize` output matches the reference python
+quantizer output (quantize_q4_0_conv.py) tensor-for-tensor. For every tensor
+present in both files it compares the raw data blob byte-for-byte and reports
+the per-tensor verdict, with special attention to Q4_0 (nntr_dtype) tensors.
+
+Usage:
+  python compare_safetensors_q40.py A.safetensors B.safetensors
+"""
+import json
+import struct
+import sys
+
+
+def parse(path):
+    with open(path, "rb") as f:
+        hsize = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(hsize).decode("utf-8"))
+        data = f.read()
+    return header, data
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: compare_safetensors_q40.py A.safetensors B.safetensors")
+        sys.exit(2)
+    ha, da = parse(sys.argv[1])
+    hb, db = parse(sys.argv[2])
+
+    names_a = {k for k in ha if k != "__metadata__"}
+    names_b = {k for k in hb if k != "__metadata__"}
+
+    only_a = sorted(names_a - names_b)
+    only_b = sorted(names_b - names_a)
+    common = sorted(names_a & names_b)
+
+    if only_a:
+        print(f"[only in A] {len(only_a)}: {only_a[:8]}{'...' if len(only_a) > 8 else ''}")
+    if only_b:
+        print(f"[only in B] {len(only_b)}: {only_b[:8]}{'...' if len(only_b) > 8 else ''}")
+
+    n_q40 = 0
+    n_q40_match = 0
+    n_other = 0
+    n_other_match = 0
+    mismatches = []
+
+    for name in common:
+        ea, eb = ha[name], hb[name]
+        oa, ob = ea["data_offsets"], eb["data_offsets"]
+        ba = da[oa[0]:oa[1]]
+        bb = db[ob[0]:ob[1]]
+        is_q40 = ea.get("nntr_dtype") == "Q4_0" or eb.get("nntr_dtype") == "Q4_0"
+        match = (ba == bb)
+        if is_q40:
+            n_q40 += 1
+            n_q40_match += int(match)
+        else:
+            n_other += 1
+            n_other_match += int(match)
+        if not match:
+            # find first differing byte
+            first = next((i for i in range(min(len(ba), len(bb))) if ba[i] != bb[i]), None)
+            mismatches.append(
+                (name, "Q4_0" if is_q40 else ea.get("nntr_dtype", ea.get("dtype")),
+                 len(ba), len(bb), first,
+                 ea.get("nntr_shape", ea.get("shape")),
+                 eb.get("nntr_shape", eb.get("shape"))))
+
+    print(f"\nQ4_0 tensors:  {n_q40_match}/{n_q40} byte-identical")
+    print(f"other tensors: {n_other_match}/{n_other} byte-identical")
+    if mismatches:
+        print(f"\nMISMATCHES ({len(mismatches)}):")
+        for name, dt, la, lb, first, sa, sb in mismatches[:40]:
+            print(f"  {name} [{dt}] lenA={la} lenB={lb} firstDiff={first} shapeA={sa} shapeB={sb}")
+    ok = (not only_a and not only_b and not mismatches)
+    print("\nRESULT:", "IDENTICAL ✓" if ok else "DIFFERENCES FOUND ✗")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
@@ -71,14 +71,19 @@ class Pack:
         self.conv_bn(f"{pt}.cv1", f"{nn}/cv1")
         self.conv_bn(f"{pt}.cv2", f"{nn}/cv2")
         m, o = f"{pt}.m.0", f"{nn}/m0"
-        self.conv_bn(f"{m}.cv1", f"{o}/cv1")
-        self.conv_bn(f"{m}.cv2", f"{o}/cv2")
-        self.conv_bn(f"{m}.cv3", f"{o}/cv3")
-        j = 0
-        while f"{m}.m.{j}.cv1.conv.weight" in self.sd:
-            self.conv_bn(f"{m}.m.{j}.cv1", f"{o}/inner{j}/cv1")
-            self.conv_bn(f"{m}.m.{j}.cv2", f"{o}/inner{j}/cv2")
-            j += 1
+        # If cv3 exists, it's a C3k block. Otherwise it's a Bottleneck block.
+        if f"{m}.cv3.conv.weight" in self.sd:
+            self.conv_bn(f"{m}.cv1", f"{o}/cv1")
+            self.conv_bn(f"{m}.cv2", f"{o}/cv2")
+            self.conv_bn(f"{m}.cv3", f"{o}/cv3")
+            j = 0
+            while f"{m}.m.{j}.cv1.conv.weight" in self.sd:
+                self.conv_bn(f"{m}.m.{j}.cv1", f"{o}/inner{j}/cv1")
+                self.conv_bn(f"{m}.m.{j}.cv2", f"{o}/inner{j}/cv2")
+                j += 1
+        else:
+            self.conv_bn(f"{m}.cv1", f"{o}/cv1")
+            self.conv_bn(f"{m}.cv2", f"{o}/cv2")
 
     def c2psa(self, pt, nn):
         self.conv_bn(f"{pt}.cv1", f"{nn}/cv1")

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Convert YOLOv11m ultralytics (.pt) weights into a single nntrainer-compatible
+@file convert_weights.py
+@brief Convert YOLOv11m ultralytics (.pt) weights into a single nntrainer-compatible
 safetensors file, with tensor names matching the nntrainer model's weight names
 (as built by Applications/CausalLM/models/YOLOv11/jni/main.cpp). The example
 then loads everything with one call: model->load(file, SAFETENSORS).

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
@@ -6,12 +6,17 @@ safetensors file, with tensor names matching the nntrainer model's weight names
 (as built by Applications/CausalLM/models/YOLOv11/jni/main.cpp). The example
 then loads everything with one call: model->load(file, SAFETENSORS).
 
+Inference-only: Conv+BatchNorm pairs are fused (ultralytics model.fuse()) so
+each Conv module exports a single biased convolution and no BatchNorm tensors.
+This removes the BN layers from the nntrainer graph entirely (fewer ops, lower
+memory, and no mixed-precision BN path), with no accuracy change since BN is an
+exact affine fold at inference time.
+
 Naming scheme (matches nntrainer Weight::getName()):
   conv2d weight : "{layer}/conv:filter"        shape [out, in, kh, kw]
   conv2d bias   : "{layer}/conv:bias"          shape [1, C, 1, 1]
   depthwise     : "{layer}/dw:filter"          shape [C, 1, kh, kw]
-  batchnorm     : "{layer}/bn:moving_mean", ":moving_variance", ":gamma", ":beta"
-                  each shape [1, C, 1, 1]
+  depthwise bias: "{layer}/dw:bias"            shape [1, C, 1, 1]
 (depthwise convolution is a grouped conv2d, groups == channels.)
 
 Usage:
@@ -48,17 +53,14 @@ class Pack:
     def _np(self, key):
         return self.sd[key].detach().cpu().float().numpy().astype(np.float32)
 
-    def _bnvec(self, key, C):
-        return self._np(key).reshape(1, C, 1, 1)
-
     def conv_bn(self, pt, nn, dw=False):
+        # A PyTorch Conv module (conv+BN[+act]) already fused by model.fuse():
+        # the module now holds a single biased convolution and no BN tensors.
         w = self._np(f"{pt}.conv.weight")
-        C = w.shape[0]
-        self.T[f"{nn}/{'dw' if dw else 'conv'}:filter"] = w
-        self.T[f"{nn}/bn:moving_mean"] = self._bnvec(f"{pt}.bn.running_mean", C)
-        self.T[f"{nn}/bn:moving_variance"] = self._bnvec(f"{pt}.bn.running_var", C)
-        self.T[f"{nn}/bn:gamma"] = self._bnvec(f"{pt}.bn.weight", C)
-        self.T[f"{nn}/bn:beta"] = self._bnvec(f"{pt}.bn.bias", C)
+        b = self._np(f"{pt}.conv.bias")
+        key = "dw" if dw else "conv"
+        self.T[f"{nn}/{key}:filter"] = w
+        self.T[f"{nn}/{key}:bias"] = b.reshape(1, w.shape[0], 1, 1)
 
     def conv_bias(self, pt, nn):
         w = self._np(f"{pt}.weight")
@@ -120,7 +122,10 @@ class Pack:
 
 def main(weights, out):
     from ultralytics import YOLO
-    sd = YOLO(weights).model.state_dict()
+    model = YOLO(weights).model
+    model.eval()
+    model.fuse()  # fold Conv+BatchNorm into a single biased conv (inference-only)
+    sd = model.state_dict()
     p = Pack(sd)
 
     for pt, nn in BACKBONE.items():

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Convert YOLOv11m ultralytics (.pt) weights into a single nntrainer-compatible
+safetensors file, with tensor names matching the nntrainer model's weight names
+(as built by Applications/CausalLM/models/YOLOv11/jni/main.cpp). The example
+then loads everything with one call: model->load(file, SAFETENSORS).
+
+Naming scheme (matches nntrainer Weight::getName()):
+  conv2d weight : "{layer}/conv:filter"        shape [out, in, kh, kw]
+  conv2d bias   : "{layer}/conv:bias"          shape [1, C, 1, 1]
+  depthwise     : "{layer}/dw:filter"          shape [C, 1, kh, kw]
+  batchnorm     : "{layer}/bn:moving_mean", ":moving_variance", ":gamma", ":beta"
+                  each shape [1, C, 1, 1]
+(depthwise convolution is a grouped conv2d, groups == channels.)
+
+Usage:
+  python convert_weights.py --weights v11m_832rect_best.pt --out ../res/yolov11m.safetensors
+"""
+import os
+import json
+import struct
+import argparse
+
+import numpy as np
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+# nntrainer layer-name for each YOLOv11 module (mirrors main.cpp graph names).
+BACKBONE = {
+    "model.0": "conv0", "model.1": "conv1", "model.3": "conv3",
+    "model.5": "conv5", "model.7": "conv7", "model.17": "m17", "model.20": "m20",
+}
+C3K2 = {  # PyTorch module -> nntrainer base name
+    "model.2": "m2", "model.4": "m4", "model.6": "m6", "model.8": "m8",
+    "model.13": "m13", "model.16": "m16", "model.19": "m19", "model.22": "m22",
+}
+
+
+class Pack:
+    """Accumulates {name: float32 ndarray} and writes one safetensors file."""
+
+    def __init__(self, sd):
+        self.sd = sd
+        self.T = {}
+
+    def _np(self, key):
+        return self.sd[key].detach().cpu().float().numpy().astype(np.float32)
+
+    def _bnvec(self, key, C):
+        return self._np(key).reshape(1, C, 1, 1)
+
+    def conv_bn(self, pt, nn, dw=False):
+        w = self._np(f"{pt}.conv.weight")
+        C = w.shape[0]
+        self.T[f"{nn}/{'dw' if dw else 'conv'}:filter"] = w
+        self.T[f"{nn}/bn:moving_mean"] = self._bnvec(f"{pt}.bn.running_mean", C)
+        self.T[f"{nn}/bn:moving_variance"] = self._bnvec(f"{pt}.bn.running_var", C)
+        self.T[f"{nn}/bn:gamma"] = self._bnvec(f"{pt}.bn.weight", C)
+        self.T[f"{nn}/bn:beta"] = self._bnvec(f"{pt}.bn.bias", C)
+
+    def conv_bias(self, pt, nn):
+        w = self._np(f"{pt}.weight")
+        self.T[f"{nn}/conv:filter"] = w
+        self.T[f"{nn}/conv:bias"] = self._np(f"{pt}.bias").reshape(1, w.shape[0], 1, 1)
+
+    def c3k2(self, pt, nn):
+        self.conv_bn(f"{pt}.cv1", f"{nn}/cv1")
+        self.conv_bn(f"{pt}.cv2", f"{nn}/cv2")
+        m, o = f"{pt}.m.0", f"{nn}/m0"
+        self.conv_bn(f"{m}.cv1", f"{o}/cv1")
+        self.conv_bn(f"{m}.cv2", f"{o}/cv2")
+        self.conv_bn(f"{m}.cv3", f"{o}/cv3")
+        j = 0
+        while f"{m}.m.{j}.cv1.conv.weight" in self.sd:
+            self.conv_bn(f"{m}.m.{j}.cv1", f"{o}/inner{j}/cv1")
+            self.conv_bn(f"{m}.m.{j}.cv2", f"{o}/inner{j}/cv2")
+            j += 1
+
+    def c2psa(self, pt, nn):
+        self.conv_bn(f"{pt}.cv1", f"{nn}/cv1")
+        self.conv_bn(f"{pt}.cv2", f"{nn}/cv2")
+        self.conv_bn(f"{pt}.m.0.attn.qkv", f"{nn}/qkv")
+        self.conv_bn(f"{pt}.m.0.attn.proj", f"{nn}/proj")
+        self.conv_bn(f"{pt}.m.0.attn.pe", f"{nn}/pe", dw=True)
+        self.conv_bn(f"{pt}.m.0.ffn.0", f"{nn}/ffn0")
+        self.conv_bn(f"{pt}.m.0.ffn.1", f"{nn}/ffn1")
+
+    def detect(self, pt):
+        for i in range(3):
+            self.conv_bn(f"{pt}.cv2.{i}.0", f"det{i}/cv2_0")
+            self.conv_bn(f"{pt}.cv2.{i}.1", f"det{i}/cv2_1")
+            self.conv_bias(f"{pt}.cv2.{i}.2", f"det{i}/cv2_2")
+            self.conv_bn(f"{pt}.cv3.{i}.0.0", f"det{i}/cv3_0_dw", dw=True)
+            self.conv_bn(f"{pt}.cv3.{i}.0.1", f"det{i}/cv3_0_pw")
+            self.conv_bn(f"{pt}.cv3.{i}.1.0", f"det{i}/cv3_1_dw", dw=True)
+            self.conv_bn(f"{pt}.cv3.{i}.1.1", f"det{i}/cv3_1_pw")
+            self.conv_bias(f"{pt}.cv3.{i}.2", f"det{i}/cv3_2")
+
+    def write(self, path):
+        names = list(self.T.keys())
+        header, blob, offset = {}, bytearray(), 0
+        for n in names:
+            arr = np.ascontiguousarray(self.T[n], dtype="<f4")
+            b = arr.tobytes()
+            header[n] = {"dtype": "F32", "shape": list(arr.shape),
+                         "data_offsets": [offset, offset + len(b)]}
+            blob += b
+            offset += len(b)
+        hjson = json.dumps(header, separators=(",", ":")).encode("utf-8")
+        # safetensors: 8-byte little-endian header length, header, then data
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(struct.pack("<Q", len(hjson)))
+            f.write(hjson)
+            f.write(blob)
+        return len(names)
+
+
+def main(weights, out):
+    from ultralytics import YOLO
+    sd = YOLO(weights).model.state_dict()
+    p = Pack(sd)
+
+    for pt, nn in BACKBONE.items():
+        p.conv_bn(pt, nn)
+    for pt, nn in C3K2.items():
+        p.c3k2(pt, nn)
+    p.conv_bn("model.9.cv1", "m9/cv1")
+    p.conv_bn("model.9.cv2", "m9/cv2")
+    p.c2psa("model.10", "m10")
+    p.detect("model.23")
+
+    n = p.write(out)
+    print(f"Wrote {n} tensors to nntrainer safetensors: {out}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(
+        description="Convert YOLOv11m .pt to a single nntrainer safetensors")
+    ap.add_argument("--weights", required=True,
+                    help="path to the ultralytics YOLOv11m .pt checkpoint")
+    ap.add_argument("--out", default=os.path.join(_HERE, "..", "res",
+                                                  "yolov11m.safetensors"),
+                    help="output safetensors path (default: ../res/yolov11m.safetensors)")
+    args = ap.parse_args()
+    main(args.weights, args.out)

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/extract_reference.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/extract_reference.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Extract PyTorch YOLOv11m reference outputs for nntrainer verification.
+@file extract_reference.py
+@brief Extract PyTorch YOLOv11m reference outputs for nntrainer verification.
 Fixed seed input → raw Detect head logits (before DFL/sigmoid).
 """
 import torch

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/extract_reference.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/extract_reference.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Extract PyTorch YOLOv11m reference outputs for nntrainer verification.
+Fixed seed input → raw Detect head logits (before DFL/sigmoid).
+"""
+import torch
+import numpy as np
+import os
+import sys
+import argparse
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# Resolved from CLI args in __main__ (see bottom of file).
+WEIGHTS = None
+OUT_DIR = None
+
+def save_bin(tensor, path):
+    arr = tensor.detach().cpu().float().numpy()
+    arr.tofile(path)
+    print(f"  saved {path} shape={arr.shape} dtype={arr.dtype}")
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    from ultralytics import YOLO
+    model = YOLO(WEIGHTS)
+    m = model.model
+    m.eval()
+
+    # Fixed input
+    torch.manual_seed(42)
+    x = torch.randn(1, 3, 832, 832)
+    save_bin(x, os.path.join(OUT_DIR, 'input_832.bin'))
+    print(f"Input shape: {x.shape}")
+
+    # Hook to capture Detect head raw inputs (before DFL/sigmoid)
+    # model.23 is the Detect layer; its forward receives [P3, P4, P5]
+    # We want the raw cv2/cv3 outputs per scale (before decode)
+    detect_raw_inputs = {}
+    detect_raw_outputs = {}
+
+    def hook_detect_input(module, inputs, output):
+        # inputs is tuple of feature maps [P3, P4, P5]
+        for i, inp in enumerate(inputs[0] if isinstance(inputs[0], (list, tuple)) else inputs):
+            detect_raw_inputs[i] = inp.detach().clone()  # clone() prevents aliasing from in-place ops
+        # Capture cv2/cv3 raw outputs before decode
+        # We manually run cv2/cv3 here
+        detect = module
+        for i, xi in enumerate(detect_raw_inputs.values()):
+            box = detect.cv2[i](xi)  # [B, 4*reg_max, H, W]
+            cls = detect.cv3[i](xi)  # [B, nc, H, W]
+            raw = torch.cat([box, cls], dim=1)
+            detect_raw_outputs[i] = raw.detach().clone()  # clone() prevents aliasing from in-place ops
+            print(f"  P{i+3} input shape: {xi.shape}, box: {box.shape}, cls: {cls.shape}")
+
+    # Find model.23 (Detect)
+    detect_layer = m.model[-1]
+    hook = detect_layer.register_forward_hook(hook_detect_input)
+
+    # Also capture intermediate feature maps for block-level verification
+    feature_maps = {}
+    hooks = []
+
+    # Key checkpoints: after each major block
+    key_layers = {
+        0: 'conv0', 1: 'conv1', 2: 'c3k2_2', 3: 'conv3',
+        4: 'c3k2_4', 5: 'conv5', 6: 'c3k2_6', 7: 'conv7',
+        8: 'c3k2_8', 9: 'sppf_9', 10: 'c2psa_10',
+        16: 'head_p3_16', 19: 'head_p4_19', 22: 'head_p5_22',
+    }
+
+    def make_hook(name):
+        def h(module, inp, output):
+            if isinstance(output, torch.Tensor):
+                feature_maps[name] = output.detach().clone()  # clone() prevents aliasing from in-place ops
+        return h
+
+    for idx, name in key_layers.items():
+        layer = m.model[idx]
+        hooks.append(layer.register_forward_hook(make_hook(name)))
+
+    with torch.no_grad():
+        _ = m(x)
+
+    hook.remove()
+    for h in hooks:
+        h.remove()
+
+    # Save raw detect outputs
+    for i, raw in detect_raw_outputs.items():
+        scale_name = ['p3', 'p4', 'p5'][i]
+        save_bin(raw, os.path.join(OUT_DIR, f'ref_{scale_name}.bin'))
+
+    # Save key feature maps
+    for name, feat in feature_maps.items():
+        save_bin(feat, os.path.join(OUT_DIR, f'ref_{name}.bin'))
+
+    # Print summary
+    print("\n=== Reference output summary ===")
+    print(f"Input: {x.shape}")
+    for i, raw in detect_raw_outputs.items():
+        scale_name = ['P3', 'P4', 'P5'][i]
+        print(f"Detect {scale_name} raw: {raw.shape}  (box+cls concat)")
+    for name, feat in feature_maps.items():
+        print(f"  {name}: {feat.shape}")
+
+    print(f"\nAll saved to: {OUT_DIR}")
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(
+        description='Extract YOLOv11m PyTorch reference outputs for verification')
+    ap.add_argument('--weights', required=True,
+                    help='path to the ultralytics YOLOv11m .pt checkpoint')
+    ap.add_argument('--out', default=os.path.join(_HERE, '..', 'res'),
+                    help='output dir for reference .bin files (default: ../res)')
+    args = ap.parse_args()
+    WEIGHTS = args.weights
+    OUT_DIR = args.out
+    main()

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/run_pytorch.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/run_pytorch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Run PyTorch YOLOv11m and print final detections, AND write the exact 832x832
+@file run_pytorch.py
+@brief Run PyTorch YOLOv11m and print final detections, AND write the exact 832x832
 input tensor as a .bin so the nntrainer example can run on identical bytes
 (apples-to-apples comparison).
 

--- a/Applications/CausalLM/models/YOLOv11/PyTorch/run_pytorch.py
+++ b/Applications/CausalLM/models/YOLOv11/PyTorch/run_pytorch.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Run PyTorch YOLOv11m and print final detections, AND write the exact 832x832
+input tensor as a .bin so the nntrainer example can run on identical bytes
+(apples-to-apples comparison).
+
+Examples:
+  # real image:
+  python run_pytorch.py --weights v11m_832rect_best.pt --image cat.jpeg
+  # deterministic seed-42 noise (matches res/input_832.bin):
+  python run_pytorch.py --weights v11m_832rect_best.pt
+
+It writes the preprocessed input to --save-input (default ../res/input_run.bin)
+and prints detections [x1,y1,x2,y2,conf,cls] (xyxy pixels at the 832 scale).
+Run the nntrainer side on the SAME input with:  ./run_nntrainer.sh ../res/input_run.bin
+"""
+import argparse
+import os
+
+import numpy as np
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+REG_MAX, NC, STRIDES = 16, 1, (8, 16, 32)
+GRID = {8: 104, 16: 52, 32: 26}  # for 832 input
+
+
+def letterbox(path, size=832, pad=114):
+    import cv2
+    img = cv2.imread(path)  # BGR
+    if img is None:
+        raise FileNotFoundError(path)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    h, w = img.shape[:2]
+    r = min(size / h, size / w)
+    nh, nw = int(round(h * r)), int(round(w * r))
+    resized = cv2.resize(img, (nw, nh), interpolation=cv2.INTER_LINEAR)
+    out = np.full((size, size, 3), pad, np.uint8)
+    top, left = (size - nh) // 2, (size - nw) // 2
+    out[top:top + nh, left:left + nw] = resized
+    t = torch.from_numpy(out).float().permute(2, 0, 1).unsqueeze(0) / 255.0
+    return t.contiguous()
+
+
+def make_anchors():
+    pts, strd = [], []
+    for s in STRIDES:
+        g = GRID[s]
+        sx = (torch.arange(g) + 0.5)
+        sy = (torch.arange(g) + 0.5)
+        yy, xx = torch.meshgrid(sy, sx, indexing="ij")
+        pts.append(torch.stack((xx.reshape(-1), yy.reshape(-1)), 1))
+        strd.append(torch.full((g * g, 1), float(s)))
+    return torch.cat(pts), torch.cat(strd)  # [N,2], [N,1]
+
+
+def decode(raws):
+    # raws[i]: [1, 64+NC, H, W]
+    box = torch.cat([r[:, :4 * REG_MAX].reshape(1, 4 * REG_MAX, -1) for r in raws], 2)
+    cls = torch.cat([r[:, 4 * REG_MAX:].reshape(1, NC, -1) for r in raws], 2)
+    b, _, n = box.shape
+    proj = torch.arange(REG_MAX, dtype=torch.float32)
+    dist = box.view(b, 4, REG_MAX, n).softmax(2).mul(proj.view(1, 1, -1, 1)).sum(2)  # [1,4,N]
+    anchors, strd = make_anchors()
+    anchors = anchors.t().unsqueeze(0)  # [1,2,N]
+    lt, rb = dist[:, :2], dist[:, 2:]
+    x1y1 = anchors - lt
+    x2y2 = anchors + rb
+    cxcy = (x1y1 + x2y2) / 2
+    wh = x2y2 - x1y1
+    xywh = torch.cat([cxcy, wh], 1) * strd.t().unsqueeze(0)  # [1,4,N] px@832
+    score = cls.sigmoid()
+    return xywh, score  # [1,4,N], [1,NC,N]
+
+
+def nms(xywh, score, conf=0.25, iou=0.70, max_det=300):
+    import torchvision
+    cx, cy, w, h = xywh[0]
+    x1, y1, x2, y2 = cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2
+    boxes = torch.stack([x1, y1, x2, y2], 1)  # [N,4]
+    conf_t, cls_t = score[0].max(0)  # [N], [N]
+    keep0 = conf_t > conf
+    boxes, conf_t, cls_t = boxes[keep0], conf_t[keep0], cls_t[keep0]
+    if boxes.numel() == 0:
+        return []
+    offset = cls_t.float().unsqueeze(1) * 7680.0
+    keep = torchvision.ops.nms(boxes + offset, conf_t, iou)[:max_det]
+    return [(*boxes[k].tolist(), float(conf_t[k]), int(cls_t[k])) for k in keep]
+
+
+def main(weights, image, save_input, conf, iou):
+    from ultralytics import YOLO
+    m = YOLO(weights).model
+    m.eval()
+
+    if image:
+        x = letterbox(image)
+        print(f"input: letterboxed {image} -> [1,3,832,832]")
+    else:
+        torch.manual_seed(42)
+        x = torch.randn(1, 3, 832, 832)
+        print("input: fixed seed-42 noise (matches res/input_832.bin)")
+
+    x.detach().cpu().numpy().astype("<f4").tofile(save_input)
+    print(f"saved input bin for nntrainer: {save_input}")
+
+    raws = {}
+
+    def hook(mod, inp, out):
+        feats = inp[0]
+        for i, xi in enumerate(feats):
+            raws[i] = torch.cat([mod.cv2[i](xi), mod.cv3[i](xi)], 1).detach()
+
+    h = m.model[-1].register_forward_hook(hook)
+    with torch.no_grad():
+        m(x)
+    h.remove()
+
+    xywh, score = decode([raws[0], raws[1], raws[2]])
+    dets = nms(xywh, score, conf, iou)
+    print(f"\nPyTorch detections (conf>={conf}, iou={iou}): {len(dets)}")
+    for i, d in enumerate(dets):
+        print("  [%d] (%.3f, %.3f, %.3f, %.3f) conf=%.6f cls=%d" % (i, *d))
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="PyTorch YOLOv11m run + input dump")
+    ap.add_argument("--weights", required=True, help="ultralytics .pt checkpoint")
+    ap.add_argument("--image", default=None, help="image path (omit = seed-42 noise)")
+    ap.add_argument("--save-input", default=os.path.join(_HERE, "..", "res", "input_run.bin"))
+    ap.add_argument("--conf", type=float, default=0.25)
+    ap.add_argument("--iou", type=float, default=0.70)
+    a = ap.parse_args()
+    main(a.weights, a.image, a.save_input, a.conf, a.iou)

--- a/Applications/CausalLM/models/YOLOv11/QUANTIZATION.md
+++ b/Applications/CausalLM/models/YOLOv11/QUANTIZATION.md
@@ -1,0 +1,96 @@
+# YOLOv11m Q4_0 quantization & device optimization (baseline v5)
+
+This documents the framework-native Q4_0 conv quantization and the kernel
+work that landed in `yolov11-device-opt-baselinev5`. The earlier one-off numpy
+quantizer (`PyTorch/quantize_q4_0_conv.py`) is **retired** — quantization now
+goes through nntrainer's own save path, the same machinery LLMs use.
+
+## Result (S23, cat input, OMP=4, same thermal state)
+
+| | latency | RSS | detections |
+|---|---|---|---|
+| FP32 (BN-fused) | 4355 ms | 353 MB | 0.9387 / 0.9247 |
+| **all-conv Q4_0 + depthwise backend op** | **3540 ms (−18.7%)** | 350 MB | 0.9275 / 0.8906 |
+
+(Speedup ranges −18 to −23% depending on device thermal state. Detections
+preserved; memory ~flat — see "Known limits".)
+
+## Two-step workflow (general, no model-specific script)
+
+1. **Convert** PyTorch → FP32 nntrainer safetensors (BN folded into conv at
+   convert time):
+   ```
+   python PyTorch/convert_weights.py --weights v11m.pt --out res/yolov11m_fused.safetensors
+   ```
+2. **Quantize** with the framework quantizer (the YOLO inference binary in
+   quantize mode). Produces an ISA-specific Q4_0 file; x86 and arm are
+   different repack layouts (q4_0x8 vs q4_0x4) and are managed as separate
+   files:
+   ```
+   # arm (device):
+   YOLO_QUANTIZE_OUT=res/yolov11m_fw_q40_arm.safetensors YOLO_QUANTIZE_ISA=arm \
+     YOLO_WEIGHTS=yolov11m_fused.safetensors yolov11_infer res res/input_cat.bin
+   # x86 (host verify):
+   YOLO_QUANTIZE_OUT=res/yolov11m_fw_q40_x86.safetensors YOLO_QUANTIZE_ISA=x86 \
+     YOLO_WEIGHTS=yolov11m_fused.safetensors yolov11_infer res res/input_cat.bin
+   ```
+3. **Run** quantized (runtime builds eligible convs as Q4_0 and loads the file):
+   ```
+   YOLO_CONV_Q40=1 YOLO_WEIGHTS=yolov11m_fw_q40_arm.safetensors \
+     yolov11_infer res res/input_cat.bin
+   ```
+
+## Where the quantization lives (framework, not YOLO-specific)
+
+- `nntrainer/layers/conv2d_layer.cpp` `Conv2DLayer::save()`: quantizes a conv
+  FP32 filter `[out_ch, in_ch, kh, kw]` (already row-major `[out_ch, CRS]`,
+  CRS = in_ch·kh·kw) straight through `quantize_q4_0` + `repack_q4_0(ISA)` with
+  **no transpose** (the FC base path transposes because its weight is `[K,N]`).
+  Bias / 32-misaligned filters stay FP32. Stored matmul shape `[1,1,CRS,out_ch]`.
+- `nntrainer/models/neuralnet.cpp`: the safetensors save accounting +
+  `nntr_shape` were FC-shaped. `quantRowsCols()` now derives `(N,K)` per weight
+  (batch>1 → conv filter: N=out_ch, K=CRS; else FC: N=width, K=height) so a 1×1
+  conv (height==1, not a bias) quantizes and the header shape is `[1,1,K,N]`.
+- Eligibility (must match on both sides): `out_ch>1 && out_ch%32==0 &&
+  (in_ch·kh·kw)%32==0`. The graph builders own this gate
+  (`yolov11_graph.h`); `quantConvSink()` records eligible conv names during the
+  build to form the save dtype map, so the quantize-time set always equals the
+  runtime Q4_0 set.
+
+## Kernel: depthwise in the backend (not the layer)
+
+`depthwise_conv2d_fp32` is a CPU-backend compute op
+(`ComputeOps`→`CpuComputeOps`→fallback/arm/x86, link-time dispatch), parallel
+over batch×channels via `ThreadManager::parallel_for`. `Conv2DLayer::forwarding`
+calls `getComputeOps()->depthwise_conv2d_fp32(...)` for true depthwise
+(groups==channels) instead of the old in-layer loop. Saves ~350-400 ms vs the
+generic grouped path (which dispatched 256-512 tiny im2col+GEMM calls/layer).
+`NNTR_NO_DW_FASTPATH=1` falls back to the generic path. arm/x86 currently
+delegate to the scalar fallback (TODO: NEON/AVX). Depthwise is **not** Q4_0:
+per-channel K = kh·kw = 9 < the 32-block, and the weights are ~83 KB total.
+
+## 1×1 / 3×3 conv Q4_0 (matmul path)
+
+`conv2d_layer.cpp` forwarding: a quantized groups==1 conv runs as a single GEMM.
+1×1 stride-1 skips im2col (identity); k>1 uses im2col → `[OH*OW, CRS]` (already
+the activation layout — **no transpose**, the bug that caused the deep-3×3
+heap-overflow SIGSEGV) → `dotQnK`. See baselinev3/v4 commits.
+
+## Known limits / next session
+
+- **Memory ~flat** (353→350 MB): weights drop ~65 MB but the im2col `col`
+  buffer + GEMM temporaries offset it, and whether Q4_0 weights stay packed in
+  RAM is unconfirmed. Investigate for a real memory win.
+- **Quantizer entry point**: v5 quantizes via the YOLO binary's `--quantize`
+  mode (reusing the framework save). Full unification — registering YOLOv11 as
+  a factory/config model so `nntr_quantize <dir>` handles it like an LLM
+  (option B) — is deferred. The framework quantization core is already done, so
+  B is mostly factory/config plumbing.
+- **ONNX comparison**: not yet measured on device; cannot claim "beats ONNX".
+- arm/x86 depthwise NEON/AVX specialization.
+
+## Branches
+
+- `yolov11-device-opt-baselinev5` — this state (framework quant + depthwise
+  backend op), origin.
+- v4 = +depthwise inline (−22.7%); v3 = 3×3 Q4_0 crash fix; v2 = 1×1 Q4_0.

--- a/Applications/CausalLM/models/YOLOv11/README.md
+++ b/Applications/CausalLM/models/YOLOv11/README.md
@@ -1,0 +1,54 @@
+# YOLOv11m detection inference (nntrainer)
+
+Inference-only YOLOv11m (832×832, nc=1) built from nntrainer's existing layers
+(only the C2PSA spatial attention is a custom layer). Matches PyTorch
+(ultralytics) end-to-end.
+
+## 1. Convert weights (once)
+Needs a Python env with `ultralytics` + `torch`:
+```bash
+python PyTorch/convert_weights.py \
+  --weights /path/to/v11m_832rect_best.pt \
+  --out res/yolov11m.safetensors
+```
+This writes a single nntrainer safetensors whose tensor names match the model.
+
+## 2. (Optional) enable direct image input
+The example reads a raw `[1,3,832,832]` float32 `.bin` by default. To also accept
+`.jpg/.png` directly, drop in the public-domain `stb_image.h` (NOT committed):
+```bash
+curl -fsSL https://raw.githubusercontent.com/nothings/stb/master/stb_image.h \
+  -o jni/stb_image.h
+```
+The build auto-detects it (meson `fs.exists`) and enables image decoding +
+letterbox. Without it the example still builds and runs on `.bin` input.
+
+## 3. Build
+```bash
+# from the nntrainer project root
+meson setup build -Denable-app=true        # or: meson setup --reconfigure build ...
+ninja -C build "Applications/CausalLM/models/YOLOv11/jni/yolov11_infer"
+```
+
+## 4. Run
+```bash
+BIN=./build/Applications/CausalLM/models/YOLOv11/jni/yolov11_infer
+RES=Applications/CausalLM/models/YOLOv11/res
+
+# image (requires stb_image.h at build time)
+$BIN $RES some_image.jpg
+# raw .bin input
+$BIN $RES $RES/input_832.bin
+# verify vs PyTorch references (ref_*.bin in res/)
+YOLO_VERIFY=1 $BIN $RES
+```
+Output: `Detections (conf>=0.25, xyxy @832): N` followed by `[i] (x1,y1,x2,y2) conf= cls=`.
+
+## Compare with PyTorch
+Local helper scripts (not committed): `PyTorch/run_pytorch.py` writes the exact
+letterboxed input as a `.bin` and prints PyTorch detections; feed that same
+`.bin` to `yolov11_infer` for a bit-exact comparison (`compare.sh` runs both).
+
+> Note: the in-process image letterbox uses a plain bilinear resampler, so
+> detections from a `.jpg` differ from the OpenCV/PyTorch path by sub-pixel
+> amounts. For an exact match, run on the `.bin` produced by `run_pytorch.py`.

--- a/Applications/CausalLM/models/YOLOv11/compare.sh
+++ b/Applications/CausalLM/models/YOLOv11/compare.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-shot PyTorch vs nntrainer comparison on the SAME input.
+# run_pytorch.py preprocesses the input to res/input_run.bin (so both sides see
+# identical bytes), prints PyTorch detections; then nntrainer runs on that bin.
+#
+# Usage:
+#   ./compare.sh --weights /path/to/v11m_832rect_best.pt                 # seed-42 input
+#   ./compare.sh --weights /path/to/v11m_832rect_best.pt --image cat.jpeg
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+INPUT="$HERE/res/input_run.bin"
+
+echo "############## PyTorch ##############"
+python3 "$HERE/PyTorch/run_pytorch.py" "$@" --save-input "$INPUT"
+
+echo
+echo "############## nntrainer ##############"
+"$HERE/run_nntrainer.sh" "$INPUT"
+
+echo
+echo "Compare the detection lists above (boxes are xyxy pixels at the 832 scale)."

--- a/Applications/CausalLM/models/YOLOv11/jni/Android.mk
+++ b/Applications/CausalLM/models/YOLOv11/jni/Android.mk
@@ -1,0 +1,66 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+ifndef ANDROID_NDK
+$(error ANDROID_NDK is not defined!)
+endif
+
+ifndef NNTRAINER_ROOT
+NNTRAINER_ROOT := $(LOCAL_PATH)/../../../../..
+endif
+
+# Prebuilt nntrainer shared libs (produced by the meson-android build under
+# build_android/jni/arm64-v8a). Override NNTRAINER_LIBS if they live elsewhere.
+ifndef NNTRAINER_LIBS
+NNTRAINER_LIBS := $(NNTRAINER_ROOT)/build_android/jni/$(TARGET_ARCH_ABI)
+endif
+
+ML_API_COMMON_INCLUDES := $(NNTRAINER_ROOT)/ml_api_common/include
+NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
+	$(NNTRAINER_ROOT)/nntrainer/layers \
+	$(NNTRAINER_ROOT)/nntrainer/models \
+	$(NNTRAINER_ROOT)/nntrainer/graph \
+	$(NNTRAINER_ROOT)/nntrainer/optimizers \
+	$(NNTRAINER_ROOT)/nntrainer/dataset \
+	$(NNTRAINER_ROOT)/nntrainer/compiler \
+	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/fallback \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/arm \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
+	$(NNTRAINER_ROOT)/api \
+	$(NNTRAINER_ROOT)/api/ccapi/include \
+	$(ML_API_COMMON_INCLUDES)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nntrainer
+LOCAL_SRC_FILES := $(NNTRAINER_LIBS)/libnntrainer.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := ccapi-nntrainer
+LOCAL_SRC_FILES := $(NNTRAINER_LIBS)/libccapi-nntrainer.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_ARM_NEON := true
+LOCAL_ARM_MODE := arm
+LOCAL_MODULE := yolov11_infer
+LOCAL_MODULE_TAGS := optional
+LOCAL_LDLIBS := -llog -landroid
+
+# Match the library's ISA features so int8 (dotprod/i8mm) and fp16 paths
+# compile consistently with libnntrainer.
+LOCAL_CFLAGS += -std=c++17 -O3 -march=armv8.2-a+fp16+dotprod+i8mm -pthread \
+	-fexceptions -frtti
+LOCAL_CXXFLAGS += -std=c++17 -O3 -march=armv8.2-a+fp16+dotprod+i8mm -pthread \
+	-fexceptions -frtti
+LOCAL_LDFLAGS += -fexceptions
+
+LOCAL_SRC_FILES := main.cpp c2psa_layer.cpp
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+include $(BUILD_EXECUTABLE)

--- a/Applications/CausalLM/models/YOLOv11/jni/Application.mk
+++ b/Applications/CausalLM/models/YOLOv11/jni/Application.mk
@@ -1,0 +1,4 @@
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
@@ -16,6 +16,7 @@
 
 #include "c2psa_layer.h"
 
+#include <cpu_backend.h>
 #include <layer_context.h>
 #include <nntrainer_error.h>
 
@@ -44,21 +45,26 @@ void PSAAttentionLayer::multiHeadAttention(const float *Q, const float *K,
   const float scale = 1.0f / std::sqrt(static_cast<float>(kd));
   std::vector<float> score(static_cast<size_t>(N) * N);
 
+  // Q/K/V are stored head-major as row-major [d, N] matrices (element (d,i) at
+  // d*N+i). The two attention matmuls are BLAS GEMMs (RowMajor => order arg 0):
+  //   score[N,N] = scale * Qh^T[N,kd] * Kh[kd,N]   (TransA on Qh)
+  //   outh[vd,N] = Vh[vd,N] * score^T[N,N]          (TransB on score)
+  // sgemm ldX is the stored row stride (= N for every operand here), invariant
+  // under the transpose flags. This replaces the prior triple scalar loops.
   for (int h = 0; h < nh; ++h) {
     const float *Qh = Q + static_cast<size_t>(h) * kd * N;
     const float *Kh = K + static_cast<size_t>(h) * kd * N;
     const float *Vh = V + static_cast<size_t>(h) * vd * N;
     float *outh = out + static_cast<size_t>(h) * vd * N;
 
-    // score[i,j] = (Q[h,:,i] . K[h,:,j]) * scale
-    for (int i = 0; i < N; ++i) {
-      for (int j = 0; j < N; ++j) {
-        float s = 0.0f;
-        for (int d = 0; d < kd; ++d)
-          s += Qh[d * N + i] * Kh[d * N + j];
-        score[static_cast<size_t>(i) * N + j] = s * scale;
-      }
-    }
+    // score = scale * Qh^T * Kh
+    nntrainer::sgemm(0, true, false, static_cast<unsigned int>(N),
+                     static_cast<unsigned int>(N),
+                     static_cast<unsigned int>(kd), scale, Qh,
+                     static_cast<unsigned int>(N), Kh,
+                     static_cast<unsigned int>(N), 0.0f, score.data(),
+                     static_cast<unsigned int>(N));
+
     // softmax over key axis j for each query i
     for (int i = 0; i < N; ++i) {
       float *row = score.data() + static_cast<size_t>(i) * N;
@@ -72,16 +78,13 @@ void PSAAttentionLayer::multiHeadAttention(const float *Q, const float *K,
       for (int j = 0; j < N; ++j)
         row[j] *= inv;
     }
-    // out[h,d,i] = sum_j score[i,j] * V[h,d,j]
-    for (int d = 0; d < vd; ++d) {
-      for (int i = 0; i < N; ++i) {
-        float s = 0.0f;
-        const float *row = score.data() + static_cast<size_t>(i) * N;
-        for (int j = 0; j < N; ++j)
-          s += row[j] * Vh[d * N + j];
-        outh[d * N + i] = s;
-      }
-    }
+
+    // outh = Vh * score^T
+    nntrainer::sgemm(0, false, true, static_cast<unsigned int>(vd),
+                     static_cast<unsigned int>(N), static_cast<unsigned int>(N),
+                     1.0f, Vh, static_cast<unsigned int>(N), score.data(),
+                     static_cast<unsigned int>(N), 0.0f, outh,
+                     static_cast<unsigned int>(N));
   }
 }
 

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
@@ -6,6 +6,7 @@
  * @date   18 June 2026
  * @brief  PSA spatial multi-head attention custom layer (weight-free).
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs
  */
 
 #include <algorithm>

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
@@ -115,8 +115,48 @@ void PSAAttentionLayer::forwarding(nntrainer::RunLayerContext &context,
   std::vector<float> Kb(static_cast<size_t>(q_ch) * N);
   std::vector<float> Vb(static_cast<size_t>(v_ch) * N);
 
+  // NHWC input is channel-last: logical element (c, p) lives at in[p*dim_ + c],
+  // so the head/channel gather is a strided read (no contiguous memcpy) and the
+  // attention output must be scattered back to channel-last positions. The
+  // attention math itself operates on head-major planar [d,N] buffers either
+  // way, so only these boundary conversions differ.
+  const bool nhwc =
+    in_t.getFormat() == ml::train::TensorDim::Format::NHWC &&
+    out_t.getFormat() == ml::train::TensorDim::Format::NHWC;
+  std::vector<float> out_planar;
+  if (nhwc)
+    out_planar.resize(static_cast<size_t>(v_ch) * N);
+
   for (unsigned int b = 0; b < B; ++b) {
     const float *qkv = in + static_cast<size_t>(b) * dim_ * N;
+    if (nhwc) {
+      for (unsigned int h = 0; h < NUM_HEADS; ++h) {
+        const unsigned int cbase = h * head_stride;
+        for (unsigned int d = 0; d < KD; ++d) {
+          float *qdst = Qb.data() + (static_cast<size_t>(h) * KD + d) * N;
+          float *kdst = Kb.data() + (static_cast<size_t>(h) * KD + d) * N;
+          for (int p = 0; p < N; ++p) {
+            qdst[p] = qkv[static_cast<size_t>(p) * dim_ + cbase + d];
+            kdst[p] = qkv[static_cast<size_t>(p) * dim_ + cbase + KD + d];
+          }
+        }
+        for (unsigned int d = 0; d < VD; ++d) {
+          float *vdst = Vb.data() + (static_cast<size_t>(h) * VD + d) * N;
+          for (int p = 0; p < N; ++p)
+            vdst[p] = qkv[static_cast<size_t>(p) * dim_ + cbase + 2 * KD + d];
+        }
+      }
+      multiHeadAttention(Qb.data(), Kb.data(), Vb.data(), out_planar.data(),
+                         NUM_HEADS, KD, VD, N);
+      // scatter planar [v_ch, N] back to channel-last out[p*v_ch + c]
+      float *out_b = out + static_cast<size_t>(b) * v_ch * N;
+      for (unsigned int c = 0; c < v_ch; ++c) {
+        const float *src = out_planar.data() + static_cast<size_t>(c) * N;
+        for (int p = 0; p < N; ++p)
+          out_b[static_cast<size_t>(p) * v_ch + c] = src[p];
+      }
+      continue;
+    }
     for (unsigned int h = 0; h < NUM_HEADS; ++h) {
       const float *qh = qkv + static_cast<size_t>(h) * head_stride * N;
       std::memcpy(Qb.data() + static_cast<size_t>(h) * KD * N, qh,

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   c2psa_layer.cpp
+ * @date   18 June 2026
+ * @brief  PSA spatial multi-head attention custom layer (weight-free).
+ * @author Seungbaek Hong <sb92.hong@samsung.com>
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "c2psa_layer.h"
+
+#include <layer_context.h>
+#include <nntrainer_error.h>
+
+namespace yolov11 {
+
+void PSAAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "PSAAttentionLayer expects exactly 1 input (qkv)";
+
+  const nntrainer::TensorDim &in_dim = context.getInputDimensions()[0];
+  dim_ = in_dim.channel();
+
+  const unsigned int expected = NUM_HEADS * KD * 2 + NUM_HEADS * VD; // 512
+  NNTR_THROW_IF(dim_ != expected, std::invalid_argument)
+    << "PSAAttentionLayer expects " << expected << " input channels, got "
+    << dim_;
+
+  nntrainer::TensorDim out_dim = in_dim;
+  out_dim.channel(NUM_HEADS * VD); // 256
+  context.setOutputDimensions({out_dim});
+}
+
+void PSAAttentionLayer::multiHeadAttention(const float *Q, const float *K,
+                                           const float *V, float *out, int nh,
+                                           int kd, int vd, int N) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(kd));
+  std::vector<float> score(static_cast<size_t>(N) * N);
+
+  for (int h = 0; h < nh; ++h) {
+    const float *Qh = Q + static_cast<size_t>(h) * kd * N;
+    const float *Kh = K + static_cast<size_t>(h) * kd * N;
+    const float *Vh = V + static_cast<size_t>(h) * vd * N;
+    float *outh = out + static_cast<size_t>(h) * vd * N;
+
+    // score[i,j] = (Q[h,:,i] . K[h,:,j]) * scale
+    for (int i = 0; i < N; ++i) {
+      for (int j = 0; j < N; ++j) {
+        float s = 0.0f;
+        for (int d = 0; d < kd; ++d)
+          s += Qh[d * N + i] * Kh[d * N + j];
+        score[static_cast<size_t>(i) * N + j] = s * scale;
+      }
+    }
+    // softmax over key axis j for each query i
+    for (int i = 0; i < N; ++i) {
+      float *row = score.data() + static_cast<size_t>(i) * N;
+      float mx = *std::max_element(row, row + N);
+      float sum = 0.0f;
+      for (int j = 0; j < N; ++j) {
+        row[j] = std::exp(row[j] - mx);
+        sum += row[j];
+      }
+      const float inv = 1.0f / sum;
+      for (int j = 0; j < N; ++j)
+        row[j] *= inv;
+    }
+    // out[h,d,i] = sum_j score[i,j] * V[h,d,j]
+    for (int d = 0; d < vd; ++d) {
+      for (int i = 0; i < N; ++i) {
+        float s = 0.0f;
+        const float *row = score.data() + static_cast<size_t>(i) * N;
+        for (int j = 0; j < N; ++j)
+          s += row[j] * Vh[d * N + j];
+        outh[d * N + i] = s;
+      }
+    }
+  }
+}
+
+void PSAAttentionLayer::forwarding(nntrainer::RunLayerContext &context,
+                                   bool training) {
+  const nntrainer::Tensor &in_t = context.getInput(0);
+  nntrainer::Tensor &out_t = context.getOutput(0);
+
+  NNTR_THROW_IF(in_t.getDataType() != nntrainer::Tdatatype::FP32,
+                std::invalid_argument)
+    << "PSAAttentionLayer only implements the FP32 path";
+
+  const unsigned int B = in_t.batch();
+  const unsigned int H = in_t.height();
+  const unsigned int W = in_t.width();
+  const int N = static_cast<int>(H * W);
+  const unsigned int q_ch = NUM_HEADS * KD; // 128
+  const unsigned int v_ch = NUM_HEADS * VD; // 256
+
+  const float *in = in_t.getData<float>();
+  float *out = out_t.getData<float>();
+
+  // qkv uses the ultralytics per-head interleaved layout: for head h the
+  // 128 channels [h*128 : h*128+128] hold [Q(kd=32), K(kd=32), V(vd=64)].
+  // Gather them into head-major contiguous Q/K/V buffers [nh,kd|vd,N].
+  const unsigned int head_stride = 2 * KD + VD; // 128
+  std::vector<float> Qb(static_cast<size_t>(q_ch) * N);
+  std::vector<float> Kb(static_cast<size_t>(q_ch) * N);
+  std::vector<float> Vb(static_cast<size_t>(v_ch) * N);
+
+  for (unsigned int b = 0; b < B; ++b) {
+    const float *qkv = in + static_cast<size_t>(b) * dim_ * N;
+    for (unsigned int h = 0; h < NUM_HEADS; ++h) {
+      const float *qh = qkv + static_cast<size_t>(h) * head_stride * N;
+      std::memcpy(Qb.data() + static_cast<size_t>(h) * KD * N, qh,
+                  static_cast<size_t>(KD) * N * sizeof(float));
+      std::memcpy(Kb.data() + static_cast<size_t>(h) * KD * N,
+                  qh + static_cast<size_t>(KD) * N,
+                  static_cast<size_t>(KD) * N * sizeof(float));
+      std::memcpy(Vb.data() + static_cast<size_t>(h) * VD * N,
+                  qh + static_cast<size_t>(2 * KD) * N,
+                  static_cast<size_t>(VD) * N * sizeof(float));
+    }
+    float *out_b = out + static_cast<size_t>(b) * v_ch * N;
+    multiHeadAttention(Qb.data(), Kb.data(), Vb.data(), out_b, NUM_HEADS, KD,
+                       VD, N);
+  }
+}
+
+} // namespace yolov11

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.cpp
@@ -58,12 +58,11 @@ void PSAAttentionLayer::multiHeadAttention(const float *Q, const float *K,
     float *outh = out + static_cast<size_t>(h) * vd * N;
 
     // score = scale * Qh^T * Kh
-    nntrainer::sgemm(0, true, false, static_cast<unsigned int>(N),
-                     static_cast<unsigned int>(N),
-                     static_cast<unsigned int>(kd), scale, Qh,
-                     static_cast<unsigned int>(N), Kh,
-                     static_cast<unsigned int>(N), 0.0f, score.data(),
-                     static_cast<unsigned int>(N));
+    nntrainer::sgemm(
+      0, true, false, static_cast<unsigned int>(N),
+      static_cast<unsigned int>(N), static_cast<unsigned int>(kd), scale, Qh,
+      static_cast<unsigned int>(N), Kh, static_cast<unsigned int>(N), 0.0f,
+      score.data(), static_cast<unsigned int>(N));
 
     // softmax over key axis j for each query i
     for (int i = 0; i < N; ++i) {
@@ -120,9 +119,8 @@ void PSAAttentionLayer::forwarding(nntrainer::RunLayerContext &context,
   // attention output must be scattered back to channel-last positions. The
   // attention math itself operates on head-major planar [d,N] buffers either
   // way, so only these boundary conversions differ.
-  const bool nhwc =
-    in_t.getFormat() == ml::train::TensorDim::Format::NHWC &&
-    out_t.getFormat() == ml::train::TensorDim::Format::NHWC;
+  const bool nhwc = in_t.getFormat() == ml::train::TensorDim::Format::NHWC &&
+                    out_t.getFormat() == ml::train::TensorDim::Format::NHWC;
   std::vector<float> out_planar;
   if (nhwc)
     out_planar.resize(static_cast<size_t>(v_ch) * N);

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.h
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.h
@@ -6,6 +6,7 @@
  * @date   18 June 2026
  * @brief  PSA spatial multi-head attention custom layer for YOLOv11 C2PSA.
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs
  *
  * The C2PSA block (model.10) is assembled from standard nntrainer layers
  * (conv2d, depthwiseconv2d, batch_normalization, addition, concat, slice) —

--- a/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.h
+++ b/Applications/CausalLM/models/YOLOv11/jni/c2psa_layer.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   c2psa_layer.h
+ * @date   18 June 2026
+ * @brief  PSA spatial multi-head attention custom layer for YOLOv11 C2PSA.
+ * @author Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * The C2PSA block (model.10) is assembled from standard nntrainer layers
+ * (conv2d, depthwiseconv2d, batch_normalization, addition, concat, slice) —
+ * see buildC2PSA() in main.cpp. The ONLY genuinely-novel op is the spatial
+ * multi-head attention, kept here as a (weight-free) custom layer.
+ *
+ * Input : qkv tensor [B, 512, H, W]  (channels: Q[0:128], K[128:256],
+ * V[256:512]) Output: attention  [B, 256, H, W]  (= nh*vd, nh=4, kd=32, vd=64)
+ *   score[i,j] = softmax_j( sum_d Q[h,d,i]*K[h,d,j] / sqrt(kd) )
+ *   out[h,d,i] = sum_j score[i,j] * V[h,d,j]
+ */
+
+#ifndef __C2PSA_LAYER_H__
+#define __C2PSA_LAYER_H__
+
+#include <string>
+#include <vector>
+
+#include <layer_devel.h>
+#include <layer_impl.h>
+#include <node_exporter.h>
+
+namespace yolov11 {
+
+/**
+ * @class PSAAttentionLayer
+ * @brief Spatial multi-head attention for YOLOv11 C2PSA (weight-free).
+ *        Hardcoded nh=4, kd=32, vd=64: input 512 ch (Q128/K128/V256) -> 256 ch.
+ */
+class PSAAttentionLayer : public nntrainer::LayerImpl {
+public:
+  PSAAttentionLayer() : dim_(0) {}
+  ~PSAAttentionLayer() override = default;
+
+  void finalize(nntrainer::InitLayerContext &context) override;
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+  void calcDerivative(nntrainer::RunLayerContext &context) override {}
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override {}
+  const std::string getType() const override { return PSAAttentionLayer::type; }
+  void setProperty(const std::vector<std::string> &values) override {
+    nntrainer::LayerImpl::setProperty(values);
+  }
+  bool supportBackwarding() const override { return false; }
+
+  static constexpr const char *type = "psa_attention";
+
+private:
+  /**
+   * @brief Spatial multi-head attention.
+   * Q: [nh, kd, N], K: [nh, kd, N], V: [nh, vd, N], out: [nh, vd, N].
+   */
+  static void multiHeadAttention(const float *Q, const float *K, const float *V,
+                                 float *out, int nh, int kd, int vd, int N);
+
+  unsigned int dim_; ///< input channels (= 512)
+  static constexpr unsigned int NUM_HEADS = 4;
+  static constexpr unsigned int KD = 32; ///< key dim per head
+  static constexpr unsigned int VD = 64; ///< val dim per head
+};
+
+} // namespace yolov11
+
+#endif // __C2PSA_LAYER_H__

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -70,16 +70,20 @@ namespace yolov11 {
 
 // ===== graph block builders (Conv/BN/SiLU, C3k2, SPPF) =====
 /**
- * @brief Build a Conv2d + BN + SiLU sub-graph block.
+ * @brief Build a (BN-fused) Conv2d + SiLU sub-graph block.
  *
- * @param name     Layer-name prefix (conv="{name}/conv", bn="{name}/bn")
+ * The original Conv+BatchNorm+SiLU is exported with BatchNorm folded into the
+ * convolution at convert time (PyTorch/convert_weights.py: model.fuse()), so
+ * here the BN is gone: a single biased conv followed by a standalone SiLU.
+ *
+ * @param name     Layer-name prefix (conv="{name}/conv", act="{name}/act")
  * @param in_ch    Input channels
  * @param out_ch   Output channels
  * @param k        Kernel size (square)
  * @param stride   Stride
  * @param padding  Padding
  * @param input    Input symbolic tensor
- * @return Output symbolic tensor after BN+SiLU
+ * @return Output symbolic tensor after conv+SiLU
  */
 inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
                          int stride, int padding, Tensor input) {
@@ -90,15 +94,13 @@ inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
                            nntrainer::withKey("kernel_size", {k, k}),
                            nntrainer::withKey("filters", out_ch),
                            nntrainer::withKey("stride", {stride, stride}),
-                           nntrainer::withKey("padding", padding),
-                           nntrainer::withKey("disable_bias", "true")}));
+                           nntrainer::withKey("padding", padding)}));
   auto h = conv(input);
 
-  LayerHandle bn(createLayer("batch_normalization",
-                             {nntrainer::withKey("name", name + "/bn"),
-                              nntrainer::withKey("momentum", "0.9"),
-                              nntrainer::withKey("activation", "swish")}));
-  return bn(h);
+  LayerHandle act(
+    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
+                               nntrainer::withKey("activation", "swish")}));
+  return act(h);
 }
 
 /**
@@ -208,18 +210,20 @@ inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
 }
 
 /**
- * @brief Build a Conv2d + BN sub-graph block (NO activation).
+ * @brief Build a (BN-fused) Conv2d sub-graph block (NO activation).
  *
- * Used by SPPF cv1 which has act=Identity in PyTorch.
+ * Used where PyTorch had Conv+BN with act=Identity (e.g. SPPF cv1, C2PSA
+ * qkv/proj/ffn1). BatchNorm is folded into the conv at convert time, so this
+ * is just a single biased convolution.
  *
- * @param name     Layer-name prefix (conv="{name}/conv", bn="{name}/bn")
+ * @param name     Layer-name prefix (conv="{name}/conv")
  * @param in_ch    Input channels (unused, inferred from graph)
  * @param out_ch   Output channels
  * @param k        Kernel size
  * @param stride   Stride
  * @param padding  Padding
  * @param input    Input symbolic tensor
- * @return Output symbolic tensor after BN only (no activation)
+ * @return Output symbolic tensor (no activation)
  */
 inline Tensor convBnOnly(const std::string &name, int in_ch, int out_ch, int k,
                          int stride, int padding, Tensor input) {
@@ -230,14 +234,8 @@ inline Tensor convBnOnly(const std::string &name, int in_ch, int out_ch, int k,
                            nntrainer::withKey("kernel_size", {k, k}),
                            nntrainer::withKey("filters", out_ch),
                            nntrainer::withKey("stride", {stride, stride}),
-                           nntrainer::withKey("padding", padding),
-                           nntrainer::withKey("disable_bias", "true")}));
-  auto h = conv(input);
-
-  LayerHandle bn(createLayer("batch_normalization",
-                             {nntrainer::withKey("name", name + "/bn"),
-                              nntrainer::withKey("momentum", "0.9")}));
-  return bn(h);
+                           nntrainer::withKey("padding", padding)}));
+  return conv(input);
 }
 
 /**
@@ -308,7 +306,8 @@ inline Tensor convBias1x1(const std::string &name, int out_ch, Tensor input) {
   return conv(input);
 }
 
-/** @brief Depthwise 3x3 (pad 1) + BN + SiLU. */
+/** @brief Depthwise 3x3 (pad 1) + SiLU, BN folded into the conv at convert
+ * time. */
 inline Tensor dwConvBnSilu(const std::string &name, int ch, Tensor input) {
   // depthwise = grouped conv2d with groups == channels
   LayerHandle dw(createLayer(
@@ -316,18 +315,16 @@ inline Tensor dwConvBnSilu(const std::string &name, int ch, Tensor input) {
     {nntrainer::withKey("name", name + "/dw"),
      nntrainer::withKey("kernel_size", {3, 3}),
      nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
-     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1),
-     nntrainer::withKey("disable_bias", "true")}));
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
   auto h = dw(input);
-  LayerHandle bn(createLayer("batch_normalization",
-                             {nntrainer::withKey("name", name + "/bn"),
-                              nntrainer::withKey("momentum", "0.9"),
-                              nntrainer::withKey("activation", "swish")}));
-  return bn(h);
+  LayerHandle act(
+    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
+                               nntrainer::withKey("activation", "swish")}));
+  return act(h);
 }
 
-/** @brief Depthwise 3x3 (pad 1) + BN, NO activation (e.g. C2PSA position enc).
- */
+/** @brief Depthwise 3x3 (pad 1), NO activation (e.g. C2PSA position enc).
+ *  BN folded into the conv at convert time. */
 inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
   // depthwise = grouped conv2d with groups == channels
   LayerHandle dw(createLayer(
@@ -335,13 +332,8 @@ inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
     {nntrainer::withKey("name", name + "/dw"),
      nntrainer::withKey("kernel_size", {3, 3}),
      nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
-     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1),
-     nntrainer::withKey("disable_bias", "true")}));
-  auto h = dw(input);
-  LayerHandle bn(createLayer("batch_normalization",
-                             {nntrainer::withKey("name", name + "/bn"),
-                              nntrainer::withKey("momentum", "0.9")}));
-  return bn(h);
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
+  return dw(input);
 }
 
 /**
@@ -909,6 +901,23 @@ void verifyAgainst(const std::string &ref_name, const float *out, size_t n) {
             << std::endl;
 }
 
+// Report peak resident set size (VmHWM) from /proc/self/status. Linux/Android
+// only; silently does nothing elsewhere or if the file is unreadable.
+inline void printPeakRSS() {
+#if defined(__linux__)
+  std::ifstream st("/proc/self/status");
+  if (!st.is_open())
+    return;
+  std::string line;
+  while (std::getline(st, line)) {
+    if (line.rfind("VmHWM:", 0) == 0) {
+      std::cout << "Peak RSS: " << line.substr(6) << std::endl;
+      return;
+    }
+  }
+#endif
+}
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -926,6 +935,16 @@ int main(int argc, char *argv[]) {
       ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", "1")});
 
+    // Optional precision override. YOLO_TENSOR_TYPE selects the model tensor
+    // type, e.g. "FP16-FP16" (weights+activations FP16) or "FP32-FP16"
+    // (FP16 activations only). Default (unset) is FP32-FP32. Since Conv+BN are
+    // fused at convert time, there is no BatchNorm mixed-precision path to
+    // block FP16. Must be set before compile().
+    if (const char *tt = std::getenv("YOLO_TENSOR_TYPE")) {
+      model->setProperty({nntrainer::withKey("model_tensor_type", tt)});
+      std::cout << "[YOLO] model_tensor_type = " << tt << std::endl;
+    }
+
     auto x = Tensor({1, 3, 832, 832}, "input0");
     Tensor m4, m6;
     auto m10 = buildBackbone(x, m4, m6);
@@ -936,9 +955,16 @@ int main(int argc, char *argv[]) {
       throw std::runtime_error("compile failed: " + std::to_string(ret));
     // Load every weight from the single nntrainer safetensors produced by
     // PyTorch/convert_weights.py (tensor names match the model weight names).
-    model->load(RES_DIR + "/yolov11m.safetensors",
-                ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
-    std::cout << "Model built and weights loaded." << std::endl;
+    // YOLO_WEIGHTS overrides the file (absolute, or relative to RES_DIR) so a
+    // baseline and a fused/quantized model can be compared without rebuilding.
+    std::string weights_path = RES_DIR + "/yolov11m.safetensors";
+    if (const char *wenv = std::getenv("YOLO_WEIGHTS")) {
+      weights_path =
+        (wenv[0] == '/') ? std::string(wenv) : RES_DIR + "/" + wenv;
+    }
+    model->load(weights_path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
+    std::cout << "Model built and weights loaded (" << weights_path << ")."
+              << std::endl;
 
     // Run one forward pass on the input.
     // argv[2] may be a raw [1,3,832,832] float32 .bin (e.g. from
@@ -951,9 +977,27 @@ int main(int argc, char *argv[]) {
     auto input = loadBin(input_path);
 #endif
     std::vector<float *> in_ptr = {input.data()};
-    auto outs = model->inference(1, in_ptr, std::vector<float *>());
+
+    // Inference timing. YOLO_BENCH_ITERS (default 1) controls how many timed
+    // forward passes to run; the average wall-clock is reported and the last
+    // run's outputs feed post-processing. More iters give a stabler number.
+    int bench_iters =
+      std::getenv("YOLO_BENCH_ITERS")
+        ? std::max(1, std::atoi(std::getenv("YOLO_BENCH_ITERS")))
+        : 1;
+    std::vector<float *> outs;
+    double total_ms = 0.0;
+    for (int it = 0; it < bench_iters; ++it) {
+      auto t0 = std::chrono::steady_clock::now();
+      outs = model->inference(1, in_ptr, std::vector<float *>());
+      auto t1 = std::chrono::steady_clock::now();
+      total_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
     std::cout << "Inference done (" << outs.size() << " scale outputs)."
               << std::endl;
+    std::cout << "Inference time: " << (total_ms / bench_iters)
+              << " ms (avg over " << bench_iters << " iters)" << std::endl;
+    printPeakRSS();
 
     // Post-process: DFL decode + dist2bbox + sigmoid -> [5, N] then NMS.
     std::vector<yolov11::ScaleInfo> scales = {

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <fstream>
@@ -1013,15 +1014,23 @@ int main(int argc, char *argv[]) {
       off += scales[i].H * scales[i].W;
     }
 
-    const float conf_thres = 0.25f, iou_thres = 0.70f;
+    const float conf_thres =
+      std::getenv("YOLO_CONF") ? std::stof(std::getenv("YOLO_CONF")) : 0.25f;
+    const float iou_thres =
+      std::getenv("YOLO_IOU") ? std::stof(std::getenv("YOLO_IOU")) : 0.70f;
     auto dets = yolov11::nms(decoded, N_total, conf_thres, iou_thres, 300);
 
     std::cout << "\nDetections (conf>=" << conf_thres
               << ", xyxy @832): " << dets.size() << std::endl;
     for (size_t i = 0; i < dets.size(); ++i) {
       const auto &d = dets[i];
+      // area in pixels^2 (832 scale)
+      float area = (d.x2 - d.x1) * (d.y2 - d.y1);
+      float cx = (d.x1 + d.x2) * 0.5f;
+      float cy = (d.y1 + d.y2) * 0.5f;
       std::cout << "  [" << i << "] (" << d.x1 << ", " << d.y1 << ", " << d.x2
                 << ", " << d.y2 << ")  conf=" << d.conf << " cls=" << d.cls
+                << " area=" << area << " center=(" << cx << "," << cy << ")"
                 << std::endl;
     }
 

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -482,14 +482,16 @@ int main(int argc, char *argv[]) {
     if (const char *tt = std::getenv("YOLO_TENSOR_TYPE")) {
       std::string tts = tt;
       if (tts == "w4a16" || tts == "W4A16") {
-        model->setProperty({nntrainer::withKey("model_tensor_type", "FP32-FP16")});
+        model->setProperty(
+          {nntrainer::withKey("model_tensor_type", "FP32-FP16")});
         fp16_act = true;
         preset_q40 = true;
         preset_nhwc = true;
         std::cout << "[YOLO] preset = w4a16 (Q4_0 weights + FP16 act + NHWC)"
                   << std::endl;
       } else if (tts == "w4a8" || tts == "W4A8") {
-        model->setProperty({nntrainer::withKey("model_tensor_type", "FP32-FP16")});
+        model->setProperty(
+          {nntrainer::withKey("model_tensor_type", "FP32-FP16")});
         fp16_act = true;
         preset_q40 = true;
         preset_nhwc = true;
@@ -541,14 +543,14 @@ int main(int argc, char *argv[]) {
     const bool in_nhwc = (preset_nhwc || std::getenv("YOLO_NHWC"));
     const auto in_fmt = in_nhwc ? ml::train::TensorDim::Format::NHWC
                                 : ml::train::TensorDim::Format::NCHW;
-    auto x = fp16_act
-               ? Tensor(ml::train::TensorDim(
-                          1, 3, 832, 832, in_fmt,
-                          ml::train::TensorDim::DataType::FP16),
-                        "input0")
-               : Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
-                                             ml::train::TensorDim::DataType::FP32),
-                        "input0");
+    auto x =
+      fp16_act
+        ? Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
+                                      ml::train::TensorDim::DataType::FP16),
+                 "input0")
+        : Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
+                                      ml::train::TensorDim::DataType::FP32),
+                 "input0");
     Tensor m4, m6;
     auto m10 = yolov11::buildBackbone(x, m4, m6, conv_q40);
     auto outputs = yolov11::buildHead(m4, m6, m10, conv_q40); // {P3, P4, P5}

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -192,7 +192,7 @@ inline void dist2bbox(const std::vector<float> &dist, int N,
 inline void decodeOneScale(const float *raw, int H, int W, float stride,
                            const std::vector<float> &anchors,
                            const std::vector<float> &strides_vec,
-                           int anchor_off, int N_total,
+                           int anchor_off, int N_total, int nc,
                            std::vector<float> &decoded) {
   const int N = H * W;
   const int reg_max = 16;
@@ -219,9 +219,11 @@ inline void decodeOneScale(const float *raw, int H, int W, float stride,
       decoded[c * N_total + anchor_off + a] = decoded_box[c * N + a];
     }
   }
-  for (int a = 0; a < N; ++a) {
-    decoded[4 * N_total + anchor_off + a] =
-      1.0f / (1.0f + std::exp(-raw_cls[a]));
+  for (int c = 0; c < nc; ++c) {
+    for (int a = 0; a < N; ++a) {
+      decoded[(4 + c) * N_total + anchor_off + a] =
+        1.0f / (1.0f + std::exp(-raw_cls[c * N + a]));
+    }
   }
 }
 
@@ -250,15 +252,16 @@ inline float iou(const Detection &a, const Detection &b) {
 
 /**
  * @brief Run NMS on decoded predictions.
- * @param decoded    [5, N_total] (cx, cy, w, h, score)
+ * @param decoded    [(4 + nc) * N_total] (cx, cy, w, h, class_scores...)
  * @param N_total    total anchors
+ * @param nc         number of classes
  * @param conf_thres confidence threshold
  * @param iou_thres  IoU threshold
  * @param max_det    max detections to keep
  * @return sorted (descending conf) list of Detection
  */
 inline std::vector<Detection> nms(const std::vector<float> &decoded,
-                                  int N_total, float conf_thres,
+                                  int N_total, int nc, float conf_thres,
                                   float iou_thres, int max_det) {
   const float *cx_ptr = decoded.data() + 0 * N_total;
   const float *cy_ptr = decoded.data() + 1 * N_total;
@@ -266,14 +269,20 @@ inline std::vector<Detection> nms(const std::vector<float> &decoded,
   const float *h_ptr = decoded.data() + 3 * N_total;
   const float *sc_ptr = decoded.data() + 4 * N_total;
 
-  // nc=1: single class, cls_idx always 0
-  // per-class offset = cls_idx * 7680 = 0 for nc=1
   // Build candidate list: xywh → xyxy, filter by score
   std::vector<Detection> candidates;
   candidates.reserve(512);
   for (int a = 0; a < N_total; ++a) {
-    float score = sc_ptr[a];
-    if (score <= conf_thres)
+    float max_score = -1e9f;
+    int max_cls = -1;
+    for (int c = 0; c < nc; ++c) {
+      float score = sc_ptr[c * N_total + a];
+      if (score > max_score) {
+        max_score = score;
+        max_cls = c;
+      }
+    }
+    if (max_score <= conf_thres)
       continue;
     float cx = cx_ptr[a];
     float cy = cy_ptr[a];
@@ -283,7 +292,7 @@ inline std::vector<Detection> nms(const std::vector<float> &decoded,
     float y1 = cy - bh * 0.5f;
     float x2 = cx + bw * 0.5f;
     float y2 = cy + bh * 0.5f;
-    candidates.push_back({x1, y1, x2, y2, score, 0});
+    candidates.push_back({x1, y1, x2, y2, max_score, max_cls});
   }
 
   // Sort descending by conf
@@ -292,8 +301,6 @@ inline std::vector<Detection> nms(const std::vector<float> &decoded,
     [](const Detection &a, const Detection &b) { return a.conf > b.conf; });
 
   // Greedy NMS
-  // For agnostic=False with nc=1, per-class offset = cls_idx*7680 = 0
-  // So effectively agnostic NMS here (same as agnostic since nc=1)
   std::vector<bool> suppressed(candidates.size(), false);
   std::vector<Detection> result;
   result.reserve(max_det);
@@ -534,6 +541,19 @@ int main(int argc, char *argv[]) {
     if (quantize_mode)
       yolov11::quantConvSink() = &q_conv_names;
 
+    // Retrieve dynamic model configuration from environment variables
+    const std::string scale =
+      std::getenv("YOLO_SCALE") ? std::getenv("YOLO_SCALE") : "m";
+    const int imgsz =
+      std::getenv("YOLO_IMGSZ") ? std::atoi(std::getenv("YOLO_IMGSZ")) : 832;
+    const int nc =
+      std::getenv("YOLO_NC") ? std::atoi(std::getenv("YOLO_NC")) : 1;
+    const yolov11::YOLOv11Params p = yolov11::getParams(scale, nc);
+
+    std::cout << "[YOLO] Configuration: scale=" << scale << " ("
+              << (scale == "s" || scale == "S" ? "v11s" : "v11m")
+              << "), imgsz=" << imgsz << ", nc=" << nc << std::endl;
+
     // Declare the input tensor's dtype to match the activation dtype so the
     // synthesized InputLayer emits FP16 output for an FP16-activation model.
     // The input tensor's declared format must match the graph layout so the
@@ -545,25 +565,28 @@ int main(int argc, char *argv[]) {
                                 : ml::train::TensorDim::Format::NCHW;
     auto x =
       fp16_act
-        ? Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
+        ? Tensor(ml::train::TensorDim(1, 3, imgsz, imgsz, in_fmt,
                                       ml::train::TensorDim::DataType::FP16),
                  "input0")
-        : Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
+        : Tensor(ml::train::TensorDim(1, 3, imgsz, imgsz, in_fmt,
                                       ml::train::TensorDim::DataType::FP32),
                  "input0");
     Tensor m4, m6;
-    auto m10 = yolov11::buildBackbone(x, m4, m6, conv_q40);
-    auto outputs = yolov11::buildHead(m4, m6, m10, conv_q40); // {P3, P4, P5}
+    auto m10 = yolov11::buildBackbone(x, m4, m6, p, conv_q40);
+    auto outputs = yolov11::buildHead(m4, m6, m10, p, conv_q40); // {P3, P4, P5}
     yolov11::quantConvSink() = nullptr;
 
     if (int ret =
           model->compile(x, outputs, ml::train::ExecutionMode::INFERENCE))
       throw std::runtime_error("compile failed: " + std::to_string(ret));
+
     // Load every weight from the single nntrainer safetensors produced by
     // PyTorch/convert_weights.py (tensor names match the model weight names).
     // YOLO_WEIGHTS overrides the file (absolute, or relative to RES_DIR) so a
     // baseline and a fused/quantized model can be compared without rebuilding.
-    std::string weights_path = RES_DIR + "/yolov11m.safetensors";
+    std::string weights_path = RES_DIR + "/yolov11" +
+                               (scale == "s" || scale == "S" ? "s" : "m") +
+                               ".safetensors";
     if (const char *wenv = std::getenv("YOLO_WEIGHTS")) {
       weights_path =
         (wenv[0] == '/') ? std::string(wenv) : RES_DIR + "/" + wenv;
@@ -610,7 +633,7 @@ int main(int argc, char *argv[]) {
     // run_pytorch.py), or — when built with stb_image.h present — an image
     // (.jpg/.png/...) which is decoded + letterboxed here.
 #ifdef YOLO_WITH_STB_IMAGE
-    auto input = isImagePath(input_path) ? loadImageLetterbox(input_path)
+    auto input = isImagePath(input_path) ? loadImageLetterbox(input_path, imgsz)
                                          : loadBin(input_path);
 #else
     auto input = loadBin(input_path);
@@ -622,7 +645,7 @@ int main(int argc, char *argv[]) {
     // When the graph is NHWC, the input bytes must also be NHWC-ordered
     // ([N,H,W,C]); input_832.bin is stored NCHW, so transpose here.
     if (preset_nhwc || std::getenv("YOLO_NHWC")) {
-      const int C = 3, H = 832, W = 832;
+      const int C = 3, H = imgsz, W = imgsz;
       std::vector<float> nhwc(input.size());
       for (int c = 0; c < C; ++c)
         for (int h = 0; h < H; ++h)
@@ -653,20 +676,23 @@ int main(int argc, char *argv[]) {
               << " ms (avg over " << bench_iters << " iters)" << std::endl;
     printPeakRSS();
 
-    // Post-process: DFL decode + dist2bbox + sigmoid -> [5, N] then NMS.
-    std::vector<yolov11::ScaleInfo> scales = {
-      {104, 104, 8.0f}, {52, 52, 16.0f}, {26, 26, 32.0f}};
-    const int N_total = 104 * 104 + 52 * 52 + 26 * 26; // 14196
+    // Post-process: DFL decode + dist2bbox + sigmoid -> [4+nc, N] then NMS.
+    std::vector<yolov11::ScaleInfo> scales = {{imgsz / 8, imgsz / 8, 8.0f},
+                                              {imgsz / 16, imgsz / 16, 16.0f},
+                                              {imgsz / 32, imgsz / 32, 32.0f}};
+    const int N_total = (imgsz / 8) * (imgsz / 8) +
+                        (imgsz / 16) * (imgsz / 16) +
+                        (imgsz / 32) * (imgsz / 32);
     std::vector<float> anchors, strides;
     yolov11::makeAnchors(scales, anchors, strides);
 
     // When the graph runs NHWC, each scale output tensor is stored channel-last
     // in memory ((h*W+w)*C + c), but decodeOneScale expects the NCHW channel-
     // major layout (c*N + a). Transpose each output to NCHW before decoding.
-    // Detect output channels = 4*reg_max (DFL box) + nc = 64 + 1 = 65 (nc=1).
+    // Detect output channels = 4*reg_max (DFL box) + nc = 64 + nc.
     const bool out_nhwc = preset_nhwc || std::getenv("YOLO_NHWC");
-    const int OUT_CH = 65;
-    std::vector<float> decoded(5 * N_total, 0.0f);
+    const int OUT_CH = 64 + nc;
+    std::vector<float> decoded((4 + nc) * N_total, 0.0f);
     int off = 0;
     for (size_t i = 0; i < scales.size(); ++i) {
       const float *raw = outs[i];
@@ -681,7 +707,7 @@ int main(int argc, char *argv[]) {
         raw = nchw_buf.data();
       }
       yolov11::decodeOneScale(raw, scales[i].H, scales[i].W, scales[i].stride,
-                              anchors, strides, off, N_total, decoded);
+                              anchors, strides, off, N_total, nc, decoded);
       off += scales[i].H * scales[i].W;
     }
 
@@ -689,7 +715,7 @@ int main(int argc, char *argv[]) {
       std::getenv("YOLO_CONF") ? std::stof(std::getenv("YOLO_CONF")) : 0.25f;
     const float iou_thres =
       std::getenv("YOLO_IOU") ? std::stof(std::getenv("YOLO_IOU")) : 0.70f;
-    auto dets = yolov11::nms(decoded, N_total, conf_thres, iou_thres, 300);
+    auto dets = yolov11::nms(decoded, N_total, nc, conf_thres, iou_thres, 300);
 
     // JSON output — same field names as the PyTorch reference JSON
     std::cout << "\n[";
@@ -705,7 +731,10 @@ int main(int argc, char *argv[]) {
 
     if (verify) {
       std::cout << "\nVerification vs PyTorch references:" << std::endl;
-      const size_t ns[3] = {65UL * 104 * 104, 65UL * 52 * 52, 65UL * 26 * 26};
+      const size_t ns[3] = {
+        static_cast<size_t>(OUT_CH) * (imgsz / 8) * (imgsz / 8),
+        static_cast<size_t>(OUT_CH) * (imgsz / 16) * (imgsz / 16),
+        static_cast<size_t>(OUT_CH) * (imgsz / 32) * (imgsz / 32)};
       const char *names[3] = {"ref_p3.bin", "ref_p4.bin", "ref_p5.bin"};
       for (int i = 0; i < 3; ++i)
         verifyAgainst(names[i], outs[i], ns[i]);

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -1,0 +1,1042 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   main.cpp
+ * @date   18 June 2026
+ * @brief  YOLOv11m (832x832, nc=1) detection inference example on nntrainer.
+ *         Builds the full model (backbone + FPN head + 3-scale Detect head),
+ *         loads converted weights, runs one forward pass, and post-processes
+ *         (DFL decode + NMS) into final detection boxes.
+ *
+ *         Usage: yolov11_infer [RES_DIR] [INPUT_BIN]
+ *           RES_DIR   dir with weights/ and input bins
+ *                     (default: Applications/CausalLM/models/YOLOv11/res)
+ *           INPUT_BIN [1,3,832,832] float32 NCHW (default:
+ * RES_DIR/input_832.bin) Set env YOLO_VERIFY=1 to also compare raw logits /
+ * decoded output to PyTorch references (ref_p3/p4/p5.bin, ref_decoded.bin) when
+ * present.
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include <app_context.h>
+#include <engine.h>
+#include <layer.h>
+#include <model.h>
+#include <safetensors_util.h>
+#include <tensor.h>
+#include <tensor_api.h>
+#include <util_func.h>
+
+#include "c2psa_layer.h"
+
+// Optional direct image input. Enabled only when stb_image.h is present (the
+// build defines YOLO_WITH_STB_IMAGE via meson fs.exists). stb_image.h is NOT
+// committed; download it to enable .jpg/.png input:
+//   curl -fsSL
+//   https://raw.githubusercontent.com/nothings/stb/master/stb_image.h \
+//     -o Applications/CausalLM/models/YOLOv11/jni/stb_image.h
+// Without it the example still builds and runs on .bin input.
+#ifdef YOLO_WITH_STB_IMAGE
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#pragma GCC diagnostic pop
+#endif
+
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
+using ModelHandle = std::unique_ptr<ml::train::Model>;
+
+namespace yolov11 {
+
+// ===== graph block builders (Conv/BN/SiLU, C3k2, SPPF) =====
+/**
+ * @brief Build a Conv2d + BN + SiLU sub-graph block.
+ *
+ * @param name     Layer-name prefix (conv="{name}/conv", bn="{name}/bn")
+ * @param in_ch    Input channels
+ * @param out_ch   Output channels
+ * @param k        Kernel size (square)
+ * @param stride   Stride
+ * @param padding  Padding
+ * @param input    Input symbolic tensor
+ * @return Output symbolic tensor after BN+SiLU
+ */
+inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
+                         int stride, int padding, Tensor input) {
+  (void)in_ch; // shape is inferred from the graph
+
+  LayerHandle conv(
+    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
+                           nntrainer::withKey("kernel_size", {k, k}),
+                           nntrainer::withKey("filters", out_ch),
+                           nntrainer::withKey("stride", {stride, stride}),
+                           nntrainer::withKey("padding", padding),
+                           nntrainer::withKey("disable_bias", "true")}));
+  auto h = conv(input);
+
+  LayerHandle bn(createLayer("batch_normalization",
+                             {nntrainer::withKey("name", name + "/bn"),
+                              nntrainer::withKey("momentum", "0.9"),
+                              nntrainer::withKey("activation", "swish")}));
+  return bn(h);
+}
+
+/**
+ * @brief Build a Bottleneck sub-graph (cv1 3x3 + cv2 3x3 + residual add).
+ *
+ * PyTorch: return x + cv2(cv1(x))   [shortcut=True]
+ *
+ * @param name    Layer-name prefix (e.g. "m2/m0/inner0")
+ * @param ch      Both input and output channel count
+ * @param input   Input symbolic tensor
+ * @return Output symbolic tensor
+ */
+inline Tensor bottleneck(const std::string &name, int ch, Tensor input) {
+  auto h = convBnSilu(name + "/cv1", ch, ch, 3, 1, 1, input);
+  h = convBnSilu(name + "/cv2", ch, ch, 3, 1, 1, h);
+  // residual add
+  LayerHandle add(
+    createLayer("Addition", {nntrainer::withKey("name", name + "/add")}));
+  return add({h, input});
+}
+
+/**
+ * @brief Build a C3k sub-graph.
+ *
+ * Forward:
+ *   inner_path = inner1(inner0(cv1(x)))   [chain of Bottlenecks]
+ *   skip       = cv2(x)
+ *   out        = cv3(concat([inner_path, skip], dim=1))
+ *
+ * @param name       Layer-name prefix (e.g. "m2/m0")
+ * @param in_ch      Input channels  (64)
+ * @param inner_ch   Inner (half) channels fed to Bottleneck chain (32)
+ * @param out_ch     Output channels (64)
+ * @param input      Input symbolic tensor
+ * @return Output symbolic tensor
+ */
+inline Tensor c3kBlock(const std::string &name, int in_ch, int inner_ch,
+                       int out_ch, Tensor input) {
+  // cv1: 1x1, in_ch → inner_ch
+  auto inner = convBnSilu(name + "/cv1", in_ch, inner_ch, 1, 1, 0, input);
+
+  // Two Bottleneck blocks
+  inner = bottleneck(name + "/inner0", inner_ch, inner);
+  inner = bottleneck(name + "/inner1", inner_ch, inner);
+
+  // cv2: 1x1, in_ch → inner_ch  (skip branch)
+  auto skip = convBnSilu(name + "/cv2", in_ch, inner_ch, 1, 1, 0, input);
+
+  // concat along channel dim (axis=1)
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({inner, skip});
+
+  // cv3: 1x1, 2*inner_ch → out_ch
+  return convBnSilu(name + "/cv3", 2 * inner_ch, out_ch, 1, 1, 0, concat_out);
+}
+
+/**
+ * @brief Build a C3k2 sub-graph.
+ *
+ * Forward:
+ *   y      = cv1(x)                  // 128→128 (1x1)
+ *   y_a    = y[:, :c, :, :]          // first  64 channels
+ *   y_b    = y[:, c:, :, :]          // second 64 channels
+ *   y_c    = m0(y_b)                 // C3k block, 64→64
+ *   out    = cv2(concat([y_a, y_b, y_c], dim=1))  // 192→256
+ *
+ * @param name     Layer-name prefix (e.g. "m2")
+ * @param in_ch    Input channels  (128)
+ * @param out_ch   Output channels (256)
+ * @param c        Hidden channel count (64 = floor(out_ch * e))
+ * @param input    Input symbolic tensor
+ * @return Output symbolic tensor
+ */
+inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
+                        Tensor input) {
+  // cv1: 1x1, in_ch → 2*c
+  auto y = convBnSilu(name + "/cv1", in_ch, 2 * c, 1, 1, 0, input);
+
+  // Split y along channel dim into y_a (first c) and y_b (second c)
+  // Using two slice layers: axis=1, 1-indexed [start_index, end_index)
+  LayerHandle sliceA(
+    createLayer("slice", {nntrainer::withKey("name", name + "/slice_a"),
+                          nntrainer::withKey("axis", 1),
+                          nntrainer::withKey("start_index", 1),
+                          nntrainer::withKey("end_index", c + 1)}));
+  auto y_a = sliceA(y);
+
+  LayerHandle sliceB(
+    createLayer("slice", {nntrainer::withKey("name", name + "/slice_b"),
+                          nntrainer::withKey("axis", 1),
+                          nntrainer::withKey("start_index", c + 1),
+                          nntrainer::withKey("end_index", 2 * c + 1)}));
+  auto y_b = sliceB(y);
+
+  // m0: C3k block, c → c  (inner_ch = c/2 = 32)
+  auto y_c = c3kBlock(name + "/m0", c, c / 2, c, y_b);
+
+  // cv2: 1x1, 3*c → out_ch  (concat of y_a, y_b, y_c)
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({y_a, y_b, y_c});
+
+  return convBnSilu(name + "/cv2", 3 * c, out_ch, 1, 1, 0, concat_out);
+}
+
+/**
+ * @brief Build a Conv2d + BN sub-graph block (NO activation).
+ *
+ * Used by SPPF cv1 which has act=Identity in PyTorch.
+ *
+ * @param name     Layer-name prefix (conv="{name}/conv", bn="{name}/bn")
+ * @param in_ch    Input channels (unused, inferred from graph)
+ * @param out_ch   Output channels
+ * @param k        Kernel size
+ * @param stride   Stride
+ * @param padding  Padding
+ * @param input    Input symbolic tensor
+ * @return Output symbolic tensor after BN only (no activation)
+ */
+inline Tensor convBnOnly(const std::string &name, int in_ch, int out_ch, int k,
+                         int stride, int padding, Tensor input) {
+  (void)in_ch;
+
+  LayerHandle conv(
+    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
+                           nntrainer::withKey("kernel_size", {k, k}),
+                           nntrainer::withKey("filters", out_ch),
+                           nntrainer::withKey("stride", {stride, stride}),
+                           nntrainer::withKey("padding", padding),
+                           nntrainer::withKey("disable_bias", "true")}));
+  auto h = conv(input);
+
+  LayerHandle bn(createLayer("batch_normalization",
+                             {nntrainer::withKey("name", name + "/bn"),
+                              nntrainer::withKey("momentum", "0.9")}));
+  return bn(h);
+}
+
+/**
+ * @brief Build a MaxPool2d layer with explicit padding.
+ *
+ * @param name     Layer name
+ * @param k        Kernel size (square)
+ * @param input    Input symbolic tensor
+ * @return Output symbolic tensor
+ */
+inline Tensor maxPool(const std::string &name, int k, Tensor input) {
+  int p = k / 2;
+  // Padding2D format: "pt,pb,pl,pr"
+  std::string pad_str = std::to_string(p) + "," + std::to_string(p) + "," +
+                        std::to_string(p) + "," + std::to_string(p);
+  LayerHandle pool(
+    createLayer("pooling2d", {nntrainer::withKey("name", name),
+                              nntrainer::withKey("pooling", "max"),
+                              nntrainer::withKey("pool_size", {k, k}),
+                              nntrainer::withKey("stride", {1, 1}),
+                              nntrainer::withKey("padding", pad_str)}));
+  return pool(input);
+}
+
+/**
+ * @brief Build an SPPF sub-graph.
+ *
+ * PyTorch SPPF forward (verified by model inspection):
+ *   y   = cv1(x)            # Conv+BN, act=Identity (NO SiLU)
+ *   y   = [y, m(y), m(m(y)), m(m(m(y)))]   # 3× sequential MaxPool
+ *   out = cv2(concat(y, 1)) # Conv+BN+SiLU
+ *
+ * @param name    Layer-name prefix (e.g. "m9")
+ * @param in_ch   Input channels  (512)
+ * @param input   Input symbolic tensor
+ * @return Output symbolic tensor
+ */
+inline Tensor sppfBlock(const std::string &name, int in_ch, Tensor input) {
+  int half = in_ch / 2;
+
+  // cv1: 1x1, in_ch → in_ch/2, NO activation (act=Identity in PyTorch)
+  auto x = convBnOnly(name + "/cv1", in_ch, half, 1, 1, 0, input);
+
+  // Three sequential MaxPool(k=5,s=1,p=2)
+  auto p1 = maxPool(name + "/pool1", 5, x);
+  auto p2 = maxPool(name + "/pool2", 5, p1);
+  auto p3 = maxPool(name + "/pool3", 5, p2);
+
+  // concat([x, p1, p2, p3], dim=1) → half*4 channels
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({x, p1, p2, p3});
+
+  // cv2: 1x1, (in_ch/2)*4 → in_ch, SiLU activation
+  return convBnSilu(name + "/cv2", half * 4, in_ch, 1, 1, 0, concat_out);
+}
+
+// ===== Detect head graph builders =====
+/** @brief 1x1 Conv2d with bias, no BN, no activation (detect output conv). */
+inline Tensor convBias1x1(const std::string &name, int out_ch, Tensor input) {
+  LayerHandle conv(
+    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
+                           nntrainer::withKey("kernel_size", {1, 1}),
+                           nntrainer::withKey("filters", out_ch),
+                           nntrainer::withKey("stride", {1, 1}),
+                           nntrainer::withKey("padding", 0)}));
+  return conv(input);
+}
+
+/** @brief Depthwise 3x3 (pad 1) + BN + SiLU. */
+inline Tensor dwConvBnSilu(const std::string &name, int ch, Tensor input) {
+  // depthwise = grouped conv2d with groups == channels
+  LayerHandle dw(createLayer(
+    "conv2d",
+    {nntrainer::withKey("name", name + "/dw"),
+     nntrainer::withKey("kernel_size", {3, 3}),
+     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1),
+     nntrainer::withKey("disable_bias", "true")}));
+  auto h = dw(input);
+  LayerHandle bn(createLayer("batch_normalization",
+                             {nntrainer::withKey("name", name + "/bn"),
+                              nntrainer::withKey("momentum", "0.9"),
+                              nntrainer::withKey("activation", "swish")}));
+  return bn(h);
+}
+
+/** @brief Depthwise 3x3 (pad 1) + BN, NO activation (e.g. C2PSA position enc).
+ */
+inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
+  // depthwise = grouped conv2d with groups == channels
+  LayerHandle dw(createLayer(
+    "conv2d",
+    {nntrainer::withKey("name", name + "/dw"),
+     nntrainer::withKey("kernel_size", {3, 3}),
+     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1),
+     nntrainer::withKey("disable_bias", "true")}));
+  auto h = dw(input);
+  LayerHandle bn(createLayer("batch_normalization",
+                             {nntrainer::withKey("name", name + "/bn"),
+                              nntrainer::withKey("momentum", "0.9")}));
+  return bn(h);
+}
+
+/**
+ * @brief Build one Detect scale -> raw logits [1, 64+nc, H, W].
+ * @param s     name prefix (e.g. "det0")
+ * @param pi_ch input feature channels (256 for P3, 512 for P4/P5)
+ * @param in    input feature map
+ */
+inline Tensor detectScale(const std::string &s, int pi_ch, Tensor in) {
+  // box branch (cv2)
+  auto x = convBnSilu(s + "/cv2_0", pi_ch, 64, 3, 1, 1, in);
+  x = convBnSilu(s + "/cv2_1", 64, 64, 3, 1, 1, x);
+  auto box = convBias1x1(s + "/cv2_2", 64, x);
+
+  // cls branch (cv3) — depthwise-separable x2 then 1x1
+  auto c = dwConvBnSilu(s + "/cv3_0_dw", pi_ch, in);
+  c = convBnSilu(s + "/cv3_0_pw", pi_ch, 256, 1, 1, 0, c);
+  c = dwConvBnSilu(s + "/cv3_1_dw", 256, c);
+  c = convBnSilu(s + "/cv3_1_pw", 256, 256, 1, 1, 0, c);
+  auto cls = convBias1x1(s + "/cv3_2", 1, c);
+
+  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", s + "/out"),
+                                         nntrainer::withKey("axis", 1)}));
+  return cat({box, cls});
+}
+
+// ===== post-processing (DFL decode + dist2bbox + NMS) =====
+// ---------------------------------------------------------------------------
+// Anchor generation (ultralytics tal.py: make_anchors)
+//
+// For each scale with grid (H, W) and stride s:
+//   sx = [0.5, 1.5, ..., W-0.5]
+//   sy = [0.5, 1.5, ..., H-0.5]
+//   row-major meshgrid: y outer, x inner → [H*W, 2] (x,y) in grid units
+// Concat P3 → P4 → P5.
+// ---------------------------------------------------------------------------
+struct ScaleInfo {
+  int H;
+  int W;
+  float stride;
+};
+
+/**
+ * @brief Generate anchor points and stride tensor.
+ * @param scales  Vector of (H, W, stride) for each detection scale.
+ * @param[out] anchors     [num_anchors, 2] (x, y) in grid units.
+ * @param[out] strides_out [num_anchors] stride per anchor.
+ */
+inline void makeAnchors(const std::vector<ScaleInfo> &scales,
+                        std::vector<float> &anchors,
+                        std::vector<float> &strides_out) {
+  size_t total = 0;
+  for (const auto &s : scales) {
+    total += static_cast<size_t>(s.H) * s.W;
+  }
+  anchors.resize(total * 2);
+  strides_out.resize(total);
+
+  size_t off = 0;
+  for (const auto &s : scales) {
+    for (int iy = 0; iy < s.H; ++iy) {
+      for (int ix = 0; ix < s.W; ++ix) {
+        // anchor (x, y) in grid units with 0.5 offset
+        anchors[off * 2 + 0] = static_cast<float>(ix) + 0.5f;
+        anchors[off * 2 + 1] = static_cast<float>(iy) + 0.5f;
+        strides_out[off] = s.stride;
+        ++off;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DFL (Distribution Focal Loss) decode
+//
+// Input: raw_box [64, N] (64 = 4 * reg_max, reg_max=16)
+//   Interpreted as [4, reg_max, N]: coord-major (4 outer, 16 inner).
+//   i.e. bins [0..15] for coord 0, then [0..15] for coord 1, etc.
+// Step:
+//   1. For each coord c in {0,1,2,3} and anchor a:
+//      take raw_box[c*reg_max .. c*reg_max+15][a] → 16-bin logits
+//   2. Softmax over 16 bins
+//   3. Weighted sum with weights [0,1,...,15]
+// Output: dist [4, N] in grid units (ltrb).
+// ---------------------------------------------------------------------------
+inline void dfl(const float *raw_box, int reg_max, int N,
+                std::vector<float> &dist) {
+  // raw_box layout: [64, N] = [4*reg_max, N], C-order
+  // raw_box[c*reg_max + k][a] = raw_box[(c*reg_max + k)*N + a]
+  dist.resize(4 * N);
+  for (int c = 0; c < 4; ++c) {
+    for (int a = 0; a < N; ++a) {
+      // Extract 16 logits for this coord and anchor
+      float logits[16];
+      for (int k = 0; k < reg_max; ++k) {
+        logits[k] = raw_box[(c * reg_max + k) * N + a];
+      }
+      // Softmax
+      float max_logit = *std::max_element(logits, logits + reg_max);
+      float sum = 0.0f;
+      float exp_v[16];
+      for (int k = 0; k < reg_max; ++k) {
+        exp_v[k] = std::exp(logits[k] - max_logit);
+        sum += exp_v[k];
+      }
+      // Weighted sum with bin indices [0, 1, ..., 15]
+      float val = 0.0f;
+      for (int k = 0; k < reg_max; ++k) {
+        val += (exp_v[k] / sum) * static_cast<float>(k);
+      }
+      dist[c * N + a] = val;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dist2bbox + stride multiply → XYWH pixels at 832-scale
+//
+// dist [4, N] = (lt_x, lt_y, rb_x, rb_y) in grid units
+// anchors [N, 2] = (ax, ay) in grid units
+// strides [N]
+//
+// x1y1 = anchor - lt   (grid)
+// x2y2 = anchor + rb   (grid)
+// cx = (x1+x2)/2 * stride
+// cy = (y1+y2)/2 * stride
+// w  = (x2-x1) * stride
+// h  = (y2-y1) * stride
+//
+// Output decoded_box [4, N] = (cx, cy, w, h) pixels
+// ---------------------------------------------------------------------------
+inline void dist2bbox(const std::vector<float> &dist, int N,
+                      const std::vector<float> &anchors,
+                      const std::vector<float> &strides,
+                      std::vector<float> &decoded_box) {
+  // dist layout: [4, N] = lt_x[N], lt_y[N], rb_x[N], rb_y[N]
+  const float *lt_x = dist.data() + 0 * N;
+  const float *lt_y = dist.data() + 1 * N;
+  const float *rb_x = dist.data() + 2 * N;
+  const float *rb_y = dist.data() + 3 * N;
+
+  decoded_box.resize(4 * N);
+  float *cx = decoded_box.data() + 0 * N;
+  float *cy = decoded_box.data() + 1 * N;
+  float *w = decoded_box.data() + 2 * N;
+  float *h = decoded_box.data() + 3 * N;
+
+  for (int a = 0; a < N; ++a) {
+    float ax = anchors[a * 2 + 0];
+    float ay = anchors[a * 2 + 1];
+    float s = strides[a];
+
+    float x1 = ax - lt_x[a];
+    float y1 = ay - lt_y[a];
+    float x2 = ax + rb_x[a];
+    float y2 = ay + rb_y[a];
+
+    cx[a] = (x1 + x2) * 0.5f * s;
+    cy[a] = (y1 + y2) * 0.5f * s;
+    w[a] = (x2 - x1) * s;
+    h[a] = (y2 - y1) * s;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Full post-processing pipeline for one scale:
+//   raw [65, H, W] → box logits [64, N] + cls logits [1, N]
+//   → DFL → dist2bbox → sigmoid(cls)
+//   → fills decoded [5, N] starting at offset anchor_off in output
+// ---------------------------------------------------------------------------
+inline void decodeOneScale(const float *raw, // [65, H, W] channel-major
+                           int H, int W, float stride,
+                           const std::vector<float> &anchors,
+                           const std::vector<float> &strides_vec,
+                           int anchor_off, // offset into global anchor array
+                           int N_total,    // total anchors (14196)
+                           std::vector<float> &decoded // [5, N_total]
+) {
+  const int N = H * W;
+  const int reg_max = 16;
+
+  // raw layout: [65, H, W] = [65, N] in row-major (channel outer, spatial
+  // inner) box channels: 0..63, cls channel: 64 Pointer to box part:
+  // raw[0..63][a] = raw[c*N + a]
+  const float *raw_box = raw;          // [64, N]
+  const float *raw_cls = raw + 64 * N; // [1, N]
+
+  // DFL decode: dist [4, N]
+  std::vector<float> dist;
+  dfl(raw_box, reg_max, N, dist);
+
+  // Anchors for this scale (subset of global anchors)
+  // anchors[anchor_off..anchor_off+N-1] × 2
+  std::vector<float> scale_anchors(N * 2);
+  std::vector<float> scale_strides(N);
+  for (int a = 0; a < N; ++a) {
+    scale_anchors[a * 2 + 0] = anchors[(anchor_off + a) * 2 + 0];
+    scale_anchors[a * 2 + 1] = anchors[(anchor_off + a) * 2 + 1];
+    scale_strides[a] = strides_vec[anchor_off + a];
+  }
+
+  // dist2bbox → decoded_box [4, N]
+  std::vector<float> decoded_box;
+  dist2bbox(dist, N, scale_anchors, scale_strides, decoded_box);
+
+  // Fill decoded [5, N_total] at this scale's anchor offset
+  // decoded layout: [5, N_total] = (cx[N_total], cy[N_total], w[N_total],
+  //                                  h[N_total], cls[N_total])
+  for (int c = 0; c < 4; ++c) {
+    for (int a = 0; a < N; ++a) {
+      decoded[c * N_total + anchor_off + a] = decoded_box[c * N + a];
+    }
+  }
+  // cls: sigmoid
+  for (int a = 0; a < N; ++a) {
+    decoded[4 * N_total + anchor_off + a] =
+      1.0f / (1.0f + std::exp(-raw_cls[a]));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NMS (non_max_suppression matching ultralytics behavior)
+//
+// Input: decoded [5, N_total] = (cx, cy, w, h, score)
+// Steps:
+//   1. xywh → xyxy
+//   2. filter score > conf_thres
+//   3. per-class offset: box_nms = xyxy + cls_idx * max_wh (agnostic=False)
+//      (nc=1, so cls_idx=0 always → no actual offset)
+//   4. NMS with iou_thres
+//   5. keep up to max_det
+// Output: vector of [x1,y1,x2,y2,conf,cls] rows
+// ---------------------------------------------------------------------------
+struct Detection {
+  float x1, y1, x2, y2, conf;
+  int cls;
+};
+
+inline float iou(const Detection &a, const Detection &b) {
+  float ix1 = std::max(a.x1, b.x1);
+  float iy1 = std::max(a.y1, b.y1);
+  float ix2 = std::min(a.x2, b.x2);
+  float iy2 = std::min(a.y2, b.y2);
+  float inter_w = std::max(0.0f, ix2 - ix1);
+  float inter_h = std::max(0.0f, iy2 - iy1);
+  float inter = inter_w * inter_h;
+  if (inter == 0.0f)
+    return 0.0f;
+  float area_a = (a.x2 - a.x1) * (a.y2 - a.y1);
+  float area_b = (b.x2 - b.x1) * (b.y2 - b.y1);
+  return inter / (area_a + area_b - inter);
+}
+
+/**
+ * @brief Run NMS on decoded predictions.
+ * @param decoded    [5, N_total] (cx, cy, w, h, score)
+ * @param N_total    total anchors
+ * @param conf_thres confidence threshold
+ * @param iou_thres  IoU threshold
+ * @param max_det    max detections to keep
+ * @return sorted (descending conf) list of Detection
+ */
+inline std::vector<Detection> nms(const std::vector<float> &decoded,
+                                  int N_total, float conf_thres,
+                                  float iou_thres, int max_det) {
+  const float *cx_ptr = decoded.data() + 0 * N_total;
+  const float *cy_ptr = decoded.data() + 1 * N_total;
+  const float *w_ptr = decoded.data() + 2 * N_total;
+  const float *h_ptr = decoded.data() + 3 * N_total;
+  const float *sc_ptr = decoded.data() + 4 * N_total;
+
+  // nc=1: single class, cls_idx always 0
+  // per-class offset = cls_idx * 7680 = 0 for nc=1
+  // Build candidate list: xywh → xyxy, filter by score
+  std::vector<Detection> candidates;
+  candidates.reserve(512);
+  for (int a = 0; a < N_total; ++a) {
+    float score = sc_ptr[a];
+    if (score <= conf_thres)
+      continue;
+    float cx = cx_ptr[a];
+    float cy = cy_ptr[a];
+    float bw = w_ptr[a];
+    float bh = h_ptr[a];
+    float x1 = cx - bw * 0.5f;
+    float y1 = cy - bh * 0.5f;
+    float x2 = cx + bw * 0.5f;
+    float y2 = cy + bh * 0.5f;
+    candidates.push_back({x1, y1, x2, y2, score, 0});
+  }
+
+  // Sort descending by conf
+  std::sort(
+    candidates.begin(), candidates.end(),
+    [](const Detection &a, const Detection &b) { return a.conf > b.conf; });
+
+  // Greedy NMS
+  // For agnostic=False with nc=1, per-class offset = cls_idx*7680 = 0
+  // So effectively agnostic NMS here (same as agnostic since nc=1)
+  std::vector<bool> suppressed(candidates.size(), false);
+  std::vector<Detection> result;
+  result.reserve(max_det);
+
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    if (suppressed[i])
+      continue;
+    result.push_back(candidates[i]);
+    if (static_cast<int>(result.size()) >= max_det)
+      break;
+    for (size_t j = i + 1; j < candidates.size(); ++j) {
+      if (suppressed[j])
+        continue;
+      // Both class 0, so NMS boxes are the same as original boxes
+      if (iou(candidates[i], candidates[j]) > iou_thres) {
+        suppressed[j] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+} // namespace yolov11
+
+namespace {
+
+// Resource directory (yolov11m.safetensors + input/reference bins). Overridable
+// via argv[1]; default assumes the binary runs from the nntrainer project root.
+std::string RES_DIR = "Applications/CausalLM/models/YOLOv11/res";
+
+/**
+ * @brief Load binary file as float vector
+ */
+std::vector<float> loadBin(const std::string &path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    throw std::runtime_error("Cannot open: " + path);
+  }
+  f.seekg(0, std::ios::end);
+  size_t n = f.tellg() / sizeof(float);
+  f.seekg(0);
+  std::vector<float> v(n);
+  f.read(reinterpret_cast<char *>(v.data()), n * sizeof(float));
+  return v;
+}
+
+#ifdef YOLO_WITH_STB_IMAGE
+/** @brief True if the path looks like an image we can decode with stb_image. */
+bool isImagePath(const std::string &p) {
+  auto lower = p;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  for (const char *e : {".jpg", ".jpeg", ".png", ".bmp"})
+    if (lower.size() >= std::strlen(e) &&
+        lower.compare(lower.size() - std::strlen(e), std::strlen(e), e) == 0)
+      return true;
+  return false;
+}
+
+/**
+ * @brief Decode an image and letterbox it to [1,3,size,size] float32 CHW RGB.
+ *
+ * Mirrors ultralytics letterbox: resize (bilinear, half-pixel centers) keeping
+ * aspect ratio, pad the rest with 114, /255. Note the bilinear resampler is not
+ * bit-identical to OpenCV's, so detections on a real image are very close to
+ * but not exactly equal to the PyTorch/cv2 path; for an exact match feed the
+ * .bin written by PyTorch/run_pytorch.py instead.
+ */
+std::vector<float> loadImageLetterbox(const std::string &path, int size = 832,
+                                      float pad = 114.0f) {
+  int w = 0, h = 0, c = 0;
+  unsigned char *img = stbi_load(path.c_str(), &w, &h, &c, 3); // force RGB
+  if (!img)
+    throw std::runtime_error("Cannot decode image: " + path);
+
+  const float r = std::min((float)size / h, (float)size / w);
+  const int nh = (int)std::round(h * r), nw = (int)std::round(w * r);
+  const int top = (size - nh) / 2, left = (size - nw) / 2;
+
+  std::vector<float> out(3UL * size * size, pad / 255.0f);
+  for (int oy = 0; oy < nh; ++oy) {
+    float sy = (oy + 0.5f) * h / nh - 0.5f; // cv2 INTER_LINEAR mapping
+    int y0 = (int)std::floor(sy);
+    float fy = sy - y0;
+    int y0c = std::min(std::max(y0, 0), h - 1), y1c = std::min(y0 + 1, h - 1);
+    for (int ox = 0; ox < nw; ++ox) {
+      float sx = (ox + 0.5f) * w / nw - 0.5f;
+      int x0 = (int)std::floor(sx);
+      float fx = sx - x0;
+      int x0c = std::min(std::max(x0, 0), w - 1), x1c = std::min(x0 + 1, w - 1);
+      for (int ch = 0; ch < 3; ++ch) {
+        auto px = [&](int yy, int xx) {
+          return (float)img[(yy * w + xx) * 3 + ch];
+        };
+        float v = px(y0c, x0c) * (1 - fx) * (1 - fy) +
+                  px(y0c, x1c) * fx * (1 - fy) + px(y1c, x0c) * (1 - fx) * fy +
+                  px(y1c, x1c) * fx * fy;
+        out[(size_t)ch * size * size + (size_t)(top + oy) * size +
+            (left + ox)] = v / 255.0f;
+      }
+    }
+  }
+  stbi_image_free(img);
+  std::cout << "image " << path << " (" << w << "x" << h << ") letterboxed to "
+            << size << "x" << size << std::endl;
+  return out;
+}
+#endif // YOLO_WITH_STB_IMAGE
+
+/** @brief Channel-axis slice [start, end) — slice layer uses 1-indexed bounds.
+ */
+inline Tensor sliceCh(const std::string &name, int start0, int end0,
+                      Tensor in) {
+  LayerHandle s(createLayer(
+    "slice", {nntrainer::withKey("name", name), nntrainer::withKey("axis", 1),
+              nntrainer::withKey("start_index", start0 + 1),
+              nntrainer::withKey("end_index", end0 + 1)}));
+  return s(in);
+}
+
+/** @brief Elementwise addition of two tensors. */
+inline Tensor addT(const std::string &name, Tensor a, Tensor b) {
+  LayerHandle l(createLayer("Addition", {nntrainer::withKey("name", name)}));
+  return l({a, b});
+}
+
+/**
+ * @brief Build the C2PSA block (model.10) from standard layers + the
+ *        psa_attention custom op. Input/output [B, 512, H, W].
+ *
+ *   cv1 = Conv1x1+BN+SiLU; split -> a[256], b[256]
+ *   qkv = Conv1x1+BN(b);  V = qkv[256:512]
+ *   attn = psa_attention(qkv);  pe = DWConv3x3+BN(V);  attn += pe
+ *   b = b + proj(attn);  b = b + ffn1(ffn0(b))
+ *   out = Conv1x1+BN+SiLU(concat([a, b]))
+ */
+inline Tensor buildC2PSA(const std::string &n, Tensor x) {
+  auto cv1 = yolov11::convBnSilu(n + "/cv1", 512, 512, 1, 1, 0, x);
+  auto a = sliceCh(n + "/slice_a", 0, 256, cv1);
+  auto b = sliceCh(n + "/slice_b", 256, 512, cv1);
+
+  auto qkv = yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b);
+
+  // qkv has the per-head interleaved layout [Q32,K32,V64] x 4 heads.
+  // Gather the V parts (channels [h*128+64 : h*128+128]) head-major -> [256].
+  std::vector<Tensor> v_parts;
+  for (int h = 0; h < 4; ++h)
+    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h), h * 128 + 64,
+                              h * 128 + 128, qkv));
+  LayerHandle vcat(
+    createLayer("concat", {nntrainer::withKey("name", n + "/vcat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto v = vcat(v_parts);
+  auto pe = yolov11::dwConvBnOnly(n + "/pe", 256, v);
+
+  LayerHandle att(
+    createLayer("psa_attention", {nntrainer::withKey("name", n + "/attn")}));
+  auto attn = att(qkv);
+  auto attn_pe = addT(n + "/add_pe", attn, pe);
+  auto proj = yolov11::convBnOnly(n + "/proj", 256, 256, 1, 1, 0, attn_pe);
+  auto b1 = addT(n + "/res1", b, proj);
+
+  auto ffn0 = yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1);
+  // NOTE: ffn1 has BN but NO SiLU (verified against PyTorch; SiLU here yields
+  // a ~0.78 error at model.10 that amplifies downstream).
+  auto ffn1 = yolov11::convBnOnly(n + "/ffn1", 512, 256, 1, 1, 0, ffn0);
+  auto b2 = addT(n + "/res2", b1, ffn1);
+
+  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", n + "/cat"),
+                                         nntrainer::withKey("axis", 1)}));
+  auto cc = cat({a, b2});
+  return yolov11::convBnSilu(n + "/cv2", 512, 512, 1, 1, 0, cc);
+}
+
+inline Tensor buildBackbone(Tensor xIn, Tensor &m4_out, Tensor &m6_out) {
+  auto h = yolov11::convBnSilu("conv0", 3, 64, 3, 2, 1, xIn);
+  h = yolov11::convBnSilu("conv1", 64, 128, 3, 2, 1, h);
+  h = yolov11::c3k2Block("m2", 128, 256, 64, h);
+  h = yolov11::convBnSilu("conv3", 256, 256, 3, 2, 1, h);
+  m4_out = yolov11::c3k2Block("m4", 256, 512, 128, h);
+  h = yolov11::convBnSilu("conv5", 512, 512, 3, 2, 1, m4_out);
+  m6_out = yolov11::c3k2Block("m6", 512, 512, 256, h);
+  h = yolov11::convBnSilu("conv7", 512, 512, 3, 2, 1, m6_out);
+  h = yolov11::c3k2Block("m8", 512, 512, 256, h);
+  h = yolov11::sppfBlock("m9", 512, h);
+  return buildC2PSA("m10", h); // model.10 (C2PSA)
+}
+
+} // namespace
+
+namespace {
+
+/** @brief Upsample(nearest, x2) layer. */
+Tensor upsampleX2(const std::string &name, Tensor in) {
+  LayerHandle l(
+    createLayer("upsample2d", {nntrainer::withKey("name", name),
+                               nntrainer::withKey("upsample", "nearest"),
+                               nntrainer::withKey("kernel_size", "2,2")}));
+  return l(in);
+}
+
+/** @brief Channel-axis concat layer. */
+Tensor concatCh(const std::string &name, const std::vector<Tensor> &ins) {
+  LayerHandle l(createLayer("concat", {nntrainer::withKey("name", name),
+                                       nntrainer::withKey("axis", 1)}));
+  return l(ins);
+}
+
+/**
+ * @brief Build the FPN head (model.11~22) and 3-scale Detect head (model.23).
+ * @return raw detection logits for P3, P4, P5 (each [1, 4*reg_max+nc, H, W]).
+ */
+std::vector<Tensor> buildHead(Tensor m4, Tensor m6, Tensor m10) {
+  auto m11 = upsampleX2("m11", m10);
+  auto m12 = concatCh("m12", {m11, m6});
+  auto m13 = yolov11::c3k2Block("m13", 1024, 512, 256, m12);
+
+  auto m14 = upsampleX2("m14", m13);
+  auto m15 = concatCh("m15", {m14, m4});
+  auto m16 = yolov11::c3k2Block("m16", 1024, 256, 128, m15); // P3 feature
+
+  auto m17 = yolov11::convBnSilu("m17", 256, 256, 3, 2, 1, m16);
+  auto m18 = concatCh("m18", {m17, m13});
+  auto m19 = yolov11::c3k2Block("m19", 768, 512, 256, m18); // P4 feature
+
+  auto m20 = yolov11::convBnSilu("m20", 512, 512, 3, 2, 1, m19);
+  auto m21 = concatCh("m21", {m20, m10});
+  auto m22 = yolov11::c3k2Block("m22", 1024, 512, 256, m21); // P5 feature
+
+  // Detect head (model.23): built from standard layers (conv2d/depthwiseconv2d/
+  // batch_normalization/concat) — see detect_block.h.
+  return {yolov11::detectScale("det0", 256, m16),
+          yolov11::detectScale("det1", 512, m19),
+          yolov11::detectScale("det2", 512, m22)};
+}
+
+/**
+ * @brief Load all weights from a single nntrainer safetensors file.
+ *
+ * The file (produced by PyTorch/convert_weights.py) holds one tensor per model
+ * weight, named "{layer}:{weight}" (e.g. "conv0/conv:filter",
+ * "conv0/bn:moving_mean"). Tensors of the same layer are contiguous and stored
+ * in the layer's weight-registration order, so we group consecutive tensors by
+ * layer name and push them to layer->setWeights() in file order.
+ */
+void loadSafetensors(ml::train::Model *model, const std::string &path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f)
+    throw std::runtime_error("Cannot open safetensors: " + path);
+  uint64_t hlen = 0;
+  f.read(reinterpret_cast<char *>(&hlen), 8);
+  std::string hdr(hlen, '\0');
+  f.read(&hdr[0], static_cast<std::streamsize>(hlen));
+
+  // Parse the header with nntrainer's own safetensors parser (preserves order).
+  auto entries = nntrainer::safetensors::parseHeaderEntries(hdr);
+  const std::streamoff data_base = 8 + static_cast<std::streamoff>(hlen);
+  auto layerOf = [](const std::string &n) { return n.substr(0, n.find(':')); };
+
+  // Group consecutive entries by layer and setWeights per layer.
+  size_t i = 0;
+  while (i < entries.size()) {
+    const std::string layer = layerOf(entries[i].name);
+    std::vector<std::vector<float>> bufs;
+    std::vector<float *> ptrs;
+    size_t j = i;
+    for (; j < entries.size() && layerOf(entries[j].name) == layer; ++j) {
+      size_t n =
+        (entries[j].offset_end - entries[j].offset_start) / sizeof(float);
+      std::vector<float> buf(n);
+      f.seekg(data_base + static_cast<std::streamoff>(entries[j].offset_start));
+      f.read(reinterpret_cast<char *>(buf.data()),
+             static_cast<std::streamsize>(n * sizeof(float)));
+      bufs.push_back(std::move(buf));
+    }
+    for (auto &b : bufs)
+      ptrs.push_back(b.data());
+    std::shared_ptr<ml::train::Layer> l;
+    if (model->getLayer(layer.c_str(), &l))
+      throw std::runtime_error("safetensors: no model layer named " + layer);
+    l->setWeights(ptrs);
+    i = j;
+  }
+}
+
+/** @brief Register the YOLOv11 custom layers with the global AppContext.
+ *  Only C2PSA is custom; the Detect head uses standard nntrainer layers. */
+void registerCustomLayers() {
+  auto &app_ctx = nntrainer::AppContext::Global();
+  app_ctx.registerFactory(nntrainer::createLayer<yolov11::PSAAttentionLayer>);
+}
+
+/** @brief Optionally compare a logit tensor to a PyTorch reference .bin. */
+void verifyAgainst(const std::string &ref_name, const float *out, size_t n) {
+  std::ifstream f(RES_DIR + "/" + ref_name, std::ios::binary);
+  if (!f) {
+    std::cout << "  [verify] " << ref_name << " not found, skipped"
+              << std::endl;
+    return;
+  }
+  auto ref = loadBin(RES_DIR + "/" + ref_name);
+  float max_diff = 0.0f;
+  for (size_t i = 0; i < n && i < ref.size(); ++i)
+    max_diff = std::max(max_diff, std::abs(out[i] - ref[i]));
+  std::cout << "  [verify] " << ref_name << ": max_abs_diff=" << max_diff
+            << std::endl;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  try {
+    if (argc > 1)
+      RES_DIR = argv[1];
+    const std::string input_path =
+      (argc > 2) ? argv[2] : (RES_DIR + "/input_832.bin");
+    const bool verify = std::getenv("YOLO_VERIFY") != nullptr;
+
+    registerCustomLayers();
+
+    // Build the full model: input -> backbone -> head -> 3 detect outputs.
+    ModelHandle model =
+      ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+    model->setProperty({nntrainer::withKey("batch_size", "1"),
+                        nntrainer::withKey("memory_optimization", "false")});
+
+    auto x = Tensor({1, 3, 832, 832}, "input0");
+    Tensor m4, m6;
+    auto m10 = buildBackbone(x, m4, m6);
+    auto outputs = buildHead(m4, m6, m10); // {P3, P4, P5} raw logits
+
+    if (int ret =
+          model->compile(x, outputs, ml::train::ExecutionMode::INFERENCE))
+      throw std::runtime_error("compile failed: " + std::to_string(ret));
+    // Load every weight from the single nntrainer safetensors produced by
+    // PyTorch/convert_weights.py (tensor names match the model weight names).
+    loadSafetensors(model.get(), RES_DIR + "/yolov11m.safetensors");
+    std::cout << "Model built and weights loaded." << std::endl;
+
+    // Run one forward pass on the input.
+    // argv[2] may be a raw [1,3,832,832] float32 .bin (e.g. from
+    // run_pytorch.py), or — when built with stb_image.h present — an image
+    // (.jpg/.png/...) which is decoded + letterboxed here.
+#ifdef YOLO_WITH_STB_IMAGE
+    auto input = isImagePath(input_path) ? loadImageLetterbox(input_path)
+                                         : loadBin(input_path);
+#else
+    auto input = loadBin(input_path);
+#endif
+    std::vector<float *> in_ptr = {input.data()};
+    auto outs = model->inference(1, in_ptr, std::vector<float *>());
+    std::cout << "Inference done (" << outs.size() << " scale outputs)."
+              << std::endl;
+
+    // Post-process: DFL decode + dist2bbox + sigmoid -> [5, N] then NMS.
+    std::vector<yolov11::ScaleInfo> scales = {
+      {104, 104, 8.0f}, {52, 52, 16.0f}, {26, 26, 32.0f}};
+    const int N_total = 104 * 104 + 52 * 52 + 26 * 26; // 14196
+    std::vector<float> anchors, strides;
+    yolov11::makeAnchors(scales, anchors, strides);
+
+    std::vector<float> decoded(5 * N_total, 0.0f);
+    int off = 0;
+    for (size_t i = 0; i < scales.size(); ++i) {
+      yolov11::decodeOneScale(outs[i], scales[i].H, scales[i].W,
+                              scales[i].stride, anchors, strides, off, N_total,
+                              decoded);
+      off += scales[i].H * scales[i].W;
+    }
+
+    const float conf_thres = 0.25f, iou_thres = 0.70f;
+    auto dets = yolov11::nms(decoded, N_total, conf_thres, iou_thres, 300);
+
+    std::cout << "\nDetections (conf>=" << conf_thres
+              << ", xyxy @832): " << dets.size() << std::endl;
+    for (size_t i = 0; i < dets.size(); ++i) {
+      const auto &d = dets[i];
+      std::cout << "  [" << i << "] (" << d.x1 << ", " << d.y1 << ", " << d.x2
+                << ", " << d.y2 << ")  conf=" << d.conf << " cls=" << d.cls
+                << std::endl;
+    }
+
+    if (verify) {
+      std::cout << "\nVerification vs PyTorch references:" << std::endl;
+      const size_t ns[3] = {65UL * 104 * 104, 65UL * 52 * 52, 65UL * 26 * 26};
+      const char *names[3] = {"ref_p3.bin", "ref_p4.bin", "ref_p5.bin"};
+      for (int i = 0; i < 3; ++i)
+        verifyAgainst(names[i], outs[i], ns[i]);
+      verifyAgainst("ref_decoded.bin", decoded.data(), decoded.size());
+    }
+
+    return 0;
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
+}

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -63,6 +63,10 @@
 #pragma GCC diagnostic pop
 #endif
 
+// OpenBLAS runtime thread-count API (pthread build). Declared here to avoid
+// pulling the cblas backend header into the app; see the call in main().
+extern "C" void openblas_set_num_threads(int);
+
 using ml::train::createLayer;
 using ml::train::LayerHandle;
 using ml::train::Tensor;
@@ -442,6 +446,16 @@ inline void printPeakRSS() {
 
 int main(int argc, char *argv[]) {
   try {
+    // Force the BLAS backend (used by the C2PSA attention sgemm and the detect
+    // head) to a single thread. nntrainer's conv path drives its own
+    // ThreadManager pool; letting OpenBLAS spawn a competing thread pool over-
+    // subscribes the cores and both slows the conv path and inflates RSS
+    // (~+25MB). OpenBLAS reads OPENBLAS_NUM_THREADS at its dlopen constructor
+    // (before main), so setenv() here is too late; the pthread build honors the
+    // runtime openblas_set_num_threads() API instead. Small GEMMs stay cache-
+    // friendly without a competing pool.
+    openblas_set_num_threads(1);
+
     if (argc > 1)
       RES_DIR = argv[1];
     const std::string input_path =

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -31,19 +31,21 @@
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <sstream>
 #include <utility>
 #include <vector>
 
+#include "c2psa_layer.h"
+#include "yolov11_graph.h"
 #include <app_context.h>
 #include <engine.h>
 #include <layer.h>
 #include <model.h>
 #include <tensor.h>
 #include <tensor_api.h>
-#include "c2psa_layer.h"
 
 // Optional direct image input. Enabled only when stb_image.h is present (the
 // build defines YOLO_WITH_STB_IMAGE via meson fs.exists). stb_image.h is NOT
@@ -66,301 +68,12 @@ using ml::train::LayerHandle;
 using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 
+// Graph block builders are defined in yolov11_graph.h (included above).
+// Post-processing (DFL decode, NMS) remains here.
+
 namespace yolov11 {
 
-// ===== graph block builders (Conv/BN/SiLU, C3k2, SPPF) =====
-/**
- * @brief Build a (BN-fused) Conv2d + SiLU sub-graph block.
- *
- * The original Conv+BatchNorm+SiLU is exported with BatchNorm folded into the
- * convolution at convert time (PyTorch/convert_weights.py: model.fuse()), so
- * here the BN is gone: a single biased conv followed by a standalone SiLU.
- *
- * @param name     Layer-name prefix (conv="{name}/conv", act="{name}/act")
- * @param in_ch    Input channels
- * @param out_ch   Output channels
- * @param k        Kernel size (square)
- * @param stride   Stride
- * @param padding  Padding
- * @param input    Input symbolic tensor
- * @return Output symbolic tensor after conv+SiLU
- */
-inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
-                         int stride, int padding, Tensor input) {
-  (void)in_ch; // shape is inferred from the graph
-
-  LayerHandle conv(
-    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
-                           nntrainer::withKey("kernel_size", {k, k}),
-                           nntrainer::withKey("filters", out_ch),
-                           nntrainer::withKey("stride", {stride, stride}),
-                           nntrainer::withKey("padding", padding)}));
-  auto h = conv(input);
-
-  LayerHandle act(
-    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
-                               nntrainer::withKey("activation", "swish")}));
-  return act(h);
-}
-
-/**
- * @brief Build a Bottleneck sub-graph (cv1 3x3 + cv2 3x3 + residual add).
- *
- * PyTorch: return x + cv2(cv1(x))   [shortcut=True]
- *
- * @param name    Layer-name prefix (e.g. "m2/m0/inner0")
- * @param ch      Both input and output channel count
- * @param input   Input symbolic tensor
- * @return Output symbolic tensor
- */
-inline Tensor bottleneck(const std::string &name, int ch, Tensor input) {
-  auto h = convBnSilu(name + "/cv1", ch, ch, 3, 1, 1, input);
-  h = convBnSilu(name + "/cv2", ch, ch, 3, 1, 1, h);
-  // residual add
-  LayerHandle add(
-    createLayer("Addition", {nntrainer::withKey("name", name + "/add")}));
-  return add({h, input});
-}
-
-/**
- * @brief Build a C3k sub-graph.
- *
- * Forward:
- *   inner_path = inner1(inner0(cv1(x)))   [chain of Bottlenecks]
- *   skip       = cv2(x)
- *   out        = cv3(concat([inner_path, skip], dim=1))
- *
- * @param name       Layer-name prefix (e.g. "m2/m0")
- * @param in_ch      Input channels  (64)
- * @param inner_ch   Inner (half) channels fed to Bottleneck chain (32)
- * @param out_ch     Output channels (64)
- * @param input      Input symbolic tensor
- * @return Output symbolic tensor
- */
-inline Tensor c3kBlock(const std::string &name, int in_ch, int inner_ch,
-                       int out_ch, Tensor input) {
-  // cv1: 1x1, in_ch → inner_ch
-  auto inner = convBnSilu(name + "/cv1", in_ch, inner_ch, 1, 1, 0, input);
-
-  // Two Bottleneck blocks
-  inner = bottleneck(name + "/inner0", inner_ch, inner);
-  inner = bottleneck(name + "/inner1", inner_ch, inner);
-
-  // cv2: 1x1, in_ch → inner_ch  (skip branch)
-  auto skip = convBnSilu(name + "/cv2", in_ch, inner_ch, 1, 1, 0, input);
-
-  // concat along channel dim (axis=1)
-  LayerHandle cat(
-    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
-                           nntrainer::withKey("axis", 1)}));
-  auto concat_out = cat({inner, skip});
-
-  // cv3: 1x1, 2*inner_ch → out_ch
-  return convBnSilu(name + "/cv3", 2 * inner_ch, out_ch, 1, 1, 0, concat_out);
-}
-
-/**
- * @brief Build a C3k2 sub-graph.
- *
- * Forward:
- *   y      = cv1(x)                  // 128→128 (1x1)
- *   y_a    = y[:, :c, :, :]          // first  64 channels
- *   y_b    = y[:, c:, :, :]          // second 64 channels
- *   y_c    = m0(y_b)                 // C3k block, 64→64
- *   out    = cv2(concat([y_a, y_b, y_c], dim=1))  // 192→256
- *
- * @param name     Layer-name prefix (e.g. "m2")
- * @param in_ch    Input channels  (128)
- * @param out_ch   Output channels (256)
- * @param c        Hidden channel count (64 = floor(out_ch * e))
- * @param input    Input symbolic tensor
- * @return Output symbolic tensor
- */
-inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
-                        Tensor input) {
-  // cv1: 1x1, in_ch → 2*c
-  auto y = convBnSilu(name + "/cv1", in_ch, 2 * c, 1, 1, 0, input);
-
-  // Split y along channel dim into y_a (first c) and y_b (second c)
-  // Using two slice layers: axis=1, 1-indexed [start_index, end_index)
-  LayerHandle sliceA(
-    createLayer("slice", {nntrainer::withKey("name", name + "/slice_a"),
-                          nntrainer::withKey("axis", 1),
-                          nntrainer::withKey("start_index", 1),
-                          nntrainer::withKey("end_index", c + 1)}));
-  auto y_a = sliceA(y);
-
-  LayerHandle sliceB(
-    createLayer("slice", {nntrainer::withKey("name", name + "/slice_b"),
-                          nntrainer::withKey("axis", 1),
-                          nntrainer::withKey("start_index", c + 1),
-                          nntrainer::withKey("end_index", 2 * c + 1)}));
-  auto y_b = sliceB(y);
-
-  // m0: C3k block, c → c  (inner_ch = c/2 = 32)
-  auto y_c = c3kBlock(name + "/m0", c, c / 2, c, y_b);
-
-  // cv2: 1x1, 3*c → out_ch  (concat of y_a, y_b, y_c)
-  LayerHandle cat(
-    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
-                           nntrainer::withKey("axis", 1)}));
-  auto concat_out = cat({y_a, y_b, y_c});
-
-  return convBnSilu(name + "/cv2", 3 * c, out_ch, 1, 1, 0, concat_out);
-}
-
-/**
- * @brief Build a (BN-fused) Conv2d sub-graph block (NO activation).
- *
- * Used where PyTorch had Conv+BN with act=Identity (e.g. SPPF cv1, C2PSA
- * qkv/proj/ffn1). BatchNorm is folded into the conv at convert time, so this
- * is just a single biased convolution.
- *
- * @param name     Layer-name prefix (conv="{name}/conv")
- * @param in_ch    Input channels (unused, inferred from graph)
- * @param out_ch   Output channels
- * @param k        Kernel size
- * @param stride   Stride
- * @param padding  Padding
- * @param input    Input symbolic tensor
- * @return Output symbolic tensor (no activation)
- */
-inline Tensor convBnOnly(const std::string &name, int in_ch, int out_ch, int k,
-                         int stride, int padding, Tensor input) {
-  (void)in_ch;
-
-  LayerHandle conv(
-    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
-                           nntrainer::withKey("kernel_size", {k, k}),
-                           nntrainer::withKey("filters", out_ch),
-                           nntrainer::withKey("stride", {stride, stride}),
-                           nntrainer::withKey("padding", padding)}));
-  return conv(input);
-}
-
-/**
- * @brief Build a MaxPool2d layer with explicit padding.
- *
- * @param name     Layer name
- * @param k        Kernel size (square)
- * @param input    Input symbolic tensor
- * @return Output symbolic tensor
- */
-inline Tensor maxPool(const std::string &name, int k, Tensor input) {
-  int p = k / 2;
-  // Padding2D format: "pt,pb,pl,pr"
-  std::string pad_str = std::to_string(p) + "," + std::to_string(p) + "," +
-                        std::to_string(p) + "," + std::to_string(p);
-  LayerHandle pool(
-    createLayer("pooling2d", {nntrainer::withKey("name", name),
-                              nntrainer::withKey("pooling", "max"),
-                              nntrainer::withKey("pool_size", {k, k}),
-                              nntrainer::withKey("stride", {1, 1}),
-                              nntrainer::withKey("padding", pad_str)}));
-  return pool(input);
-}
-
-/**
- * @brief Build an SPPF sub-graph.
- *
- * PyTorch SPPF forward (verified by model inspection):
- *   y   = cv1(x)            # Conv+BN, act=Identity (NO SiLU)
- *   y   = [y, m(y), m(m(y)), m(m(m(y)))]   # 3× sequential MaxPool
- *   out = cv2(concat(y, 1)) # Conv+BN+SiLU
- *
- * @param name    Layer-name prefix (e.g. "m9")
- * @param in_ch   Input channels  (512)
- * @param input   Input symbolic tensor
- * @return Output symbolic tensor
- */
-inline Tensor sppfBlock(const std::string &name, int in_ch, Tensor input) {
-  int half = in_ch / 2;
-
-  // cv1: 1x1, in_ch → in_ch/2, NO activation (act=Identity in PyTorch)
-  auto x = convBnOnly(name + "/cv1", in_ch, half, 1, 1, 0, input);
-
-  // Three sequential MaxPool(k=5,s=1,p=2)
-  auto p1 = maxPool(name + "/pool1", 5, x);
-  auto p2 = maxPool(name + "/pool2", 5, p1);
-  auto p3 = maxPool(name + "/pool3", 5, p2);
-
-  // concat([x, p1, p2, p3], dim=1) → half*4 channels
-  LayerHandle cat(
-    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
-                           nntrainer::withKey("axis", 1)}));
-  auto concat_out = cat({x, p1, p2, p3});
-
-  // cv2: 1x1, (in_ch/2)*4 → in_ch, SiLU activation
-  return convBnSilu(name + "/cv2", half * 4, in_ch, 1, 1, 0, concat_out);
-}
-
-// ===== Detect head graph builders =====
-/** @brief 1x1 Conv2d with bias, no BN, no activation (detect output conv). */
-inline Tensor convBias1x1(const std::string &name, int out_ch, Tensor input) {
-  LayerHandle conv(
-    createLayer("conv2d", {nntrainer::withKey("name", name + "/conv"),
-                           nntrainer::withKey("kernel_size", {1, 1}),
-                           nntrainer::withKey("filters", out_ch),
-                           nntrainer::withKey("stride", {1, 1}),
-                           nntrainer::withKey("padding", 0)}));
-  return conv(input);
-}
-
-/** @brief Depthwise 3x3 (pad 1) + SiLU, BN folded into the conv at convert
- * time. */
-inline Tensor dwConvBnSilu(const std::string &name, int ch, Tensor input) {
-  // depthwise = grouped conv2d with groups == channels
-  LayerHandle dw(createLayer(
-    "conv2d",
-    {nntrainer::withKey("name", name + "/dw"),
-     nntrainer::withKey("kernel_size", {3, 3}),
-     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
-     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
-  auto h = dw(input);
-  LayerHandle act(
-    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
-                               nntrainer::withKey("activation", "swish")}));
-  return act(h);
-}
-
-/** @brief Depthwise 3x3 (pad 1), NO activation (e.g. C2PSA position enc).
- *  BN folded into the conv at convert time. */
-inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
-  // depthwise = grouped conv2d with groups == channels
-  LayerHandle dw(createLayer(
-    "conv2d",
-    {nntrainer::withKey("name", name + "/dw"),
-     nntrainer::withKey("kernel_size", {3, 3}),
-     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
-     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
-  return dw(input);
-}
-
-/**
- * @brief Build one Detect scale -> raw logits [1, 64+nc, H, W].
- * @param s     name prefix (e.g. "det0")
- * @param pi_ch input feature channels (256 for P3, 512 for P4/P5)
- * @param in    input feature map
- */
-inline Tensor detectScale(const std::string &s, int pi_ch, Tensor in) {
-  // box branch (cv2)
-  auto x = convBnSilu(s + "/cv2_0", pi_ch, 64, 3, 1, 1, in);
-  x = convBnSilu(s + "/cv2_1", 64, 64, 3, 1, 1, x);
-  auto box = convBias1x1(s + "/cv2_2", 64, x);
-
-  // cls branch (cv3) — depthwise-separable x2 then 1x1
-  auto c = dwConvBnSilu(s + "/cv3_0_dw", pi_ch, in);
-  c = convBnSilu(s + "/cv3_0_pw", pi_ch, 256, 1, 1, 0, c);
-  c = dwConvBnSilu(s + "/cv3_1_dw", 256, c);
-  c = convBnSilu(s + "/cv3_1_pw", 256, 256, 1, 1, 0, c);
-  auto cls = convBias1x1(s + "/cv3_2", 1, c);
-
-  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", s + "/out"),
-                                         nntrainer::withKey("axis", 1)}));
-  return cat({box, cls});
-}
-
-// ===== post-processing (DFL decode + dist2bbox + NMS) =====
+// ===== Post-processing (DFL decode + dist2bbox + NMS) =====
 // ---------------------------------------------------------------------------
 // Anchor generation (ultralytics tal.py: make_anchors)
 //
@@ -396,7 +109,6 @@ inline void makeAnchors(const std::vector<ScaleInfo> &scales,
   for (const auto &s : scales) {
     for (int iy = 0; iy < s.H; ++iy) {
       for (int ix = 0; ix < s.W; ++ix) {
-        // anchor (x, y) in grid units with 0.5 offset
         anchors[off * 2 + 0] = static_cast<float>(ix) + 0.5f;
         anchors[off * 2 + 1] = static_cast<float>(iy) + 0.5f;
         strides_out[off] = s.stride;
@@ -408,30 +120,16 @@ inline void makeAnchors(const std::vector<ScaleInfo> &scales,
 
 // ---------------------------------------------------------------------------
 // DFL (Distribution Focal Loss) decode
-//
-// Input: raw_box [64, N] (64 = 4 * reg_max, reg_max=16)
-//   Interpreted as [4, reg_max, N]: coord-major (4 outer, 16 inner).
-//   i.e. bins [0..15] for coord 0, then [0..15] for coord 1, etc.
-// Step:
-//   1. For each coord c in {0,1,2,3} and anchor a:
-//      take raw_box[c*reg_max .. c*reg_max+15][a] → 16-bin logits
-//   2. Softmax over 16 bins
-//   3. Weighted sum with weights [0,1,...,15]
-// Output: dist [4, N] in grid units (ltrb).
 // ---------------------------------------------------------------------------
 inline void dfl(const float *raw_box, int reg_max, int N,
                 std::vector<float> &dist) {
-  // raw_box layout: [64, N] = [4*reg_max, N], C-order
-  // raw_box[c*reg_max + k][a] = raw_box[(c*reg_max + k)*N + a]
   dist.resize(4 * N);
   for (int c = 0; c < 4; ++c) {
     for (int a = 0; a < N; ++a) {
-      // Extract 16 logits for this coord and anchor
       float logits[16];
       for (int k = 0; k < reg_max; ++k) {
         logits[k] = raw_box[(c * reg_max + k) * N + a];
       }
-      // Softmax
       float max_logit = *std::max_element(logits, logits + reg_max);
       float sum = 0.0f;
       float exp_v[16];
@@ -439,7 +137,6 @@ inline void dfl(const float *raw_box, int reg_max, int N,
         exp_v[k] = std::exp(logits[k] - max_logit);
         sum += exp_v[k];
       }
-      // Weighted sum with bin indices [0, 1, ..., 15]
       float val = 0.0f;
       for (int k = 0; k < reg_max; ++k) {
         val += (exp_v[k] / sum) * static_cast<float>(k);
@@ -451,25 +148,11 @@ inline void dfl(const float *raw_box, int reg_max, int N,
 
 // ---------------------------------------------------------------------------
 // dist2bbox + stride multiply → XYWH pixels at 832-scale
-//
-// dist [4, N] = (lt_x, lt_y, rb_x, rb_y) in grid units
-// anchors [N, 2] = (ax, ay) in grid units
-// strides [N]
-//
-// x1y1 = anchor - lt   (grid)
-// x2y2 = anchor + rb   (grid)
-// cx = (x1+x2)/2 * stride
-// cy = (y1+y2)/2 * stride
-// w  = (x2-x1) * stride
-// h  = (y2-y1) * stride
-//
-// Output decoded_box [4, N] = (cx, cy, w, h) pixels
 // ---------------------------------------------------------------------------
 inline void dist2bbox(const std::vector<float> &dist, int N,
                       const std::vector<float> &anchors,
                       const std::vector<float> &strides,
                       std::vector<float> &decoded_box) {
-  // dist layout: [4, N] = lt_x[N], lt_y[N], rb_x[N], rb_y[N]
   const float *lt_x = dist.data() + 0 * N;
   const float *lt_y = dist.data() + 1 * N;
   const float *rb_x = dist.data() + 2 * N;
@@ -499,34 +182,22 @@ inline void dist2bbox(const std::vector<float> &dist, int N,
 }
 
 // ---------------------------------------------------------------------------
-// Full post-processing pipeline for one scale:
-//   raw [65, H, W] → box logits [64, N] + cls logits [1, N]
-//   → DFL → dist2bbox → sigmoid(cls)
-//   → fills decoded [5, N] starting at offset anchor_off in output
+// Full post-processing pipeline for one scale
 // ---------------------------------------------------------------------------
-inline void decodeOneScale(const float *raw, // [65, H, W] channel-major
-                           int H, int W, float stride,
+inline void decodeOneScale(const float *raw, int H, int W, float stride,
                            const std::vector<float> &anchors,
                            const std::vector<float> &strides_vec,
-                           int anchor_off, // offset into global anchor array
-                           int N_total,    // total anchors (14196)
-                           std::vector<float> &decoded // [5, N_total]
-) {
+                           int anchor_off, int N_total,
+                           std::vector<float> &decoded) {
   const int N = H * W;
   const int reg_max = 16;
 
-  // raw layout: [65, H, W] = [65, N] in row-major (channel outer, spatial
-  // inner) box channels: 0..63, cls channel: 64 Pointer to box part:
-  // raw[0..63][a] = raw[c*N + a]
-  const float *raw_box = raw;          // [64, N]
-  const float *raw_cls = raw + 64 * N; // [1, N]
+  const float *raw_box = raw;
+  const float *raw_cls = raw + 64 * N;
 
-  // DFL decode: dist [4, N]
   std::vector<float> dist;
   dfl(raw_box, reg_max, N, dist);
 
-  // Anchors for this scale (subset of global anchors)
-  // anchors[anchor_off..anchor_off+N-1] × 2
   std::vector<float> scale_anchors(N * 2);
   std::vector<float> scale_strides(N);
   for (int a = 0; a < N; ++a) {
@@ -535,19 +206,14 @@ inline void decodeOneScale(const float *raw, // [65, H, W] channel-major
     scale_strides[a] = strides_vec[anchor_off + a];
   }
 
-  // dist2bbox → decoded_box [4, N]
   std::vector<float> decoded_box;
   dist2bbox(dist, N, scale_anchors, scale_strides, decoded_box);
 
-  // Fill decoded [5, N_total] at this scale's anchor offset
-  // decoded layout: [5, N_total] = (cx[N_total], cy[N_total], w[N_total],
-  //                                  h[N_total], cls[N_total])
   for (int c = 0; c < 4; ++c) {
     for (int a = 0; a < N; ++a) {
       decoded[c * N_total + anchor_off + a] = decoded_box[c * N + a];
     }
   }
-  // cls: sigmoid
   for (int a = 0; a < N; ++a) {
     decoded[4 * N_total + anchor_off + a] =
       1.0f / (1.0f + std::exp(-raw_cls[a]));
@@ -555,17 +221,7 @@ inline void decodeOneScale(const float *raw, // [65, H, W] channel-major
 }
 
 // ---------------------------------------------------------------------------
-// NMS (non_max_suppression matching ultralytics behavior)
-//
-// Input: decoded [5, N_total] = (cx, cy, w, h, score)
-// Steps:
-//   1. xywh → xyxy
-//   2. filter score > conf_thres
-//   3. per-class offset: box_nms = xyxy + cls_idx * max_wh (agnostic=False)
-//      (nc=1, so cls_idx=0 always → no actual offset)
-//   4. NMS with iou_thres
-//   5. keep up to max_det
-// Output: vector of [x1,y1,x2,y2,conf,cls] rows
+// NMS
 // ---------------------------------------------------------------------------
 struct Detection {
   float x1, y1, x2, y2, conf;
@@ -742,142 +398,6 @@ std::vector<float> loadImageLetterbox(const std::string &path, int size = 832,
 }
 #endif // YOLO_WITH_STB_IMAGE
 
-/** @brief Channel-axis slice [start, end) — slice layer uses 1-indexed bounds.
- */
-inline Tensor sliceCh(const std::string &name, int start0, int end0,
-                      Tensor in) {
-  LayerHandle s(createLayer(
-    "slice", {nntrainer::withKey("name", name), nntrainer::withKey("axis", 1),
-              nntrainer::withKey("start_index", start0 + 1),
-              nntrainer::withKey("end_index", end0 + 1)}));
-  return s(in);
-}
-
-/** @brief Elementwise addition of two tensors. */
-inline Tensor addT(const std::string &name, Tensor a, Tensor b) {
-  LayerHandle l(createLayer("Addition", {nntrainer::withKey("name", name)}));
-  return l({a, b});
-}
-
-/**
- * @brief Build the C2PSA block (model.10) from standard layers + the
- *        psa_attention custom op. Input/output [B, 512, H, W].
- *
- *   cv1 = Conv1x1+BN+SiLU; split -> a[256], b[256]
- *   qkv = Conv1x1+BN(b);  V = qkv[256:512]
- *   attn = psa_attention(qkv);  pe = DWConv3x3+BN(V);  attn += pe
- *   b = b + proj(attn);  b = b + ffn1(ffn0(b))
- *   out = Conv1x1+BN+SiLU(concat([a, b]))
- */
-inline Tensor buildC2PSA(const std::string &n, Tensor x) {
-  auto cv1 = yolov11::convBnSilu(n + "/cv1", 512, 512, 1, 1, 0, x);
-  auto a = sliceCh(n + "/slice_a", 0, 256, cv1);
-  auto b = sliceCh(n + "/slice_b", 256, 512, cv1);
-
-  auto qkv = yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b);
-
-  // qkv has the per-head interleaved layout [Q32,K32,V64] x 4 heads.
-  // Gather the V parts (channels [h*128+64 : h*128+128]) head-major -> [256].
-  std::vector<Tensor> v_parts;
-  for (int h = 0; h < 4; ++h)
-    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h), h * 128 + 64,
-                              h * 128 + 128, qkv));
-  LayerHandle vcat(
-    createLayer("concat", {nntrainer::withKey("name", n + "/vcat"),
-                           nntrainer::withKey("axis", 1)}));
-  auto v = vcat(v_parts);
-  auto pe = yolov11::dwConvBnOnly(n + "/pe", 256, v);
-
-  LayerHandle att(
-    createLayer("psa_attention", {nntrainer::withKey("name", n + "/attn")}));
-  auto attn = att(qkv);
-  auto attn_pe = addT(n + "/add_pe", attn, pe);
-  auto proj = yolov11::convBnOnly(n + "/proj", 256, 256, 1, 1, 0, attn_pe);
-  auto b1 = addT(n + "/res1", b, proj);
-
-  auto ffn0 = yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1);
-  // NOTE: ffn1 has BN but NO SiLU (verified against PyTorch; SiLU here yields
-  // a ~0.78 error at model.10 that amplifies downstream).
-  auto ffn1 = yolov11::convBnOnly(n + "/ffn1", 512, 256, 1, 1, 0, ffn0);
-  auto b2 = addT(n + "/res2", b1, ffn1);
-
-  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", n + "/cat"),
-                                         nntrainer::withKey("axis", 1)}));
-  auto cc = cat({a, b2});
-  return yolov11::convBnSilu(n + "/cv2", 512, 512, 1, 1, 0, cc);
-}
-
-inline Tensor buildBackbone(Tensor xIn, Tensor &m4_out, Tensor &m6_out) {
-  auto h = yolov11::convBnSilu("conv0", 3, 64, 3, 2, 1, xIn);
-  h = yolov11::convBnSilu("conv1", 64, 128, 3, 2, 1, h);
-  h = yolov11::c3k2Block("m2", 128, 256, 64, h);
-  h = yolov11::convBnSilu("conv3", 256, 256, 3, 2, 1, h);
-  m4_out = yolov11::c3k2Block("m4", 256, 512, 128, h);
-  h = yolov11::convBnSilu("conv5", 512, 512, 3, 2, 1, m4_out);
-  m6_out = yolov11::c3k2Block("m6", 512, 512, 256, h);
-  h = yolov11::convBnSilu("conv7", 512, 512, 3, 2, 1, m6_out);
-  h = yolov11::c3k2Block("m8", 512, 512, 256, h);
-  h = yolov11::sppfBlock("m9", 512, h);
-  return buildC2PSA("m10", h); // model.10 (C2PSA)
-}
-
-} // namespace
-
-namespace {
-
-/** @brief Upsample(nearest, x2) layer. */
-Tensor upsampleX2(const std::string &name, Tensor in) {
-  LayerHandle l(
-    createLayer("upsample2d", {nntrainer::withKey("name", name),
-                               nntrainer::withKey("upsample", "nearest"),
-                               nntrainer::withKey("kernel_size", "2,2")}));
-  return l(in);
-}
-
-/** @brief Channel-axis concat layer. */
-Tensor concatCh(const std::string &name, const std::vector<Tensor> &ins) {
-  LayerHandle l(createLayer("concat", {nntrainer::withKey("name", name),
-                                       nntrainer::withKey("axis", 1)}));
-  return l(ins);
-}
-
-/**
- * @brief Build the FPN head (model.11~22) and 3-scale Detect head (model.23).
- * @return raw detection logits for P3, P4, P5 (each [1, 4*reg_max+nc, H, W]).
- */
-std::vector<Tensor> buildHead(Tensor m4, Tensor m6, Tensor m10) {
-  auto m11 = upsampleX2("m11", m10);
-  auto m12 = concatCh("m12", {m11, m6});
-  auto m13 = yolov11::c3k2Block("m13", 1024, 512, 256, m12);
-
-  auto m14 = upsampleX2("m14", m13);
-  auto m15 = concatCh("m15", {m14, m4});
-  auto m16 = yolov11::c3k2Block("m16", 1024, 256, 128, m15); // P3 feature
-
-  auto m17 = yolov11::convBnSilu("m17", 256, 256, 3, 2, 1, m16);
-  auto m18 = concatCh("m18", {m17, m13});
-  auto m19 = yolov11::c3k2Block("m19", 768, 512, 256, m18); // P4 feature
-
-  auto m20 = yolov11::convBnSilu("m20", 512, 512, 3, 2, 1, m19);
-  auto m21 = concatCh("m21", {m20, m10});
-  auto m22 = yolov11::c3k2Block("m22", 1024, 512, 256, m21); // P5 feature
-
-  // Detect head (model.23): built from standard layers (conv2d/depthwiseconv2d/
-  // batch_normalization/concat) — see detect_block.h.
-  return {yolov11::detectScale("det0", 256, m16),
-          yolov11::detectScale("det1", 512, m19),
-          yolov11::detectScale("det2", 512, m22)};
-}
-
-/**
- * @brief Load all weights from a single nntrainer safetensors file.
- *
- * The file (produced by PyTorch/convert_weights.py) holds one tensor per model
- * weight, named "{layer}:{weight}" (e.g. "conv0/conv:filter",
- * "conv0/bn:moving_mean"). Tensors of the same layer are contiguous and stored
- * in the layer's weight-registration order, so we group consecutive tensors by
- * layer name and push them to layer->setWeights() in file order.
- */
 /** @brief Register the YOLOv11 custom layers with the global AppContext.
  *  Only C2PSA is custom; the Detect head uses standard nntrainer layers. */
 void registerCustomLayers() {
@@ -945,10 +465,30 @@ int main(int argc, char *argv[]) {
       std::cout << "[YOLO] model_tensor_type = " << tt << std::endl;
     }
 
+    // Offline quantization mode (YOLO_QUANTIZE_OUT set): build the graph in
+    // FP32, load FP32 weights, then re-save through the framework's general
+    // per-layer quantizer. Must build FP32 here (not Q4_0) so finalize
+    // allocates FP32 conv weights that can receive the FP32 file.
+    const bool quantize_mode = (std::getenv("YOLO_QUANTIZE_OUT") != nullptr);
+
+    // Opt-in Q4_0 runtime path: env YOLO_CONV_Q40 enables Q4_0 weight_dtype
+    // for eligible group=1 convs (out_ch%32==0 && CRS%32==0). Requires the
+    // weights file to have been quantized first (see quantize_mode below).
+    const bool conv_q40 =
+      !quantize_mode && (std::getenv("YOLO_CONV_Q40") != nullptr);
+
+    // In quantize mode, collect the Q4_0-eligible conv layer names as the graph
+    // is built (single source of truth for eligibility) to drive the per-layer
+    // dtype map for model->save().
+    std::vector<std::string> q_conv_names;
+    if (quantize_mode)
+      yolov11::quantConvSink() = &q_conv_names;
+
     auto x = Tensor({1, 3, 832, 832}, "input0");
     Tensor m4, m6;
-    auto m10 = buildBackbone(x, m4, m6);
-    auto outputs = buildHead(m4, m6, m10); // {P3, P4, P5} raw logits
+    auto m10 = yolov11::buildBackbone(x, m4, m6, conv_q40);
+    auto outputs = yolov11::buildHead(m4, m6, m10, conv_q40); // {P3, P4, P5}
+    yolov11::quantConvSink() = nullptr;
 
     if (int ret =
           model->compile(x, outputs, ml::train::ExecutionMode::INFERENCE))
@@ -965,6 +505,39 @@ int main(int argc, char *argv[]) {
     model->load(weights_path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
     std::cout << "Model built and weights loaded (" << weights_path << ")."
               << std::endl;
+
+    // Offline quantization: re-save with the framework's general per-layer
+    // quantizer. dtype=Q4_0 + empty layer map => every layer is targeted, and
+    // Conv2DLayer::save quantizes the eligible conv filters (out_ch & CRS both
+    // 32-aligned) to the [CRS, out_ch] Q4_0 matmul weight + ISA repack, while
+    // biases / ineligible filters / weight-free layers stay FP32. This is the
+    // framework equivalent of the offline python script.
+    if (quantize_mode) {
+      const std::string out_q = std::getenv("YOLO_QUANTIZE_OUT");
+      ml::train::ISA isa = ml::train::ISA::DEFAULT;
+      if (const char *ie = std::getenv("YOLO_QUANTIZE_ISA")) {
+        std::string s = ie;
+        if (s == "arm" || s == "ARM")
+          isa = ml::train::ISA::ARM;
+        else if (s == "x86" || s == "X86")
+          isa = ml::train::ISA::X86;
+      }
+      // SAFETENSORS save requires the global dtype to be NONE; quantization is
+      // driven by the per-layer map (conv filters -> Q4_0). Conv2DLayer::save
+      // does the conv -> [CRS, out_ch] Q4_0 repack; ineligible/bias stay FP32.
+      std::map<std::string, ml::train::TensorDim::DataType> dmap;
+      for (const auto &n : q_conv_names)
+        dmap[n] = ml::train::TensorDim::DataType::Q4_0;
+      model->save(out_q, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS,
+                  ml::train::TensorDim::DataType::NONE, dmap, isa);
+      std::cout << "[YOLO] quantized " << dmap.size() << " conv filters -> "
+                << out_q
+                << " (isa=" << (std::getenv("YOLO_QUANTIZE_ISA")
+                                  ? std::getenv("YOLO_QUANTIZE_ISA")
+                                  : "default")
+                << ")" << std::endl;
+      return 0;
+    }
 
     // Run one forward pass on the input.
     // argv[2] may be a raw [1,3,832,832] float32 .bin (e.g. from

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -41,11 +41,8 @@
 #include <engine.h>
 #include <layer.h>
 #include <model.h>
-#include <safetensors_util.h>
 #include <tensor.h>
 #include <tensor_api.h>
-#include <util_func.h>
-
 #include "c2psa_layer.h"
 
 // Optional direct image input. Enabled only when stb_image.h is present (the
@@ -889,46 +886,6 @@ std::vector<Tensor> buildHead(Tensor m4, Tensor m6, Tensor m10) {
  * in the layer's weight-registration order, so we group consecutive tensors by
  * layer name and push them to layer->setWeights() in file order.
  */
-void loadSafetensors(ml::train::Model *model, const std::string &path) {
-  std::ifstream f(path, std::ios::binary);
-  if (!f)
-    throw std::runtime_error("Cannot open safetensors: " + path);
-  uint64_t hlen = 0;
-  f.read(reinterpret_cast<char *>(&hlen), 8);
-  std::string hdr(hlen, '\0');
-  f.read(&hdr[0], static_cast<std::streamsize>(hlen));
-
-  // Parse the header with nntrainer's own safetensors parser (preserves order).
-  auto entries = nntrainer::safetensors::parseHeaderEntries(hdr);
-  const std::streamoff data_base = 8 + static_cast<std::streamoff>(hlen);
-  auto layerOf = [](const std::string &n) { return n.substr(0, n.find(':')); };
-
-  // Group consecutive entries by layer and setWeights per layer.
-  size_t i = 0;
-  while (i < entries.size()) {
-    const std::string layer = layerOf(entries[i].name);
-    std::vector<std::vector<float>> bufs;
-    std::vector<float *> ptrs;
-    size_t j = i;
-    for (; j < entries.size() && layerOf(entries[j].name) == layer; ++j) {
-      size_t n =
-        (entries[j].offset_end - entries[j].offset_start) / sizeof(float);
-      std::vector<float> buf(n);
-      f.seekg(data_base + static_cast<std::streamoff>(entries[j].offset_start));
-      f.read(reinterpret_cast<char *>(buf.data()),
-             static_cast<std::streamsize>(n * sizeof(float)));
-      bufs.push_back(std::move(buf));
-    }
-    for (auto &b : bufs)
-      ptrs.push_back(b.data());
-    std::shared_ptr<ml::train::Layer> l;
-    if (model->getLayer(layer.c_str(), &l))
-      throw std::runtime_error("safetensors: no model layer named " + layer);
-    l->setWeights(ptrs);
-    i = j;
-  }
-}
-
 /** @brief Register the YOLOv11 custom layers with the global AppContext.
  *  Only C2PSA is custom; the Detect head uses standard nntrainer layers. */
 void registerCustomLayers() {
@@ -967,8 +924,7 @@ int main(int argc, char *argv[]) {
     // Build the full model: input -> backbone -> head -> 3 detect outputs.
     ModelHandle model =
       ml::train::createModel(ml::train::ModelType::NEURAL_NET);
-    model->setProperty({nntrainer::withKey("batch_size", "1"),
-                        nntrainer::withKey("memory_optimization", "false")});
+    model->setProperty({nntrainer::withKey("batch_size", "1")});
 
     auto x = Tensor({1, 3, 832, 832}, "input0");
     Tensor m4, m6;
@@ -980,7 +936,8 @@ int main(int argc, char *argv[]) {
       throw std::runtime_error("compile failed: " + std::to_string(ret));
     // Load every weight from the single nntrainer safetensors produced by
     // PyTorch/convert_weights.py (tensor names match the model weight names).
-    loadSafetensors(model.get(), RES_DIR + "/yolov11m.safetensors");
+    model->load(RES_DIR + "/yolov11m.safetensors",
+                ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
     std::cout << "Model built and weights loaded." << std::endl;
 
     // Run one forward pass on the input.
@@ -1020,19 +977,17 @@ int main(int argc, char *argv[]) {
       std::getenv("YOLO_IOU") ? std::stof(std::getenv("YOLO_IOU")) : 0.70f;
     auto dets = yolov11::nms(decoded, N_total, conf_thres, iou_thres, 300);
 
-    std::cout << "\nDetections (conf>=" << conf_thres
-              << ", xyxy @832): " << dets.size() << std::endl;
+    // JSON output — same field names as the PyTorch reference JSON
+    std::cout << "\n[";
     for (size_t i = 0; i < dets.size(); ++i) {
       const auto &d = dets[i];
-      // area in pixels^2 (832 scale)
-      float area = (d.x2 - d.x1) * (d.y2 - d.y1);
-      float cx = (d.x1 + d.x2) * 0.5f;
-      float cy = (d.y1 + d.y2) * 0.5f;
-      std::cout << "  [" << i << "] (" << d.x1 << ", " << d.y1 << ", " << d.x2
-                << ", " << d.y2 << ")  conf=" << d.conf << " cls=" << d.cls
-                << " area=" << area << " center=(" << cx << "," << cy << ")"
-                << std::endl;
+      if (i)
+        std::cout << ",";
+      std::printf("\n  {\"x1\": %.6g, \"y1\": %.6g, \"x2\": %.6g,"
+                  " \"y2\": %.6g, \"conf\": %.6g, \"cls\": %d}",
+                  d.x1, d.y1, d.x2, d.y2, d.conf, d.cls);
     }
+    std::cout << (dets.empty() ? "" : "\n") << "]" << std::endl;
 
     if (verify) {
       std::cout << "\nVerification vs PyTorch references:" << std::endl;

--- a/Applications/CausalLM/models/YOLOv11/jni/main.cpp
+++ b/Applications/CausalLM/models/YOLOv11/jni/main.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -469,14 +470,48 @@ int main(int argc, char *argv[]) {
       ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", "1")});
 
-    // Optional precision override. YOLO_TENSOR_TYPE selects the model tensor
-    // type, e.g. "FP16-FP16" (weights+activations FP16) or "FP32-FP16"
-    // (FP16 activations only). Default (unset) is FP32-FP32. Since Conv+BN are
-    // fused at convert time, there is no BatchNorm mixed-precision path to
-    // block FP16. Must be set before compile().
+    // YOLO_TENSOR_TYPE accepts either a raw dtype pair (e.g. "FP32-FP16") or a
+    // named quantization preset:
+    //   w4a16 — Q4_0 weights + FP16 activations + NHWC layout (best latency)
+    //   w4a8  — Q4_0 weights + Q8_0 activations + NHWC layout (experimental)
+    // Default (unset) is FP32-FP32.  YOLOv11's input is a float image; for an
+    // FP16-activation model the InputLayer must be declared FP16 (PR#4000).
+    bool fp16_act = false;
+    bool preset_q40 = false;  // implied by w4a16/w4a8 presets
+    bool preset_nhwc = false; // implied by w4a16/w4a8 presets
     if (const char *tt = std::getenv("YOLO_TENSOR_TYPE")) {
-      model->setProperty({nntrainer::withKey("model_tensor_type", tt)});
-      std::cout << "[YOLO] model_tensor_type = " << tt << std::endl;
+      std::string tts = tt;
+      if (tts == "w4a16" || tts == "W4A16") {
+        model->setProperty({nntrainer::withKey("model_tensor_type", "FP32-FP16")});
+        fp16_act = true;
+        preset_q40 = true;
+        preset_nhwc = true;
+        std::cout << "[YOLO] preset = w4a16 (Q4_0 weights + FP16 act + NHWC)"
+                  << std::endl;
+      } else if (tts == "w4a8" || tts == "W4A8") {
+        model->setProperty({nntrainer::withKey("model_tensor_type", "FP32-FP16")});
+        fp16_act = true;
+        preset_q40 = true;
+        preset_nhwc = true;
+        setenv("NNTR_CONV_Q8ACT", "1", 1);
+        std::cout << "[YOLO] preset = w4a8 (Q4_0 weights + Q8_0 act + NHWC)"
+                  << std::endl;
+      } else {
+        model->setProperty({nntrainer::withKey("model_tensor_type", tt)});
+        auto dash = tts.find('-');
+        std::string act =
+          (dash == std::string::npos) ? tts : tts.substr(dash + 1);
+        fp16_act = (act == "FP16");
+        std::cout << "[YOLO] model_tensor_type = " << tt
+                  << " (fp16_act=" << (fp16_act ? "1" : "0") << ")"
+                  << std::endl;
+      }
+    }
+
+    // NHWC layout: activated by w4a16/w4a8 presets or explicit YOLO_NHWC.
+    if (preset_nhwc || std::getenv("YOLO_NHWC")) {
+      model->setProperty({nntrainer::withKey("tensor_format", "NHWC")});
+      std::cout << "[YOLO] tensor_format = NHWC" << std::endl;
     }
 
     // Offline quantization mode (YOLO_QUANTIZE_OUT set): build the graph in
@@ -485,11 +520,10 @@ int main(int argc, char *argv[]) {
     // allocates FP32 conv weights that can receive the FP32 file.
     const bool quantize_mode = (std::getenv("YOLO_QUANTIZE_OUT") != nullptr);
 
-    // Opt-in Q4_0 runtime path: env YOLO_CONV_Q40 enables Q4_0 weight_dtype
-    // for eligible group=1 convs (out_ch%32==0 && CRS%32==0). Requires the
-    // weights file to have been quantized first (see quantize_mode below).
+    // Q4_0 weight path: activated by preset or explicit YOLO_CONV_Q40.
     const bool conv_q40 =
-      !quantize_mode && (std::getenv("YOLO_CONV_Q40") != nullptr);
+      !quantize_mode &&
+      (preset_q40 || (std::getenv("YOLO_CONV_Q40") != nullptr));
 
     // In quantize mode, collect the Q4_0-eligible conv layer names as the graph
     // is built (single source of truth for eligibility) to drive the per-layer
@@ -498,7 +532,23 @@ int main(int argc, char *argv[]) {
     if (quantize_mode)
       yolov11::quantConvSink() = &q_conv_names;
 
-    auto x = Tensor({1, 3, 832, 832}, "input0");
+    // Declare the input tensor's dtype to match the activation dtype so the
+    // synthesized InputLayer emits FP16 output for an FP16-activation model.
+    // The input tensor's declared format must match the graph layout so the
+    // synthesized InputLayer emits the right physical layout to conv0. Under an
+    // NHWC preset the whole graph is channel-last, so declare the input NHWC
+    // too (and feed NHWC-ordered bytes below).
+    const bool in_nhwc = (preset_nhwc || std::getenv("YOLO_NHWC"));
+    const auto in_fmt = in_nhwc ? ml::train::TensorDim::Format::NHWC
+                                : ml::train::TensorDim::Format::NCHW;
+    auto x = fp16_act
+               ? Tensor(ml::train::TensorDim(
+                          1, 3, 832, 832, in_fmt,
+                          ml::train::TensorDim::DataType::FP16),
+                        "input0")
+               : Tensor(ml::train::TensorDim(1, 3, 832, 832, in_fmt,
+                                             ml::train::TensorDim::DataType::FP32),
+                        "input0");
     Tensor m4, m6;
     auto m10 = yolov11::buildBackbone(x, m4, m6, conv_q40);
     auto outputs = yolov11::buildHead(m4, m6, m10, conv_q40); // {P3, P4, P5}
@@ -545,10 +595,10 @@ int main(int argc, char *argv[]) {
       model->save(out_q, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS,
                   ml::train::TensorDim::DataType::NONE, dmap, isa);
       std::cout << "[YOLO] quantized " << dmap.size() << " conv filters -> "
-                << out_q
-                << " (isa=" << (std::getenv("YOLO_QUANTIZE_ISA")
-                                  ? std::getenv("YOLO_QUANTIZE_ISA")
-                                  : "default")
+                << out_q << " (isa="
+                << (std::getenv("YOLO_QUANTIZE_ISA")
+                      ? std::getenv("YOLO_QUANTIZE_ISA")
+                      : "default")
                 << ")" << std::endl;
       return 0;
     }
@@ -563,6 +613,21 @@ int main(int argc, char *argv[]) {
 #else
     auto input = loadBin(input_path);
 #endif
+    // The inference() API is FP32 by contract: always hand it the plain FP32
+    // image. When the graph input is declared FP16 the framework converts
+    // FP32->FP16 at the binding boundary (mapExternalTensor) through the Tensor
+    // system — no app-side conversion.
+    // When the graph is NHWC, the input bytes must also be NHWC-ordered
+    // ([N,H,W,C]); input_832.bin is stored NCHW, so transpose here.
+    if (preset_nhwc || std::getenv("YOLO_NHWC")) {
+      const int C = 3, H = 832, W = 832;
+      std::vector<float> nhwc(input.size());
+      for (int c = 0; c < C; ++c)
+        for (int h = 0; h < H; ++h)
+          for (int w = 0; w < W; ++w)
+            nhwc[(h * W + w) * C + c] = input[(c * H + h) * W + w];
+      input.swap(nhwc);
+    }
     std::vector<float *> in_ptr = {input.data()};
 
     // Inference timing. YOLO_BENCH_ITERS (default 1) controls how many timed
@@ -593,12 +658,28 @@ int main(int argc, char *argv[]) {
     std::vector<float> anchors, strides;
     yolov11::makeAnchors(scales, anchors, strides);
 
+    // When the graph runs NHWC, each scale output tensor is stored channel-last
+    // in memory ((h*W+w)*C + c), but decodeOneScale expects the NCHW channel-
+    // major layout (c*N + a). Transpose each output to NCHW before decoding.
+    // Detect output channels = 4*reg_max (DFL box) + nc = 64 + 1 = 65 (nc=1).
+    const bool out_nhwc = preset_nhwc || std::getenv("YOLO_NHWC");
+    const int OUT_CH = 65;
     std::vector<float> decoded(5 * N_total, 0.0f);
     int off = 0;
     for (size_t i = 0; i < scales.size(); ++i) {
-      yolov11::decodeOneScale(outs[i], scales[i].H, scales[i].W,
-                              scales[i].stride, anchors, strides, off, N_total,
-                              decoded);
+      const float *raw = outs[i];
+      std::vector<float> nchw_buf;
+      if (out_nhwc) {
+        const int N = scales[i].H * scales[i].W;
+        nchw_buf.resize(static_cast<size_t>(OUT_CH) * N);
+        for (int a = 0; a < N; ++a)
+          for (int c = 0; c < OUT_CH; ++c)
+            nchw_buf[static_cast<size_t>(c) * N + a] =
+              raw[static_cast<size_t>(a) * OUT_CH + c];
+        raw = nchw_buf.data();
+      }
+      yolov11::decodeOneScale(raw, scales[i].H, scales[i].W, scales[i].stride,
+                              anchors, strides, off, N_total, decoded);
       off += scales[i].H * scales[i].W;
     }
 

--- a/Applications/CausalLM/models/YOLOv11/jni/meson.build
+++ b/Applications/CausalLM/models/YOLOv11/jni/meson.build
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# YOLOv11m detection inference example
+
+yolov11_infer_src = [
+  meson.current_source_dir() / 'main.cpp',
+  meson.current_source_dir() / 'c2psa_layer.cpp',
+]
+
+yolov11_inc = include_directories('.')
+
+# Optional direct image (.jpg/.png) input: enabled only when stb_image.h is
+# present in this directory (it is not committed). Without it the example still
+# builds and runs on raw .bin input, so CI stays green.
+#   curl -fsSL https://raw.githubusercontent.com/nothings/stb/master/stb_image.h \
+#     -o Applications/CausalLM/models/YOLOv11/jni/stb_image.h
+yolov11_cpp_args = []
+if import('fs').exists(meson.current_source_dir() / 'stb_image.h')
+  yolov11_cpp_args += '-DYOLO_WITH_STB_IMAGE'
+  message('YOLOv11: stb_image.h found -> direct image input enabled')
+endif
+
+yolov11_infer = executable('yolov11_infer',
+  yolov11_infer_src,
+  include_directories: [yolov11_inc],
+  cpp_args: yolov11_cpp_args,
+  dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+  build_by_default: get_option('enable-app'),
+  install: false,
+)

--- a/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
+++ b/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   yolov11_graph.h
+ * @date   25 June 2026
+ * @brief  YOLOv11m graph block builders (inline, header-only).
+ *
+ * Extracted from main.cpp so the quantization-aware model class
+ * (YOLOv11Model) can reuse the same graph construction without
+ * duplicating code.
+ *
+ * Usage:
+ *   #include "yolov11_graph.h"
+ *   bool q40 = (std::getenv("YOLO_CONV_Q40") != nullptr);
+ *   Tensor m4, m6;
+ *   auto m10 = yolov11::buildBackbone(input, m4, m6, q40);
+ *   auto outputs = yolov11::buildHead(m4, m6, m10, q40);
+ *
+ * @author Seungbaek Hong <sb92.hong@samsung.com>
+ */
+
+#ifndef __YOLOV11_GRAPH_H__
+#define __YOLOV11_GRAPH_H__
+
+#include <string>
+#include <vector>
+
+#include <layer.h>
+#include <model.h>
+#include <tensor_api.h>
+
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
+
+namespace yolov11 {
+
+// When set (non-null), the conv block builders append the layer name of every
+// Q4_0-eligible conv filter (out_ch and in_ch*k*k both 32-aligned) to this
+// sink. The offline quantizer (main.cpp --quantize mode) uses it to build the
+// per-layer dtype map for model->save() without enumerating the compiled
+// graph. Default null = no collection. Eligibility here MUST match the
+// conv_q40 gate below and quantize_q4_0_conv.py.
+inline std::vector<std::string> *&quantConvSink() {
+  static std::vector<std::string> *sink = nullptr;
+  return sink;
+}
+
+// ===== Primitive graph block builders =====
+
+/**
+ * @brief Build a (BN-fused) Conv2d + SiLU sub-graph block.
+ *
+ * BatchNorm is folded into the convolution at convert time, so this is a
+ * single biased conv followed by a standalone SiLU.
+ *
+ * @param name      Layer-name prefix
+ * @param in_ch     Input channels
+ * @param out_ch    Output channels
+ * @param k         Kernel size (square)
+ * @param stride    Stride
+ * @param padding   Padding
+ * @param input     Input symbolic tensor
+ * @param conv_q40  If true, eligible convs get weight_dtype=Q4_0.
+ *                  Eligibility: groups==1 && out_ch>1 && out_ch%32==0 &&
+ *                  (in_ch*k*k)%32==0 (must match quantize_q4_0_conv.py).
+ * @return Output symbolic tensor after conv+SiLU
+ */
+inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
+                         int stride, int padding, Tensor input,
+                         bool conv_q40 = false) {
+  std::vector<std::string> conv_props = {
+    nntrainer::withKey("name", name + "/conv"),
+    nntrainer::withKey("kernel_size", {k, k}),
+    nntrainer::withKey("filters", out_ch),
+    nntrainer::withKey("stride", {stride, stride}),
+    nntrainer::withKey("padding", padding)};
+  if (out_ch > 1 && out_ch % 32 == 0 && (in_ch * k * k) % 32 == 0) {
+    if (conv_q40)
+      conv_props.push_back(nntrainer::withKey("weight_dtype", "Q4_0"));
+    if (quantConvSink() != nullptr)
+      quantConvSink()->push_back(name + "/conv");
+  }
+  LayerHandle conv(createLayer("conv2d", conv_props));
+  auto h = conv(input);
+
+  LayerHandle act(
+    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
+                               nntrainer::withKey("activation", "swish")}));
+  return act(h);
+}
+
+/**
+ * @brief Build a Bottleneck sub-graph (cv1 3x3 + cv2 3x3 + residual add).
+ */
+inline Tensor bottleneck(const std::string &name, int ch, Tensor input,
+                         bool conv_q40 = false) {
+  auto h = convBnSilu(name + "/cv1", ch, ch, 3, 1, 1, input, conv_q40);
+  h = convBnSilu(name + "/cv2", ch, ch, 3, 1, 1, h, conv_q40);
+  LayerHandle add(
+    createLayer("Addition", {nntrainer::withKey("name", name + "/add")}));
+  return add({h, input});
+}
+
+/**
+ * @brief Build a C3k sub-graph.
+ */
+inline Tensor c3kBlock(const std::string &name, int in_ch, int inner_ch,
+                       int out_ch, Tensor input, bool conv_q40 = false) {
+  auto inner =
+    convBnSilu(name + "/cv1", in_ch, inner_ch, 1, 1, 0, input, conv_q40);
+  inner = bottleneck(name + "/inner0", inner_ch, inner, conv_q40);
+  inner = bottleneck(name + "/inner1", inner_ch, inner, conv_q40);
+  auto skip =
+    convBnSilu(name + "/cv2", in_ch, inner_ch, 1, 1, 0, input, conv_q40);
+
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({inner, skip});
+
+  return convBnSilu(name + "/cv3", 2 * inner_ch, out_ch, 1, 1, 0, concat_out,
+                    conv_q40);
+}
+
+/**
+ * @brief Build a C3k2 sub-graph.
+ */
+inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
+                        Tensor input, bool conv_q40 = false) {
+  auto y = convBnSilu(name + "/cv1", in_ch, 2 * c, 1, 1, 0, input, conv_q40);
+
+  LayerHandle sliceA(
+    createLayer("slice", {nntrainer::withKey("name", name + "/slice_a"),
+                          nntrainer::withKey("axis", 1),
+                          nntrainer::withKey("start_index", 1),
+                          nntrainer::withKey("end_index", c + 1)}));
+  auto y_a = sliceA(y);
+
+  LayerHandle sliceB(
+    createLayer("slice", {nntrainer::withKey("name", name + "/slice_b"),
+                          nntrainer::withKey("axis", 1),
+                          nntrainer::withKey("start_index", c + 1),
+                          nntrainer::withKey("end_index", 2 * c + 1)}));
+  auto y_b = sliceB(y);
+
+  auto y_c = c3kBlock(name + "/m0", c, c / 2, c, y_b, conv_q40);
+
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({y_a, y_b, y_c});
+
+  return convBnSilu(name + "/cv2", 3 * c, out_ch, 1, 1, 0, concat_out,
+                    conv_q40);
+}
+
+/**
+ * @brief Build a (BN-fused) Conv2d sub-graph block (NO activation).
+ *
+ * @param conv_q40  If true, eligible convs get weight_dtype=Q4_0.
+ */
+inline Tensor convBnOnly(const std::string &name, int in_ch, int out_ch, int k,
+                         int stride, int padding, Tensor input,
+                         bool conv_q40 = false) {
+  std::vector<std::string> conv_props = {
+    nntrainer::withKey("name", name + "/conv"),
+    nntrainer::withKey("kernel_size", {k, k}),
+    nntrainer::withKey("filters", out_ch),
+    nntrainer::withKey("stride", {stride, stride}),
+    nntrainer::withKey("padding", padding)};
+  if (out_ch > 1 && out_ch % 32 == 0 && (in_ch * k * k) % 32 == 0) {
+    if (conv_q40)
+      conv_props.push_back(nntrainer::withKey("weight_dtype", "Q4_0"));
+    if (quantConvSink() != nullptr)
+      quantConvSink()->push_back(name + "/conv");
+  }
+  LayerHandle conv(createLayer("conv2d", conv_props));
+  return conv(input);
+}
+
+/**
+ * @brief Build a MaxPool2d layer with explicit padding.
+ */
+inline Tensor maxPool(const std::string &name, int k, Tensor input) {
+  int p = k / 2;
+  std::string pad_str = std::to_string(p) + "," + std::to_string(p) + "," +
+                        std::to_string(p) + "," + std::to_string(p);
+  LayerHandle pool(
+    createLayer("pooling2d", {nntrainer::withKey("name", name),
+                              nntrainer::withKey("pooling", "max"),
+                              nntrainer::withKey("pool_size", {k, k}),
+                              nntrainer::withKey("stride", {1, 1}),
+                              nntrainer::withKey("padding", pad_str)}));
+  return pool(input);
+}
+
+/**
+ * @brief Build an SPPF sub-graph.
+ */
+inline Tensor sppfBlock(const std::string &name, int in_ch, Tensor input,
+                        bool conv_q40 = false) {
+  int half = in_ch / 2;
+  auto x = convBnOnly(name + "/cv1", in_ch, half, 1, 1, 0, input, conv_q40);
+
+  auto p1 = maxPool(name + "/pool1", 5, x);
+  auto p2 = maxPool(name + "/pool2", 5, p1);
+  auto p3 = maxPool(name + "/pool3", 5, p2);
+
+  LayerHandle cat(
+    createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto concat_out = cat({x, p1, p2, p3});
+
+  return convBnSilu(name + "/cv2", half * 4, in_ch, 1, 1, 0, concat_out,
+                    conv_q40);
+}
+
+// ===== Detect head graph builders =====
+
+/**
+ * @brief 1x1 Conv2d with bias, no BN, no activation (detect output conv).
+ *
+ * @param conv_q40  If true, eligible 1x1 convs get weight_dtype=Q4_0.
+ *                  Note: out_ch for box branch is 64 (divisible by 32) but
+ *                  in_ch (64) * 1 * 1 = 64 is also divisible by 32, so it
+ *                  can be Q4_0. cls branch out_ch=1 is NOT eligible
+ *                  (out_ch>1 check).
+ */
+inline Tensor convBias1x1(const std::string &name, int out_ch, int in_ch,
+                          Tensor input, bool conv_q40 = false) {
+  std::vector<std::string> conv_props = {
+    nntrainer::withKey("name", name + "/conv"),
+    nntrainer::withKey("kernel_size", {1, 1}),
+    nntrainer::withKey("filters", out_ch),
+    nntrainer::withKey("stride", {1, 1}),
+    nntrainer::withKey("padding", 0)};
+  if (out_ch > 1 && out_ch % 32 == 0 && (in_ch * 1 * 1) % 32 == 0) {
+    if (conv_q40)
+      conv_props.push_back(nntrainer::withKey("weight_dtype", "Q4_0"));
+    if (quantConvSink() != nullptr)
+      quantConvSink()->push_back(name + "/conv");
+  }
+  LayerHandle conv(createLayer("conv2d", conv_props));
+  return conv(input);
+}
+
+/**
+ * @brief Depthwise 3x3 (pad 1) + SiLU, BN folded. Always FP32 (never Q4_0).
+ */
+inline Tensor dwConvBnSilu(const std::string &name, int ch, Tensor input) {
+  LayerHandle dw(createLayer(
+    "conv2d",
+    {nntrainer::withKey("name", name + "/dw"),
+     nntrainer::withKey("kernel_size", {3, 3}),
+     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
+  auto h = dw(input);
+  LayerHandle act(
+    createLayer("activation", {nntrainer::withKey("name", name + "/act"),
+                               nntrainer::withKey("activation", "swish")}));
+  return act(h);
+}
+
+/**
+ * @brief Depthwise 3x3 (pad 1), NO activation. Always FP32 (never Q4_0).
+ */
+inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
+  LayerHandle dw(createLayer(
+    "conv2d",
+    {nntrainer::withKey("name", name + "/dw"),
+     nntrainer::withKey("kernel_size", {3, 3}),
+     nntrainer::withKey("filters", ch), nntrainer::withKey("groups", ch),
+     nntrainer::withKey("stride", {1, 1}), nntrainer::withKey("padding", 1)}));
+  return dw(input);
+}
+
+/**
+ * @brief Build one Detect scale -> raw logits [1, 64+nc, H, W].
+ *
+ * @param s       name prefix (e.g. "det0")
+ * @param pi_ch   input feature channels (256 for P3, 512 for P4/P5)
+ * @param in      input feature map
+ * @param conv_q40  If true, eligible convs use Q4_0.
+ */
+inline Tensor detectScale(const std::string &s, int pi_ch, Tensor in,
+                          bool conv_q40 = false) {
+  // box branch (cv2): pi_ch->64->64->64 (1x1 output)
+  auto x = convBnSilu(s + "/cv2_0", pi_ch, 64, 3, 1, 1, in, conv_q40);
+  x = convBnSilu(s + "/cv2_1", 64, 64, 3, 1, 1, x, conv_q40);
+  auto box = convBias1x1(s + "/cv2_2", 64, 64, x, conv_q40);
+
+  // cls branch (cv3): depthwise-separable x2 then 1x1 (out_ch=1, never Q4_0)
+  auto c = dwConvBnSilu(s + "/cv3_0_dw", pi_ch, in);
+  c = convBnSilu(s + "/cv3_0_pw", pi_ch, 256, 1, 1, 0, c, conv_q40);
+  c = dwConvBnSilu(s + "/cv3_1_dw", 256, c);
+  c = convBnSilu(s + "/cv3_1_pw", 256, 256, 1, 1, 0, c, conv_q40);
+  auto cls = convBias1x1(s + "/cv3_2", 1, 256, c, conv_q40); // out_ch=1: FP32
+
+  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", s + "/out"),
+                                         nntrainer::withKey("axis", 1)}));
+  return cat({box, cls});
+}
+
+// ===== Utility builders used by C2PSA and head =====
+
+/** @brief Channel-axis slice [start0, end0) — slice layer uses 1-indexed. */
+inline Tensor sliceCh(const std::string &name, int start0, int end0,
+                      Tensor in) {
+  LayerHandle s(createLayer(
+    "slice", {nntrainer::withKey("name", name), nntrainer::withKey("axis", 1),
+              nntrainer::withKey("start_index", start0 + 1),
+              nntrainer::withKey("end_index", end0 + 1)}));
+  return s(in);
+}
+
+/** @brief Elementwise addition of two tensors. */
+inline Tensor addT(const std::string &name, Tensor a, Tensor b) {
+  LayerHandle l(createLayer("Addition", {nntrainer::withKey("name", name)}));
+  return l({a, b});
+}
+
+/** @brief Upsample (nearest, x2). */
+inline Tensor upsampleX2(const std::string &name, Tensor in) {
+  LayerHandle l(
+    createLayer("upsample2d", {nntrainer::withKey("name", name),
+                               nntrainer::withKey("upsample", "nearest"),
+                               nntrainer::withKey("kernel_size", "2,2")}));
+  return l(in);
+}
+
+/** @brief Channel-axis concat. */
+inline Tensor concatCh(const std::string &name,
+                       const std::vector<Tensor> &ins) {
+  LayerHandle l(createLayer("concat", {nntrainer::withKey("name", name),
+                                       nntrainer::withKey("axis", 1)}));
+  return l(ins);
+}
+
+/**
+ * @brief Build the C2PSA block (model.10) from standard layers + psa_attention.
+ *
+ * @param conv_q40  If true, eligible group=1 convs use Q4_0.
+ */
+inline Tensor buildC2PSA(const std::string &n, Tensor x,
+                         bool conv_q40 = false) {
+  auto cv1 = yolov11::convBnSilu(n + "/cv1", 512, 512, 1, 1, 0, x, conv_q40);
+  auto a = sliceCh(n + "/slice_a", 0, 256, cv1);
+  auto b = sliceCh(n + "/slice_b", 256, 512, cv1);
+
+  auto qkv =
+    yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b, conv_q40);
+
+  std::vector<Tensor> v_parts;
+  for (int h = 0; h < 4; ++h)
+    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h),
+                              h * 128 + 64, h * 128 + 128, qkv));
+  LayerHandle vcat(
+    createLayer("concat", {nntrainer::withKey("name", n + "/vcat"),
+                           nntrainer::withKey("axis", 1)}));
+  auto v = vcat(v_parts);
+  auto pe = yolov11::dwConvBnOnly(n + "/pe", 256, v);
+
+  LayerHandle att(
+    createLayer("psa_attention", {nntrainer::withKey("name", n + "/attn")}));
+  auto attn = att(qkv);
+  auto attn_pe = addT(n + "/add_pe", attn, pe);
+  auto proj =
+    yolov11::convBnOnly(n + "/proj", 256, 256, 1, 1, 0, attn_pe, conv_q40);
+  auto b1 = addT(n + "/res1", b, proj);
+
+  auto ffn0 =
+    yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1, conv_q40);
+  auto ffn1 =
+    yolov11::convBnOnly(n + "/ffn1", 512, 256, 1, 1, 0, ffn0, conv_q40);
+  auto b2 = addT(n + "/res2", b1, ffn1);
+
+  LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", n + "/cat"),
+                                         nntrainer::withKey("axis", 1)}));
+  auto cc = cat({a, b2});
+  return yolov11::convBnSilu(n + "/cv2", 512, 512, 1, 1, 0, cc, conv_q40);
+}
+
+// ===== Top-level whole-network builders =====
+
+/**
+ * @brief Build the backbone (model.0-10) and return m10 (C2PSA output).
+ *
+ * Also outputs m4 and m6 (FPN skip connections).
+ *
+ * @param xIn       Input symbolic tensor [1, 3, 832, 832]
+ * @param m4_out    [out] C3k2 block 4 output (P3 skip)
+ * @param m6_out    [out] C3k2 block 6 output (P4 skip)
+ * @param conv_q40  If true, eligible convs use Q4_0.
+ * @return m10 (C2PSA output, P5 feature)
+ */
+inline Tensor buildBackbone(Tensor xIn, Tensor &m4_out, Tensor &m6_out,
+                            bool conv_q40 = false) {
+  auto h = yolov11::convBnSilu("conv0", 3, 64, 3, 2, 1, xIn, conv_q40);
+  h = yolov11::convBnSilu("conv1", 64, 128, 3, 2, 1, h, conv_q40);
+  h = yolov11::c3k2Block("m2", 128, 256, 64, h, conv_q40);
+  h = yolov11::convBnSilu("conv3", 256, 256, 3, 2, 1, h, conv_q40);
+  m4_out = yolov11::c3k2Block("m4", 256, 512, 128, h, conv_q40);
+  h = yolov11::convBnSilu("conv5", 512, 512, 3, 2, 1, m4_out, conv_q40);
+  m6_out = yolov11::c3k2Block("m6", 512, 512, 256, h, conv_q40);
+  h = yolov11::convBnSilu("conv7", 512, 512, 3, 2, 1, m6_out, conv_q40);
+  h = yolov11::c3k2Block("m8", 512, 512, 256, h, conv_q40);
+  h = yolov11::sppfBlock("m9", 512, h, conv_q40);
+  return buildC2PSA("m10", h, conv_q40);
+}
+
+/**
+ * @brief Build the FPN head (model.11-22) and 3-scale Detect head (model.23).
+ *
+ * @param m4       C3k2 block 4 output (P3 skip from backbone)
+ * @param m6       C3k2 block 6 output (P4 skip from backbone)
+ * @param m10      C2PSA output (P5 feature from backbone)
+ * @param conv_q40 If true, eligible convs use Q4_0.
+ * @return {P3, P4, P5} raw detection logits [1, 65, H, W] each
+ */
+inline std::vector<Tensor> buildHead(Tensor m4, Tensor m6, Tensor m10,
+                                     bool conv_q40 = false) {
+  auto m11 = upsampleX2("m11", m10);
+  auto m12 = concatCh("m12", {m11, m6});
+  auto m13 = yolov11::c3k2Block("m13", 1024, 512, 256, m12, conv_q40);
+
+  auto m14 = upsampleX2("m14", m13);
+  auto m15 = concatCh("m15", {m14, m4});
+  auto m16 = yolov11::c3k2Block("m16", 1024, 256, 128, m15, conv_q40);
+
+  auto m17 = yolov11::convBnSilu("m17", 256, 256, 3, 2, 1, m16, conv_q40);
+  auto m18 = concatCh("m18", {m17, m13});
+  auto m19 = yolov11::c3k2Block("m19", 768, 512, 256, m18, conv_q40);
+
+  auto m20 = yolov11::convBnSilu("m20", 512, 512, 3, 2, 1, m19, conv_q40);
+  auto m21 = concatCh("m21", {m20, m10});
+  auto m22 = yolov11::c3k2Block("m22", 1024, 512, 256, m21, conv_q40);
+
+  return {detectScale("det0", 256, m16, conv_q40),
+          detectScale("det1", 512, m19, conv_q40),
+          detectScale("det2", 512, m22, conv_q40)};
+}
+
+} // namespace yolov11
+
+#endif // __YOLOV11_GRAPH_H__

--- a/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
+++ b/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
@@ -233,8 +233,7 @@ inline Tensor convBias1x1(const std::string &name, int out_ch, int in_ch,
   std::vector<std::string> conv_props = {
     nntrainer::withKey("name", name + "/conv"),
     nntrainer::withKey("kernel_size", {1, 1}),
-    nntrainer::withKey("filters", out_ch),
-    nntrainer::withKey("stride", {1, 1}),
+    nntrainer::withKey("filters", out_ch), nntrainer::withKey("stride", {1, 1}),
     nntrainer::withKey("padding", 0)};
   if (out_ch > 1 && out_ch % 32 == 0 && (in_ch * 1 * 1) % 32 == 0) {
     if (conv_q40)
@@ -349,13 +348,12 @@ inline Tensor buildC2PSA(const std::string &n, Tensor x,
   auto a = sliceCh(n + "/slice_a", 0, 256, cv1);
   auto b = sliceCh(n + "/slice_b", 256, 512, cv1);
 
-  auto qkv =
-    yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b, conv_q40);
+  auto qkv = yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b, conv_q40);
 
   std::vector<Tensor> v_parts;
   for (int h = 0; h < 4; ++h)
-    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h),
-                              h * 128 + 64, h * 128 + 128, qkv));
+    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h), h * 128 + 64,
+                              h * 128 + 128, qkv));
   LayerHandle vcat(
     createLayer("concat", {nntrainer::withKey("name", n + "/vcat"),
                            nntrainer::withKey("axis", 1)}));
@@ -370,8 +368,7 @@ inline Tensor buildC2PSA(const std::string &n, Tensor x,
     yolov11::convBnOnly(n + "/proj", 256, 256, 1, 1, 0, attn_pe, conv_q40);
   auto b1 = addT(n + "/res1", b, proj);
 
-  auto ffn0 =
-    yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1, conv_q40);
+  auto ffn0 = yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1, conv_q40);
   auto ffn1 =
     yolov11::convBnOnly(n + "/ffn1", 512, 256, 1, 1, 0, ffn0, conv_q40);
   auto b2 = addT(n + "/res2", b1, ffn1);

--- a/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
+++ b/Applications/CausalLM/models/YOLOv11/jni/yolov11_graph.h
@@ -94,10 +94,11 @@ inline Tensor convBnSilu(const std::string &name, int in_ch, int out_ch, int k,
 /**
  * @brief Build a Bottleneck sub-graph (cv1 3x3 + cv2 3x3 + residual add).
  */
-inline Tensor bottleneck(const std::string &name, int ch, Tensor input,
-                         bool conv_q40 = false) {
-  auto h = convBnSilu(name + "/cv1", ch, ch, 3, 1, 1, input, conv_q40);
-  h = convBnSilu(name + "/cv2", ch, ch, 3, 1, 1, h, conv_q40);
+inline Tensor bottleneck(const std::string &name, int in_ch, int hidden_ch,
+                         int out_ch, Tensor input, bool conv_q40 = false) {
+  auto h =
+    convBnSilu(name + "/cv1", in_ch, hidden_ch, 3, 1, 1, input, conv_q40);
+  h = convBnSilu(name + "/cv2", hidden_ch, out_ch, 3, 1, 1, h, conv_q40);
   LayerHandle add(
     createLayer("Addition", {nntrainer::withKey("name", name + "/add")}));
   return add({h, input});
@@ -110,8 +111,10 @@ inline Tensor c3kBlock(const std::string &name, int in_ch, int inner_ch,
                        int out_ch, Tensor input, bool conv_q40 = false) {
   auto inner =
     convBnSilu(name + "/cv1", in_ch, inner_ch, 1, 1, 0, input, conv_q40);
-  inner = bottleneck(name + "/inner0", inner_ch, inner, conv_q40);
-  inner = bottleneck(name + "/inner1", inner_ch, inner, conv_q40);
+  inner =
+    bottleneck(name + "/inner0", inner_ch, inner_ch, inner_ch, inner, conv_q40);
+  inner =
+    bottleneck(name + "/inner1", inner_ch, inner_ch, inner_ch, inner, conv_q40);
   auto skip =
     convBnSilu(name + "/cv2", in_ch, inner_ch, 1, 1, 0, input, conv_q40);
 
@@ -128,7 +131,7 @@ inline Tensor c3kBlock(const std::string &name, int in_ch, int inner_ch,
  * @brief Build a C3k2 sub-graph.
  */
 inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
-                        Tensor input, bool conv_q40 = false) {
+                        bool c3k, Tensor input, bool conv_q40 = false) {
   auto y = convBnSilu(name + "/cv1", in_ch, 2 * c, 1, 1, 0, input, conv_q40);
 
   LayerHandle sliceA(
@@ -145,7 +148,12 @@ inline Tensor c3k2Block(const std::string &name, int in_ch, int out_ch, int c,
                           nntrainer::withKey("end_index", 2 * c + 1)}));
   auto y_b = sliceB(y);
 
-  auto y_c = c3kBlock(name + "/m0", c, c / 2, c, y_b, conv_q40);
+  Tensor y_c;
+  if (c3k) {
+    y_c = c3kBlock(name + "/m0", c, c / 2, c, y_b, conv_q40);
+  } else {
+    y_c = bottleneck(name + "/m0", c, c / 2, c, y_b, conv_q40);
+  }
 
   LayerHandle cat(
     createLayer("concat", {nntrainer::withKey("name", name + "/cat"),
@@ -275,27 +283,160 @@ inline Tensor dwConvBnOnly(const std::string &name, int ch, Tensor input) {
   return dw(input);
 }
 
+struct YOLOv11Params {
+  std::string scale;
+  int nc;
+
+  // Backbone channels
+  int c0, c1, c2, c3, m4_in, m4_out, c5, m6_in, m6_out, c7, m8_in, m8_out;
+  int m10_c;
+
+  // Backbone C3k2/C2PSA configs
+  bool m2_c3k, m4_c3k, m6_c3k, m8_c3k;
+  int m2_inner_c, m4_inner_c, m6_inner_c, m8_inner_c;
+
+  // Head channels
+  int m13_in, m13_out, m13_c;
+  int m16_in, m16_out, m16_c;
+  int m17_out;
+  int m19_in, m19_out, m19_c;
+  int m20_out;
+  int m22_in, m22_out, m22_c;
+
+  bool m13_c3k, m16_c3k, m19_c3k, m22_c3k;
+
+  // Detect head channels
+  int det0_pi, det1_pi, det2_pi;
+};
+
+inline YOLOv11Params getParams(const std::string &scale, int nc = 1) {
+  YOLOv11Params p;
+  p.scale = scale;
+  p.nc = nc;
+
+  if (scale == "s" || scale == "S") {
+    p.c0 = 32;
+    p.c1 = 64;
+    p.c2 = 128;
+    p.c3 = 128;
+    p.m4_in = 128;
+    p.m4_out = 256;
+    p.c5 = 256;
+    p.m6_in = 256;
+    p.m6_out = 256;
+    p.c7 = 512;
+    p.m8_in = 512;
+    p.m8_out = 512;
+
+    p.m2_c3k = false;
+    p.m2_inner_c = 32;
+    p.m4_c3k = false;
+    p.m4_inner_c = 64;
+    p.m6_c3k = true;
+    p.m6_inner_c = 128;
+    p.m8_c3k = true;
+    p.m8_inner_c = 256;
+
+    p.m10_c = 512;
+
+    p.m13_in = 768;
+    p.m13_out = 256;
+    p.m13_c = 128;
+    p.m13_c3k = false;
+    p.m16_in = 512;
+    p.m16_out = 128;
+    p.m16_c = 64;
+    p.m16_c3k = false;
+    p.m17_out = 128;
+    p.m19_in = 384;
+    p.m19_out = 256;
+    p.m19_c = 128;
+    p.m19_c3k = false;
+    p.m20_out = 256;
+    p.m22_in = 768;
+    p.m22_out = 512;
+    p.m22_c = 256;
+    p.m22_c3k = true;
+
+    p.det0_pi = 128;
+    p.det1_pi = 256;
+    p.det2_pi = 512;
+  } else {
+    // Default to medium ("m")
+    p.c0 = 64;
+    p.c1 = 128;
+    p.c2 = 256;
+    p.c3 = 256;
+    p.m4_in = 256;
+    p.m4_out = 512;
+    p.c5 = 512;
+    p.m6_in = 512;
+    p.m6_out = 512;
+    p.c7 = 512;
+    p.m8_in = 512;
+    p.m8_out = 512;
+
+    p.m2_c3k = true;
+    p.m2_inner_c = 64;
+    p.m4_c3k = true;
+    p.m4_inner_c = 128;
+    p.m6_c3k = true;
+    p.m6_inner_c = 256;
+    p.m8_c3k = true;
+    p.m8_inner_c = 256;
+
+    p.m10_c = 512;
+
+    p.m13_in = 1024;
+    p.m13_out = 512;
+    p.m13_c = 256;
+    p.m13_c3k = true;
+    p.m16_in = 1024;
+    p.m16_out = 256;
+    p.m16_c = 128;
+    p.m16_c3k = true;
+    p.m17_out = 256;
+    p.m19_in = 768;
+    p.m19_out = 512;
+    p.m19_c = 256;
+    p.m19_c3k = true;
+    p.m20_out = 512;
+    p.m22_in = 1024;
+    p.m22_out = 512;
+    p.m22_c = 256;
+    p.m22_c3k = true;
+
+    p.det0_pi = 256;
+    p.det1_pi = 512;
+    p.det2_pi = 512;
+  }
+
+  return p;
+}
+
 /**
  * @brief Build one Detect scale -> raw logits [1, 64+nc, H, W].
  *
  * @param s       name prefix (e.g. "det0")
  * @param pi_ch   input feature channels (256 for P3, 512 for P4/P5)
+ * @param c3      classification branch channels (max(ch[0], nc))
+ * @param nc      number of classes
  * @param in      input feature map
  * @param conv_q40  If true, eligible convs use Q4_0.
  */
-inline Tensor detectScale(const std::string &s, int pi_ch, Tensor in,
-                          bool conv_q40 = false) {
+inline Tensor detectScale(const std::string &s, int pi_ch, int c3, int nc,
+                          Tensor in, bool conv_q40 = false) {
   // box branch (cv2): pi_ch->64->64->64 (1x1 output)
   auto x = convBnSilu(s + "/cv2_0", pi_ch, 64, 3, 1, 1, in, conv_q40);
   x = convBnSilu(s + "/cv2_1", 64, 64, 3, 1, 1, x, conv_q40);
   auto box = convBias1x1(s + "/cv2_2", 64, 64, x, conv_q40);
 
-  // cls branch (cv3): depthwise-separable x2 then 1x1 (out_ch=1, never Q4_0)
+  // cls branch (cv3): depthwise-separable x2 then 1x1 (out_ch=nc, never Q4_0)
   auto c = dwConvBnSilu(s + "/cv3_0_dw", pi_ch, in);
-  c = convBnSilu(s + "/cv3_0_pw", pi_ch, 256, 1, 1, 0, c, conv_q40);
-  c = dwConvBnSilu(s + "/cv3_1_dw", 256, c);
-  c = convBnSilu(s + "/cv3_1_pw", 256, 256, 1, 1, 0, c, conv_q40);
-  auto cls = convBias1x1(s + "/cv3_2", 1, 256, c, conv_q40); // out_ch=1: FP32
+  c = convBnSilu(s + "/cv3_0_pw", pi_ch, c3, 1, 1, 0, c, conv_q40);
+  c = dwConvBnSilu(s + "/cv3_1_dw", c3, c);
+  c = convBnSilu(s + "/cv3_1_pw", c3, c3, 1, 1, 0, c, conv_q40);
+  auto cls = convBias1x1(s + "/cv3_2", nc, c3, c, conv_q40); // out_ch=nc: FP32
 
   LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", s + "/out"),
                                          nntrainer::withKey("axis", 1)}));
@@ -342,41 +483,45 @@ inline Tensor concatCh(const std::string &name,
  *
  * @param conv_q40  If true, eligible group=1 convs use Q4_0.
  */
-inline Tensor buildC2PSA(const std::string &n, Tensor x,
+inline Tensor buildC2PSA(const std::string &n, int ch, Tensor x,
                          bool conv_q40 = false) {
-  auto cv1 = yolov11::convBnSilu(n + "/cv1", 512, 512, 1, 1, 0, x, conv_q40);
-  auto a = sliceCh(n + "/slice_a", 0, 256, cv1);
-  auto b = sliceCh(n + "/slice_b", 256, 512, cv1);
+  auto cv1 = yolov11::convBnSilu(n + "/cv1", ch, ch, 1, 1, 0, x, conv_q40);
+  auto a = sliceCh(n + "/slice_a", 0, ch / 2, cv1);
+  auto b = sliceCh(n + "/slice_b", ch / 2, ch, cv1);
 
-  auto qkv = yolov11::convBnOnly(n + "/qkv", 256, 512, 1, 1, 0, b, conv_q40);
+  auto qkv = yolov11::convBnOnly(n + "/qkv", ch / 2, ch, 1, 1, 0, b, conv_q40);
 
   std::vector<Tensor> v_parts;
+  int head_dim = ch / 4;
+  int v_dim = head_dim / 2;
   for (int h = 0; h < 4; ++h)
-    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h), h * 128 + 64,
-                              h * 128 + 128, qkv));
+    v_parts.push_back(sliceCh(n + "/slice_v" + std::to_string(h),
+                              h * head_dim + v_dim, h * head_dim + head_dim,
+                              qkv));
   LayerHandle vcat(
     createLayer("concat", {nntrainer::withKey("name", n + "/vcat"),
                            nntrainer::withKey("axis", 1)}));
   auto v = vcat(v_parts);
-  auto pe = yolov11::dwConvBnOnly(n + "/pe", 256, v);
+  auto pe = yolov11::dwConvBnOnly(n + "/pe", ch / 2, v);
 
   LayerHandle att(
     createLayer("psa_attention", {nntrainer::withKey("name", n + "/attn")}));
   auto attn = att(qkv);
   auto attn_pe = addT(n + "/add_pe", attn, pe);
-  auto proj =
-    yolov11::convBnOnly(n + "/proj", 256, 256, 1, 1, 0, attn_pe, conv_q40);
+  auto proj = yolov11::convBnOnly(n + "/proj", ch / 2, ch / 2, 1, 1, 0, attn_pe,
+                                  conv_q40);
   auto b1 = addT(n + "/res1", b, proj);
 
-  auto ffn0 = yolov11::convBnSilu(n + "/ffn0", 256, 512, 1, 1, 0, b1, conv_q40);
+  auto ffn0 =
+    yolov11::convBnSilu(n + "/ffn0", ch / 2, ch, 1, 1, 0, b1, conv_q40);
   auto ffn1 =
-    yolov11::convBnOnly(n + "/ffn1", 512, 256, 1, 1, 0, ffn0, conv_q40);
+    yolov11::convBnOnly(n + "/ffn1", ch, ch / 2, 1, 1, 0, ffn0, conv_q40);
   auto b2 = addT(n + "/res2", b1, ffn1);
 
   LayerHandle cat(createLayer("concat", {nntrainer::withKey("name", n + "/cat"),
                                          nntrainer::withKey("axis", 1)}));
   auto cc = cat({a, b2});
-  return yolov11::convBnSilu(n + "/cv2", 512, 512, 1, 1, 0, cc, conv_q40);
+  return yolov11::convBnSilu(n + "/cv2", ch, ch, 1, 1, 0, cc, conv_q40);
 }
 
 // ===== Top-level whole-network builders =====
@@ -386,25 +531,29 @@ inline Tensor buildC2PSA(const std::string &n, Tensor x,
  *
  * Also outputs m4 and m6 (FPN skip connections).
  *
- * @param xIn       Input symbolic tensor [1, 3, 832, 832]
+ * @param xIn       Input symbolic tensor [1, 3, imgsz, imgsz]
  * @param m4_out    [out] C3k2 block 4 output (P3 skip)
  * @param m6_out    [out] C3k2 block 6 output (P4 skip)
+ * @param p         YOLOv11 scaling and layout parameters
  * @param conv_q40  If true, eligible convs use Q4_0.
  * @return m10 (C2PSA output, P5 feature)
  */
 inline Tensor buildBackbone(Tensor xIn, Tensor &m4_out, Tensor &m6_out,
-                            bool conv_q40 = false) {
-  auto h = yolov11::convBnSilu("conv0", 3, 64, 3, 2, 1, xIn, conv_q40);
-  h = yolov11::convBnSilu("conv1", 64, 128, 3, 2, 1, h, conv_q40);
-  h = yolov11::c3k2Block("m2", 128, 256, 64, h, conv_q40);
-  h = yolov11::convBnSilu("conv3", 256, 256, 3, 2, 1, h, conv_q40);
-  m4_out = yolov11::c3k2Block("m4", 256, 512, 128, h, conv_q40);
-  h = yolov11::convBnSilu("conv5", 512, 512, 3, 2, 1, m4_out, conv_q40);
-  m6_out = yolov11::c3k2Block("m6", 512, 512, 256, h, conv_q40);
-  h = yolov11::convBnSilu("conv7", 512, 512, 3, 2, 1, m6_out, conv_q40);
-  h = yolov11::c3k2Block("m8", 512, 512, 256, h, conv_q40);
-  h = yolov11::sppfBlock("m9", 512, h, conv_q40);
-  return buildC2PSA("m10", h, conv_q40);
+                            const YOLOv11Params &p, bool conv_q40 = false) {
+  auto h = yolov11::convBnSilu("conv0", 3, p.c0, 3, 2, 1, xIn, conv_q40);
+  h = yolov11::convBnSilu("conv1", p.c0, p.c1, 3, 2, 1, h, conv_q40);
+  h = yolov11::c3k2Block("m2", p.c1, p.c2, p.m2_inner_c, p.m2_c3k, h, conv_q40);
+  h = yolov11::convBnSilu("conv3", p.c2, p.c3, 3, 2, 1, h, conv_q40);
+  m4_out = yolov11::c3k2Block("m4", p.c3, p.m4_out, p.m4_inner_c, p.m4_c3k, h,
+                              conv_q40);
+  h = yolov11::convBnSilu("conv5", p.m4_out, p.c5, 3, 2, 1, m4_out, conv_q40);
+  m6_out = yolov11::c3k2Block("m6", p.c5, p.m6_out, p.m6_inner_c, p.m6_c3k, h,
+                              conv_q40);
+  h = yolov11::convBnSilu("conv7", p.m6_out, p.c7, 3, 2, 1, m6_out, conv_q40);
+  h = yolov11::c3k2Block("m8", p.c7, p.m8_out, p.m8_inner_c, p.m8_c3k, h,
+                         conv_q40);
+  h = yolov11::sppfBlock("m9", p.m8_out, h, conv_q40);
+  return buildC2PSA("m10", p.m10_c, h, conv_q40);
 }
 
 /**
@@ -413,30 +562,38 @@ inline Tensor buildBackbone(Tensor xIn, Tensor &m4_out, Tensor &m6_out,
  * @param m4       C3k2 block 4 output (P3 skip from backbone)
  * @param m6       C3k2 block 6 output (P4 skip from backbone)
  * @param m10      C2PSA output (P5 feature from backbone)
+ * @param p        YOLOv11 scaling and layout parameters
  * @param conv_q40 If true, eligible convs use Q4_0.
- * @return {P3, P4, P5} raw detection logits [1, 65, H, W] each
+ * @return {P3, P4, P5} raw detection logits [1, 64+nc, H, W] each
  */
 inline std::vector<Tensor> buildHead(Tensor m4, Tensor m6, Tensor m10,
+                                     const YOLOv11Params &p,
                                      bool conv_q40 = false) {
   auto m11 = upsampleX2("m11", m10);
   auto m12 = concatCh("m12", {m11, m6});
-  auto m13 = yolov11::c3k2Block("m13", 1024, 512, 256, m12, conv_q40);
+  auto m13 = yolov11::c3k2Block("m13", p.m13_in, p.m13_out, p.m13_c, p.m13_c3k,
+                                m12, conv_q40);
 
   auto m14 = upsampleX2("m14", m13);
   auto m15 = concatCh("m15", {m14, m4});
-  auto m16 = yolov11::c3k2Block("m16", 1024, 256, 128, m15, conv_q40);
+  auto m16 = yolov11::c3k2Block("m16", p.m16_in, p.m16_out, p.m16_c, p.m16_c3k,
+                                m15, conv_q40);
 
-  auto m17 = yolov11::convBnSilu("m17", 256, 256, 3, 2, 1, m16, conv_q40);
+  auto m17 =
+    yolov11::convBnSilu("m17", p.m16_out, p.m17_out, 3, 2, 1, m16, conv_q40);
   auto m18 = concatCh("m18", {m17, m13});
-  auto m19 = yolov11::c3k2Block("m19", 768, 512, 256, m18, conv_q40);
+  auto m19 = yolov11::c3k2Block("m19", p.m19_in, p.m19_out, p.m19_c, p.m19_c3k,
+                                m18, conv_q40);
 
-  auto m20 = yolov11::convBnSilu("m20", 512, 512, 3, 2, 1, m19, conv_q40);
+  auto m20 =
+    yolov11::convBnSilu("m20", p.m19_out, p.m20_out, 3, 2, 1, m19, conv_q40);
   auto m21 = concatCh("m21", {m20, m10});
-  auto m22 = yolov11::c3k2Block("m22", 1024, 512, 256, m21, conv_q40);
+  auto m22 = yolov11::c3k2Block("m22", p.m22_in, p.m22_out, p.m22_c, p.m22_c3k,
+                                m21, conv_q40);
 
-  return {detectScale("det0", 256, m16, conv_q40),
-          detectScale("det1", 512, m19, conv_q40),
-          detectScale("det2", 512, m22, conv_q40)};
+  return {detectScale("det0", p.det0_pi, p.det0_pi, p.nc, m16, conv_q40),
+          detectScale("det1", p.det1_pi, p.det0_pi, p.nc, m19, conv_q40),
+          detectScale("det2", p.det2_pi, p.det0_pi, p.nc, m22, conv_q40)};
 }
 
 } // namespace yolov11

--- a/Applications/CausalLM/models/YOLOv11/run_nntrainer.sh
+++ b/Applications/CausalLM/models/YOLOv11/run_nntrainer.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run the nntrainer YOLOv11m example on a given input .bin (default the one
+# written by run_pytorch.py). Builds the target if needed.
+# Usage: ./run_nntrainer.sh [INPUT_BIN]
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+RES="$HERE/res"
+INPUT="${1:-$RES/input_run.bin}"
+TARGET="Applications/CausalLM/models/YOLOv11/jni/yolov11_infer"
+BIN="$ROOT/build/$TARGET"
+
+if [ ! -f "$RES/yolov11m.safetensors" ]; then
+  echo "ERROR: $RES/yolov11m.safetensors not found."
+  echo "  Generate it first:"
+  echo "    python $HERE/PyTorch/convert_weights.py --weights <model.pt> --out $RES/yolov11m.safetensors"
+  exit 1
+fi
+if [ ! -f "$INPUT" ]; then
+  echo "ERROR: input bin not found: $INPUT (run run_pytorch.py first)"
+  exit 1
+fi
+
+if [ ! -x "$BIN" ]; then
+  echo ">> building $TARGET ..."
+  [ -d "$ROOT/build" ] || meson setup "$ROOT/build" -Denable-app=true
+  ninja -C "$ROOT/build" "$TARGET"
+fi
+
+echo "=== nntrainer (input: $INPUT) ==="
+# YOLO_VERIFY=1 also prints per-stage max_abs_diff vs res/ref_*.bin if present.
+"$BIN" "$RES" "$INPUT"

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -20,3 +20,8 @@ if get_option('platform') != 'windows'
     subdir('gpt_oss_cached_slim')
     subdir('qwen3_cached_slim_moe')
 endif
+
+# YOLOv11 inference harness
+if get_option('enable-app')
+    subdir('YOLOv11/jni')
+endif

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -455,7 +455,8 @@ void BatchNormalizationLayer::read(std::ifstream &file,
           T_read.read(file);
           run_context.getWeight(i).copyData(T_read);
         } else {
-          run_context.getWeight(i).read(file, start_offset);
+          run_context.getWeight(i).read(file, start_offset, read_from_offset,
+                                        file_fd);
         }
 
         if (run_context.isMixedPrecision(i) && trainable &&
@@ -501,7 +502,8 @@ void BatchNormalizationLayer::read(ReadSource src, RunLayerContext &run_context,
           T_read.read(src);
           run_context.getWeight(i).copyData(T_read);
         } else {
-          run_context.getWeight(i).read(src, start_offset);
+          run_context.getWeight(i).read(src, start_offset, read_from_offset,
+                                        file_fd);
         }
 
         if (run_context.isMixedPrecision(i) && trainable &&

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -477,6 +477,19 @@ public:
 };
 
 /**
+ * @brief Groups property for grouped convolution.
+ *        Input and output channels are split into `groups` independent groups.
+ *        groups=1 (the default when unset) is a regular conv;
+ * groups=in_channels is a depthwise conv. Left empty by default so it is not
+ * serialized for ordinary (groups=1) convolutions.
+ */
+class ConvGroups : public nntrainer::PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "groups"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;              /**< property type */
+};
+
+/**
  * @brief KernelSize property, kernel size is used to measure the filter size
  *
  */

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1029,6 +1029,22 @@ public:
 };
 
 /**
+ * @brief FusedActivation Enumeration Information
+ *
+ * @note Unlike props::Activation (key "activation"), this property is NOT
+ * intercepted by LayerNode's realization props nor split off into a standalone
+ * activation node by ActivationRealizer. It lets a layer (e.g. Conv2D) fuse an
+ * elementwise activation directly into its output write, avoiding the extra
+ * full-tensor read+write pass a separate activation layer would cost.
+ */
+class FusedActivation final
+  : public EnumProperty<nntrainer::props::ActivationTypeInfo> {
+public:
+  using prop_tag = enum_class_prop_tag;
+  static constexpr const char *key = "fused_activation";
+};
+
+/**
  * @brief HiddenStateActivation Enumeration Information
  *
  */

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -40,6 +40,7 @@ void ConcatLayer::finalize(InitLayerContext &context) {
     context.getInputDimensions().front().channel() > 1 ? 3 : 1;
   if (!concat_dimension_prop.empty())
     concat_dimension = concat_dimension_prop.get();
+  concat_dimension_cache = concat_dimension;
 
   /**
    * The concat is only done along the axis dimension.
@@ -147,6 +148,55 @@ void ConcatLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
 
   const TensorDim out_dim = output.getDim();
+
+  // NHWC path: channel is physical-innermost, so a channel-axis concat (the
+  // only concat YOLOv11 uses) interleaves per-pixel channel runs. The NCHW
+  // reshape-helper path below assumes channel-major planes and would copy
+  // into the wrong physical offsets, so handle NHWC separately. Only the
+  // channel axis (logical 1) is supported here, matching the graph usage.
+  if (out_dim.getFormat() == ml::train::TensorDim::Format::NHWC &&
+      concat_dimension_cache == 1) {
+    const unsigned int B = out_dim.batch();
+    const unsigned int H = out_dim.height();
+    const unsigned int W = out_dim.width();
+    const size_t HW = (size_t)H * W;
+    unsigned int c_offset = 0;
+    for (unsigned int idx = 0; idx < context.getNumInputs(); idx++) {
+      Tensor &input = context.getInput(idx);
+      const unsigned int Ci = input.channel();
+      if (input.getDataType() == TensorDim::DataType::FP32) {
+        const float *src = input.getData<float>();
+        float *dst = output.getData<float>();
+        for (unsigned int b = 0; b < B; ++b) {
+          const size_t base = (size_t)b * HW;
+          for (size_t p = 0; p < HW; ++p) {
+            // src is packed with Ci channels per pixel; dst has out channels.
+            const float *s = src + (base + p) * Ci;
+            float *d = dst + (base + p) * out_dim.channel() + c_offset;
+            std::memcpy(d, s, (size_t)Ci * sizeof(float));
+          }
+        }
+      } else if (input.getDataType() == TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+        const _FP16 *src = input.getData<_FP16>();
+        _FP16 *dst = output.getData<_FP16>();
+        for (unsigned int b = 0; b < B; ++b) {
+          const size_t base = (size_t)b * HW;
+          for (size_t p = 0; p < HW; ++p) {
+            const _FP16 *s = src + (base + p) * Ci;
+            _FP16 *d = dst + (base + p) * out_dim.channel() + c_offset;
+            std::memcpy(d, s, (size_t)Ci * sizeof(_FP16));
+          }
+        }
+#else
+        throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+      }
+      c_offset += Ci;
+    }
+    return;
+  }
+
   output.reshape(output_reshape_helper);
   unsigned int output_width_offset = 0;
   TensorDim::TensorType tensor_type = output.getTensorType();

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -109,6 +109,9 @@ private:
     input_reshape_helper;          /** helper dimension to reshape inputs */
   TensorDim output_reshape_helper; /** helper dimension to reshape outputs */
   std::tuple<props::ConcatDimension> concat_props;
+  unsigned int concat_dimension_cache =
+    1; /**< resolved in finalize for
+      forwarding (NHWC channel-concat path) */
 
   /**
    * @brief set batch for the internal variables

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -12,6 +12,7 @@
  *
  */
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <string>
@@ -337,14 +338,36 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   auto in_t_type = in_dim.getTensorType();
   in_t_type.data_type = context.getWeightDataType();
 
-  // Each filter spans in_channels/groups input channels (grouped convolution).
-  TensorDim kernel_dim = TensorDim(filter_size, in_dim.channel() / groups,
-                                   kernel_size[0], kernel_size[1], in_t_type);
+  // A quantized (Q4_0/QINT4) 1x1 conv is computed as a matmul, so its filter is
+  // stored as a [in_ch, out_ch] (K, N) weight that the quantized GEMM consumes
+  // directly (no im2col-style [out_ch, CRS] squeeze). Non-quantized or larger
+  // kernels keep the standard [out_ch, in_ch/groups, kh, kw] layout.
+  const bool quant_matmul_filter =
+    (in_t_type.data_type == nntrainer::Tdatatype::Q4_0 ||
+     in_t_type.data_type == nntrainer::Tdatatype::QINT4) &&
+    groups == 1;
 
-  TensorDim bias_dim = TensorDim(1, filter_size, 1, 1, in_t_type);
+  // Real conv kernel geometry — used for padding/output-size computation even
+  // when the quantized weight is stored flattened as [CRS, out_ch].
+  TensorDim real_kernel_dim(filter_size, in_dim.channel() / groups,
+                            kernel_size[0], kernel_size[1], in_t_type);
+  // A quantized (groups==1) conv stores its filter as a [CRS, out_ch] matmul
+  // weight (CRS = in_ch*kh*kw), consumed by the quantized GEMM after im2col.
+  TensorDim kernel_dim =
+    quant_matmul_filter
+      ? TensorDim(1, 1,
+                  in_dim.channel() * kernel_size[0].get() * kernel_size[1].get(),
+                  filter_size, in_t_type)
+      : real_kernel_dim;
+
+  // Bias is never quantized (no dequantizer for add); follow activation dtype
+  // like other compute layers so a Q4_0/QINT4 weight does not force a Q4_0 bias.
+  auto bias_t_type = in_dim.getTensorType();
+  bias_t_type.data_type = context.getActivationDataType();
+  TensorDim bias_dim = TensorDim(1, filter_size, 1, 1, bias_t_type);
 
   padding = std::get<props::Padding2D>(conv_props)
-              .compute(in_dim, kernel_dim, {stride[0], stride[1]},
+              .compute(in_dim, real_kernel_dim, {stride[0], stride[1]},
                        {dilation[0], dilation[1]});
 
   wt_idx[ConvParams::weight] = context.requestWeight(
@@ -394,6 +417,8 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
   auto &stride = std::get<std::array<props::Stride, CONV2D_DIM>>(conv_props);
   auto &dilation =
     std::get<std::array<props::Dilation, CONV2D_DIM>>(conv_props);
+  auto &kernel_size =
+    std::get<std::array<props::KernelSize, CONV2D_DIM>>(conv_props);
 
   Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
@@ -443,12 +468,22 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
   unsigned int groups = groups_prop.empty() ? 1 : groups_prop.get();
 
   if (groups == 1) {
+    // A quantized 1x1 conv stores its filter as a [in_ch, out_ch] matmul weight
+    // (K, N). The quantized GEMM (dotQnK for Q4_0) takes the weight as the dot
+    // *input* (activation is the receiver), so we keep that layout as-is and do
+    // NOT squeeze it to [out_ch, CRS] like the FP32 path.
+    const auto weight_dtype = filter_kernel.getDataType();
+    const bool weight_is_quant =
+      (weight_dtype == nntrainer::Tdatatype::Q4_0 ||
+       weight_dtype == nntrainer::Tdatatype::QINT4);
+    const unsigned int owoh = out_dim.width() * out_dim.height();
+
     TensorDim filter_dim_squeezed{filter_kernel.batch(),
                                   filter_kernel.getDim().getFeatureLen()};
-
     filter_dim_squeezed.setTensorType(filter_kernel.getTensorType());
-
-    filter_kernel.reshape(filter_dim_squeezed);
+    if (!weight_is_quant) {
+      filter_kernel.reshape(filter_dim_squeezed);
+    }
 
     /**
      * Below sets the pad area values to zero
@@ -456,18 +491,62 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
      */
     auto forwarding_job = [&](unsigned int s, unsigned int e, unsigned int pid,
                               void *user_data) {
-      Tensor result = Tensor(calcCol2ImOutputDim(out_dim, filter_dim));
-      result.setZero();
+      // im2col buffer is only needed for the FP32 path; the quantized 1x1 path
+      // is a matmul on the input directly (1x1 stride-1 im2col is an identity).
+      Tensor result;
+      if (!weight_is_quant) {
+        result = Tensor(calcCol2ImOutputDim(out_dim, filter_dim));
+        result.setZero();
+      }
       for (unsigned int b = s; b < e; ++b) {
         Tensor out = hidden_.getBatchSlice(b, 1);
-        out.reshape({filter_size, out_dim.width() * out_dim.height()});
         Tensor in_sub = input_.getBatchSlice(b, 1);
 
-        im2col(in_sub, filter_dim, padding, stride, dilation, result);
-        // filter kernel is (K, CRS), result is (CRS, OH*OW)
-        filter_kernel.dot(result, out, false, true);
+        if (weight_is_quant) {
+          // Quantized conv as matmul: act [OH*OW, CRS] . weight [CRS, out_ch]
+          // -> [OH*OW, out_ch] -> out [out_ch, OH*OW]. CRS = in_ch*kh*kw.
+          // NOTE: col must outlive `act` (act aliases col's storage), so col is
+          // declared in this scope (not inside the else branch).
+          Tensor col;
+          Tensor act;
+          if (kernel_size[0].get() == 1 && kernel_size[1].get() == 1 &&
+              stride[0].get() == 1 && stride[1].get() == 1) {
+            // 1x1 stride-1: im2col is an identity. The raw input is laid out as
+            // [in_ch, OH*OW] (NCHW), so transpose to the act layout [OH*OW, CRS]
+            // (CRS == in_ch here).
+            in_sub.reshape({in_dim.channel(), owoh});
+            act = in_sub.transpose("0:2:1");
+          } else {
+            // build the real kernel geometry (filter is stored as [CRS,out_ch])
+            TensorDim kdim(filter_size, in_dim.channel(), kernel_size[0].get(),
+                           kernel_size[1].get(), in_sub.getTensorType());
+            col = Tensor(calcCol2ImOutputDim(out_dim, kdim));
+            col.setZero();
+            // im2col reshapes col in place to [OH*OW, CRS] (spatial-major), which
+            // is ALREADY the act layout — no transpose (unlike the raw-input 1x1
+            // branch above). Transposing here gives [CRS, OH*OW] and makes the
+            // GEMM emit CRS rows into the owoh-row `tmp`, overflowing it whenever
+            // CRS > owoh (deep convs) -> heap corruption.
+            im2col(in_sub, kdim, padding, stride, dilation, col);
+            act = col;
+          }
+          Tensor tmp(TensorDim(1, 1, owoh, filter_size, act.getTensorType()));
+          act.dot(filter_kernel, tmp, false, false);
+          // [OH*OW, out_ch] -> [out_ch, OH*OW] written straight into the
+          // (memory-planned) output. `tmp` is a fresh buffer and `out` is a
+          // separate output view, so there is no aliasing — no temp+copy needed.
+          out.reshape({filter_size, owoh});
+          tmp.transpose("0:2:1", out);
+        } else {
+          out.reshape({filter_size, owoh});
+          im2col(in_sub, filter_dim, padding, stride, dilation, result);
+          // filter kernel is (K, CRS), result is (CRS, OH*OW)
+          filter_kernel.dot(result, out, false, true);
+        }
       }
-      result.deallocate();
+      if (!weight_is_quant) {
+        result.deallocate();
+      }
     };
 
     auto workers = ParallelBatch(forwarding_job, in_dim.batch(), nullptr);
@@ -478,7 +557,9 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
       forwarding_job(0, in_dim.batch(), 0, nullptr);
     }
 
-    filter_kernel.reshape(filter_dim);
+    if (!weight_is_quant) {
+      filter_kernel.reshape(filter_dim);
+    }
   } else {
     // Grouped convolution: split channels into `groups` independent groups.
     const unsigned int ocg = filter_size / groups;      // out ch per group
@@ -488,22 +569,36 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
     const unsigned int ihw = in_dim.height() * in_dim.width();
     TensorDim fdim_g(ocg, icg, fh, fw, filter_dim.getTensorType());
 
-    for (unsigned int b = 0; b < in_dim.batch(); ++b) {
-      Tensor out = hidden_.getBatchSlice(b, 1);
-      out.reshape({filter_size, owoh});
-      Tensor in_sub = input_.getBatchSlice(b, 1);
-      Tensor result = Tensor(calcCol2ImOutputDim(out_dim, fdim_g));
-      for (unsigned int g = 0; g < groups; ++g) {
-        Tensor in_g = in_sub.getSharedDataTensor(
-          {1, icg, in_dim.height(), in_dim.width()}, g * icg * ihw);
-        Tensor filt_g = filter_kernel.getSharedDataTensor(
-          {ocg, icg * fh * fw}, g * ocg * icg * fh * fw);
-        Tensor out_g = out.getSharedDataTensor({ocg, owoh}, g * ocg * owoh);
-        result.setZero();
-        im2col(in_g, fdim_g, padding, stride, dilation, result);
-        filt_g.dot(result, out_g, false, true);
+    if (ocg == 1 && icg == 1 &&
+        in_dim.getDataType() == nntrainer::Tdatatype::FP32 &&
+        std::getenv("NNTR_NO_DW_FASTPATH") == nullptr) {
+      // True depthwise (groups == channels): delegate to the CPU backend op so
+      // the optimised kernel lives in the backend, not in the layer.
+      nntrainer::getComputeOps()->depthwise_conv2d_fp32(
+        input_.getData<float>(), filter_kernel.getData<float>(),
+        hidden_.getData<float>(), in_dim.batch(), filter_size, in_dim.height(),
+        in_dim.width(), out_dim.height(), out_dim.width(), fh, fw,
+        stride[0].get(), stride[1].get(), padding[0], padding[2],
+        dilation[0].get(), dilation[1].get());
+    } else {
+      for (unsigned int b = 0; b < in_dim.batch(); ++b) {
+        Tensor out = hidden_.getBatchSlice(b, 1);
+        out.reshape({filter_size, owoh});
+        Tensor in_sub = input_.getBatchSlice(b, 1);
+        Tensor result = Tensor(calcCol2ImOutputDim(out_dim, fdim_g));
+        for (unsigned int g = 0; g < groups; ++g) {
+          Tensor in_g = in_sub.getSharedDataTensor(
+            {1, icg, in_dim.height(), in_dim.width()}, (size_t)g * icg * ihw);
+          Tensor filt_g = filter_kernel.getSharedDataTensor(
+            {ocg, (size_t)icg * fh * fw}, (size_t)g * ocg * icg * fh * fw);
+          Tensor out_g =
+            out.getSharedDataTensor({ocg, owoh}, (size_t)g * ocg * owoh);
+          result.setZero();
+          im2col(in_g, fdim_g, padding, stride, dilation, result);
+          filt_g.dot(result, out_g, false, true);
+        }
+        result.deallocate();
       }
-      result.deallocate();
     }
   }
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -299,7 +299,7 @@ Conv2DLayer::Conv2DLayer(
   padding(padding_),
   conv_props(props::FilterSize(), std::array<props::KernelSize, CONV2D_DIM>(),
              std::array<props::Stride, CONV2D_DIM>(), props::Padding2D(),
-             std::array<props::Dilation, CONV2D_DIM>()) {
+             std::array<props::Dilation, CONV2D_DIM>(), props::ConvGroups()) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -327,10 +327,18 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   auto &dilation =
     std::get<std::array<props::Dilation, CONV2D_DIM>>(conv_props);
 
+  auto &groups_prop = std::get<props::ConvGroups>(conv_props);
+  unsigned int groups = groups_prop.empty() ? 1 : groups_prop.get();
+  NNTR_THROW_IF(in_dim.channel() % groups != 0 || filter_size % groups != 0,
+                std::invalid_argument)
+    << "[Conv2D] input channels (" << in_dim.channel() << ") and filters ("
+    << filter_size << ") must both be divisible by groups (" << groups << ")";
+
   auto in_t_type = in_dim.getTensorType();
   in_t_type.data_type = context.getWeightDataType();
 
-  TensorDim kernel_dim = TensorDim(filter_size, in_dim.channel(),
+  // Each filter spans in_channels/groups input channels (grouped convolution).
+  TensorDim kernel_dim = TensorDim(filter_size, in_dim.channel() / groups,
                                    kernel_size[0], kernel_size[1], in_t_type);
 
   TensorDim bias_dim = TensorDim(1, filter_size, 1, 1, in_t_type);
@@ -431,42 +439,74 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
   const TensorDim &in_dim = input_.getDim();
   const TensorDim &out_dim = hidden_.getDim();
   const TensorDim &filter_dim = filter_kernel.getDim();
-  TensorDim filter_dim_squeezed{filter_kernel.batch(),
-                                filter_kernel.getDim().getFeatureLen()};
+  auto &groups_prop = std::get<props::ConvGroups>(conv_props);
+  unsigned int groups = groups_prop.empty() ? 1 : groups_prop.get();
 
-  filter_dim_squeezed.setTensorType(filter_kernel.getTensorType());
+  if (groups == 1) {
+    TensorDim filter_dim_squeezed{filter_kernel.batch(),
+                                  filter_kernel.getDim().getFeatureLen()};
 
-  filter_kernel.reshape(filter_dim_squeezed);
+    filter_dim_squeezed.setTensorType(filter_kernel.getTensorType());
 
-  /**
-   * Below sets the pad area values to zero
-   * it is faster to do this way than seting selective area to zero
-   */
-  auto forwarding_job = [&](unsigned int s, unsigned int e, unsigned int pid,
-                            void *user_data) {
-    Tensor result = Tensor(calcCol2ImOutputDim(out_dim, filter_dim));
-    result.setZero();
-    for (unsigned int b = s; b < e; ++b) {
-      Tensor out = hidden_.getBatchSlice(b, 1);
-      out.reshape({filter_size, out_dim.width() * out_dim.height()});
-      Tensor in_sub = input_.getBatchSlice(b, 1);
+    filter_kernel.reshape(filter_dim_squeezed);
 
-      im2col(in_sub, filter_dim, padding, stride, dilation, result);
-      // filter kernel is (K, CRS), result is (CRS, OH*OW)
-      filter_kernel.dot(result, out, false, true);
+    /**
+     * Below sets the pad area values to zero
+     * it is faster to do this way than seting selective area to zero
+     */
+    auto forwarding_job = [&](unsigned int s, unsigned int e, unsigned int pid,
+                              void *user_data) {
+      Tensor result = Tensor(calcCol2ImOutputDim(out_dim, filter_dim));
+      result.setZero();
+      for (unsigned int b = s; b < e; ++b) {
+        Tensor out = hidden_.getBatchSlice(b, 1);
+        out.reshape({filter_size, out_dim.width() * out_dim.height()});
+        Tensor in_sub = input_.getBatchSlice(b, 1);
+
+        im2col(in_sub, filter_dim, padding, stride, dilation, result);
+        // filter kernel is (K, CRS), result is (CRS, OH*OW)
+        filter_kernel.dot(result, out, false, true);
+      }
+      result.deallocate();
+    };
+
+    auto workers = ParallelBatch(forwarding_job, in_dim.batch(), nullptr);
+
+    if (workers.getNumWorkers() > 1) {
+      workers.run();
+    } else {
+      forwarding_job(0, in_dim.batch(), 0, nullptr);
     }
-    result.deallocate();
-  };
 
-  auto workers = ParallelBatch(forwarding_job, in_dim.batch(), nullptr);
-
-  if (workers.getNumWorkers() > 1) {
-    workers.run();
+    filter_kernel.reshape(filter_dim);
   } else {
-    forwarding_job(0, in_dim.batch(), 0, nullptr);
+    // Grouped convolution: split channels into `groups` independent groups.
+    const unsigned int ocg = filter_size / groups;      // out ch per group
+    const unsigned int icg = in_dim.channel() / groups; // in ch per group
+    const unsigned int fh = filter_dim.height(), fw = filter_dim.width();
+    const unsigned int owoh = out_dim.width() * out_dim.height();
+    const unsigned int ihw = in_dim.height() * in_dim.width();
+    TensorDim fdim_g(ocg, icg, fh, fw, filter_dim.getTensorType());
+
+    for (unsigned int b = 0; b < in_dim.batch(); ++b) {
+      Tensor out = hidden_.getBatchSlice(b, 1);
+      out.reshape({filter_size, owoh});
+      Tensor in_sub = input_.getBatchSlice(b, 1);
+      Tensor result = Tensor(calcCol2ImOutputDim(out_dim, fdim_g));
+      for (unsigned int g = 0; g < groups; ++g) {
+        Tensor in_g = in_sub.getSharedDataTensor(
+          {1, icg, in_dim.height(), in_dim.width()}, g * icg * ihw);
+        Tensor filt_g = filter_kernel.getSharedDataTensor(
+          {ocg, icg * fh * fw}, g * ocg * icg * fh * fw);
+        Tensor out_g = out.getSharedDataTensor({ocg, owoh}, g * ocg * owoh);
+        result.setZero();
+        im2col(in_g, fdim_g, padding, stride, dilation, result);
+        filt_g.dot(result, out_g, false, true);
+      }
+      result.deallocate();
+    }
   }
 
-  filter_kernel.reshape(filter_dim);
   if (auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
       disable_bias.empty() || disable_bias.get() == false) {
     Tensor &bias_kernel = context.getWeight(wt_idx[ConvParams::bias]);
@@ -478,6 +518,11 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
 }
 
 void Conv2DLayer::calcDerivative(RunLayerContext &context) {
+  NNTR_THROW_IF(!std::get<props::ConvGroups>(conv_props).empty() &&
+                  std::get<props::ConvGroups>(conv_props).get() != 1,
+                std::invalid_argument)
+    << "[Conv2D] backward for grouped convolution (groups>1) is not yet "
+       "implemented; only forward/inference is supported.";
   unsigned int filter_size = std::get<props::FilterSize>(conv_props);
   auto &stride = std::get<std::array<props::Stride, CONV2D_DIM>>(conv_props);
   auto &dilation =
@@ -528,6 +573,11 @@ void Conv2DLayer::calcDerivative(RunLayerContext &context) {
 }
 
 void Conv2DLayer::calcGradient(RunLayerContext &context) {
+  NNTR_THROW_IF(!std::get<props::ConvGroups>(conv_props).empty() &&
+                  std::get<props::ConvGroups>(conv_props).get() != 1,
+                std::invalid_argument)
+    << "[Conv2D] backward for grouped convolution (groups>1) is not yet "
+       "implemented; only forward/inference is supported.";
   unsigned int filter_size = std::get<props::FilterSize>(conv_props);
   auto &stride = std::get<std::array<props::Stride, CONV2D_DIM>>(conv_props);
   auto &dilation =

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -12,10 +12,14 @@
  *
  */
 #include <algorithm>
+#include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <limits>
 #include <string>
+#include <vector>
 
 #include <conv2d_layer.h>
 #include <cpu_backend.h>
@@ -28,6 +32,7 @@
 #include <profiler.h>
 #include <tensor_dim.h>
 #include <thread>
+#include <thread_manager.h>
 #include <util_func.h>
 
 namespace nntrainer {
@@ -36,6 +41,39 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 namespace {
 
+/**
+ * @brief In-place SiLU / swish (x * sigmoid(x)) over a contiguous buffer.
+ * @details Fuses what would otherwise be a separate Activation layer (a full
+ * extra read+write pass over the conv output) into the conv epilogue. The
+ * sigmoid is evaluated in fp32 and cast back to T so an FP16 activation graph
+ * does not lose precision (or overflow exp) in the half domain. Called after
+ * all conv compute completes, so it is never nested inside another
+ * parallel_for.
+ *
+ * @note ThreadManager::parallel_for invokes its callback through a type-erased
+ * std::function PER INDEX, so iterating it at element granularity would pay a
+ * non-inlinable call per element (measured ~3x slower than a serial inlined
+ * loop). Instead we parallelize over a handful of contiguous chunks (one per
+ * compute thread) and run a tight, fully-inlined inner loop inside each — the
+ * std::function is then hit only ~nthreads times while the exp stays inlined.
+ */
+template <typename T>
+static inline void convApplySwishInplace(T *data, size_t n) {
+  auto &tm = ThreadManager::Global();
+  const size_t nthreads = std::max<size_t>(1, tm.getComputeThreadCount());
+  const size_t chunk = (n + nthreads - 1) / nthreads;
+  tm.parallel_for(0, nthreads, [&](size_t t) {
+    const size_t start = t * chunk;
+    if (start >= n)
+      return;
+    const size_t end = std::min(start + chunk, n);
+    for (size_t i = start; i < end; ++i) {
+      const float x = static_cast<float>(data[i]);
+      data[i] = static_cast<T>(x / (1.0f + std::exp(-x)));
+    }
+  });
+}
+
 static TensorDim calcCol2ImOutputDim(const TensorDim &out,
                                      const TensorDim &kdim) {
 
@@ -43,10 +81,171 @@ static TensorDim calcCol2ImOutputDim(const TensorDim &out,
                    out.getTensorType());
 }
 
+#ifdef ENABLE_FP16
+/**
+ * @brief Transpose-and-quantize FP16 NCHW [in_ch, owoh] -> Q8_0 [owoh, in_ch]
+ *        in a single fused pass (no intermediate transpose copy).
+ *
+ * Each output row r (a spatial position) is quantized per 32-channel block:
+ * block (r, b) covers channels [b*32, b*32+32). The FP16 source is NCHW
+ * (channel-major), so channel c at position r lives at src[c*owoh + r]. This
+ * gathers a 32-wide channel run with a strided read and writes a packed
+ * block_q8_0 (fp16 scale + 32 int8). Parallelized over spatial positions.
+ *
+ * dst must hold (owoh * in_ch/32) block_q8_0 = owoh*in_ch/32*34 bytes, laid out
+ * row-major as [owoh][in_ch/32] blocks — exactly the [M,K] block_q8_0 layout
+ * Q8_0_Tensor::dot / the indirect GEMM consumes (M=owoh, K=in_ch).
+ */
+static inline void transpose_quantize_q8_0_act(const _FP16 *src, int in_ch,
+                                                int owoh, void *dst) {
+  struct block_q8_0 {
+    uint16_t d;
+    int8_t qs[32];
+  };
+  block_q8_0 *y = static_cast<block_q8_0 *>(dst);
+  const int qk = 32;
+  const int nb = in_ch / qk;
+
+  auto &tm = ThreadManager::Global();
+  const unsigned int chunk = 1024;
+  const size_t loops = (owoh + chunk - 1) / chunk;
+  tm.parallel_for(0, loops, [=](size_t idx) {
+    unsigned int r0 = idx * chunk;
+    unsigned int r1 = std::min(r0 + chunk, (unsigned int)owoh);
+    for (unsigned int r = r0; r < r1; ++r) {
+      for (int b = 0; b < nb; ++b) {
+        float amax = 0.0f;
+        for (int j = 0; j < qk; ++j) {
+          int c = b * qk + j;
+          float val =
+            std::abs(static_cast<float>(src[c * owoh + r]));
+          if (val > amax)
+            amax = val;
+        }
+        const float d = amax / ((1 << 7) - 1);
+        const float id = d ? 1.0f / d : 0.0f;
+        _FP16 d_half = static_cast<_FP16>(d);
+        uint16_t d_u16;
+        std::memcpy(&d_u16, &d_half, 2);
+        y[r * nb + b].d = d_u16;
+        for (int j = 0; j < qk; ++j) {
+          int c = b * qk + j;
+          float x0 = static_cast<float>(src[c * owoh + r]) * id;
+          y[r * nb + b].qs[j] = std::roundf(x0);
+        }
+      }
+    }
+  });
+}
+
+/**
+ * @brief Fused transpose + quantize FP16 NCHW [in_ch, owoh] directly into the
+ *        block_q8_0x4 (4-row interleaved) layout the SMMLA GEMM consumes, with
+ *        NO intermediate plain-block pass and NO separate interleave copy.
+ *
+ * Outputs (M4 = owoh/4) groups of 4 rows; each group packs nb=in_ch/32
+ * block_q8_0x4. block_q8_0x4.qs[128] layout = qs[32*j + 8*row + lane],
+ * j=8-element chunk (0..3), row=0..3 (matches __ggml_quantize_mat_q8_0_4x8).
+ * Remainder (owoh % 4) rows packed as plain block_q8_0 afterward for the GEMV
+ * tail. dst must hold the block_q8_0x4 region followed by the remainder
+ * block_q8_0 region (same total as Q8_0_Tensor::dot's QA buffer).
+ */
+static inline void
+transpose_quantize_q8_0x4_act(const _FP16 *src, int in_ch, int owoh,
+                               void *dst) {
+  struct block_q8_0 {
+    uint16_t d;
+    int8_t qs[32];
+  };
+  struct block_q8_0x4 {
+    uint16_t d[4];
+    int8_t qs[128];
+  };
+  const int qk = 32;
+  const int nb = in_ch / qk;
+  const int M4 = owoh / 4;
+  const int rem = owoh % 4;
+  block_q8_0x4 *y4 = static_cast<block_q8_0x4 *>(dst);
+  const size_t qa_4_rows_size = sizeof(block_q8_0x4) * nb;
+
+  auto &tm = ThreadManager::Global();
+  const unsigned int chunk = 256; // groups of 4 rows per task
+  const size_t loops = (M4 + chunk - 1) / chunk;
+  tm.parallel_for(0, loops, [=](size_t idx) {
+    unsigned int g0 = idx * chunk;
+    unsigned int g1 = std::min(g0 + chunk, (unsigned int)M4);
+    for (unsigned int g = g0; g < g1; ++g) {
+      unsigned int r0 = g * 4;
+      for (int b = 0; b < nb; ++b) {
+        block_q8_0x4 &dst_b = y4[g * nb + b];
+        for (unsigned int row = 0; row < 4; ++row) {
+          unsigned int r = r0 + row;
+          float amax = 0.0f;
+          for (int j = 0; j < qk; ++j) {
+            int c = b * qk + j;
+            float val = std::abs(static_cast<float>(src[c * owoh + r]));
+            if (val > amax)
+              amax = val;
+          }
+          const float d = amax / ((1 << 7) - 1);
+          const float id = d ? 1.0f / d : 0.0f;
+          _FP16 d_half = static_cast<_FP16>(d);
+          uint16_t d_u16;
+          std::memcpy(&d_u16, &d_half, 2);
+          dst_b.d[row] = d_u16;
+          for (int j = 0; j < qk; ++j) {
+            int c = b * qk + j;
+            float x0 = static_cast<float>(src[c * owoh + r]) * id;
+            // qs[32*chunk + 8*row + lane], chunk = j/8, lane = j%8
+            dst_b.qs[32 * (j / 8) + 8 * row + (j % 8)] =
+              static_cast<int8_t>(std::roundf(x0));
+          }
+        }
+      }
+    }
+  });
+
+  // Remainder rows (owoh % 4): plain block_q8_0 for the GEMV tail.
+  if (rem > 0) {
+    block_q8_0 *yrem =
+      reinterpret_cast<block_q8_0 *>(reinterpret_cast<char *>(dst) +
+                                     (size_t)M4 * qa_4_rows_size);
+    const unsigned int rchunk = 1024;
+    const size_t rloops = (rem + rchunk - 1) / rchunk;
+    tm.parallel_for(0, rloops, [=](size_t idx) {
+      unsigned int i0 = idx * rchunk;
+      unsigned int i1 = std::min(i0 + rchunk, (unsigned int)rem);
+      for (unsigned int i = i0; i < i1; ++i) {
+        unsigned int r = M4 * 4 + i;
+        for (int b = 0; b < nb; ++b) {
+          float amax = 0.0f;
+          for (int j = 0; j < qk; ++j) {
+            int c = b * qk + j;
+            float val = std::abs(static_cast<float>(src[c * owoh + r]));
+            if (val > amax)
+              amax = val;
+          }
+          const float d = amax / ((1 << 7) - 1);
+          const float id = d ? 1.0f / d : 0.0f;
+          _FP16 d_half = static_cast<_FP16>(d);
+          uint16_t d_u16;
+          std::memcpy(&d_u16, &d_half, 2);
+          yrem[i * nb + b].d = d_u16;
+          for (int j = 0; j < qk; ++j) {
+            int c = b * qk + j;
+            float x0 = static_cast<float>(src[c * owoh + r]) * id;
+            yrem[i * nb + b].qs[j] = static_cast<int8_t>(std::roundf(x0));
+          }
+        }
+      }
+    });
+  }
+}
+#endif
+
 /**
  * @brief     reconstruct image data from 2d column matrix
  *
- * @param[in] in input data
  * @param[in] kdim kernel dimesion for define number of row
  * @param[in] padding padding information
  * @param[in] mstride stride value : x, y direction
@@ -94,8 +293,7 @@ static void col2im(const Tensor &col_matrix, const TensorDim &kdim,
    * of Tensor. Then we could remove to access the getData or getValue which has
    * dependecy of data type.
    */
-  auto apply_data = [&](auto *val) {
-    using T = std::decay_t<decltype(*val)>;
+  auto apply_data = [&]<typename T>(T *val) {
     unsigned col_w = 0;
     for (int hs = -(int)pt; hs <= h_stride_end; hs += hstride) {
       for (int ws = -(int)pl; ws <= w_stride_end; ws += wstride) {
@@ -232,21 +430,42 @@ static void im2col(const Tensor &in, const TensorDim &kdim,
               in.getTensorType()));
   // float *out_data = out.getData();
 
-  auto apply_data = [&](auto *out_data) {
-    using T = std::decay_t<decltype(*out_data)>;
-    int h_stride_end = height - eff_k_height - pt;
+  auto apply_data = [&]<typename T>(T *out_data) {
     int w_stride_end = width - eff_k_width - pl;
 
     /// get a patch, size of kernel
     /// hs is height_strided, ws is width_strided
     unsigned int owidth = out.width();
-    unsigned int base_im_w = 0;
-    for (int hs = -(int)pt; hs <= h_stride_end; hs += mstride[0]) {
+    const int hstride = mstride[0];
+
+    /// Raw contiguous-NCHW input base + inner strides. `in` is a (batch-sliced)
+    /// contiguous NCHW tensor, so element (0,c,h,w) lives at
+    /// in_base + c*inHW + h*inW + w. Hoisting these out of the inner loop turns
+    /// the old per-element in.getValue() -- which re-fetched the data pointer
+    /// (getData<T>()) and recomputed a 4-D linear offset (getIndex(): a format
+    /// branch + 4 muls + 3 adds) plus a per-element padding branch -- into one
+    /// contiguous run copy. im2col is pure data movement; the previous form ran
+    /// far below memory bandwidth because that overhead dominated the 4-byte
+    /// move. Padding columns are left untouched (the caller zeroes the buffer
+    /// once before im2col), so the fast path only writes the valid span.
+    const T *in_base = in.getData<T>();
+    const size_t inW = (size_t)in_width;
+    const size_t inHW = (size_t)in_height * (size_t)in_width;
+    const bool unit_dil =
+      ((unsigned int)dilation[0] == 1 && (unsigned int)dilation[1] == 1);
+    const bool is_nhwc =
+      (in.getFormat() == ml::train::TensorDim::Format::NHWC);
+
+    /// Each output row (oh) writes a disjoint band of `out_width` columns
+    /// (rows [oh*out_width, (oh+1)*out_width) of the [OH*OW, CRS] matrix), so
+    /// the per-row work is independent and bit-identical when parallelized.
+    /// hs and base_im_w are derived from oh directly (no sequential carry).
+    auto fill_row = [&](size_t oh) {
+      int hs = -(int)pt + (int)oh * hstride;
+      unsigned int base_im_w = (unsigned int)oh * out_width;
       unsigned int base_im_h = 0;
       int patch_height_end = eff_k_height + hs;
       /// map the patch to a single line looping through channel
-      // We need to optimize this padding & copy. May be use multi threads, or
-      // SIMD
       for (unsigned int c = 0; c < channel; ++c) {
         for (int h = hs; h < patch_height_end; h += dilation[0]) {
           if (h < 0 || in_height <= h) {
@@ -254,26 +473,68 @@ static void im2col(const Tensor &in, const TensorDim &kdim,
             continue;
           }
 
-          unsigned int im_w = base_im_w;
-          for (int ws = -(int)pl; ws <= w_stride_end; ws += mstride[1]) {
-            unsigned int im_h = base_im_h;
-            int patch_width_end = eff_k_width + ws;
-
-            for (int w = ws; w < patch_width_end; w += dilation[1]) {
-              if (w < 0 || in_width <= w) {
-                im_h++;
-                continue;
+          if (unit_dil) {
+            /// Fast path (dilation == 1): for each output column position the
+            /// kernel-width window maps a contiguous source run
+            /// in_row[w_lo,w_hi) to a contiguous dest run; copy it in one
+            /// memcpy.
+            const T *in_row = in_base + (size_t)c * inHW + (size_t)h * inW;
+            unsigned int im_w = base_im_w;
+            for (int ws = -(int)pl; ws <= w_stride_end; ws += mstride[1]) {
+              int w_lo = ws < 0 ? 0 : ws;
+              int w_hi = ws + (int)k_width;
+              if (w_hi > in_width)
+                w_hi = in_width;
+              if (w_hi > w_lo) {
+                T *dst =
+                  out_data + (size_t)im_w * owidth + base_im_h + (w_lo - ws);
+                if (!is_nhwc) {
+                  const T *in_row =
+                    in_base + (size_t)c * inHW + (size_t)h * inW;
+                  std::memcpy(dst, in_row + w_lo,
+                              (size_t)(w_hi - w_lo) * sizeof(T));
+                } else {
+                  /// NHWC: channel is innermost, so the w-run is NOT
+                  /// contiguous in source. Gather per (w, channel) element.
+                  for (int w = w_lo; w < w_hi; ++w) {
+                    dst[w - w_lo] =
+                      in_base[((size_t)h * inW + (size_t)w) * channel + c];
+                  }
+                }
               }
-              out_data[im_w * owidth + im_h] = in.getValue<T>(0, c, h, w);
-              im_h++;
+              im_w++;
             }
-            im_w++;
+          } else {
+            /// General (dilated) path: original scalar gather, but via the
+            /// hoisted base pointer (no per-element getData()/getIndex()).
+            unsigned int im_w = base_im_w;
+            for (int ws = -(int)pl; ws <= w_stride_end; ws += mstride[1]) {
+              unsigned int im_h = base_im_h;
+              int patch_width_end = eff_k_width + ws;
+
+              for (int w = ws; w < patch_width_end; w += dilation[1]) {
+                if (w < 0 || in_width <= w) {
+                  im_h++;
+                  continue;
+                }
+                if (!is_nhwc) {
+                  out_data[(size_t)im_w * owidth + im_h] =
+                    in_base[(size_t)c * inHW + (size_t)h * inW + w];
+                } else {
+                  out_data[(size_t)im_w * owidth + im_h] =
+                    in_base[((size_t)h * inW + (size_t)w) * channel + c];
+                }
+                im_h++;
+              }
+              im_w++;
+            }
           }
           base_im_h += k_width;
         }
       }
-      base_im_w += out_width;
-    }
+    };
+
+    ThreadManager::Global().parallel_for(0, out_height, fill_row);
   };
 
   if (out.getDataType() == nntrainer::Tdatatype::FP32) {
@@ -292,7 +553,7 @@ static void im2col(const Tensor &in, const TensorDim &kdim,
 }
 } // namespace
 
-enum ConvParams { weight, bias };
+enum ConvParams { weight, bias, im2col_scratch, qgemm_scratch };
 
 Conv2DLayer::Conv2DLayer(
   const std::array<unsigned int, CONV2D_DIM * 2> &padding_) :
@@ -300,7 +561,8 @@ Conv2DLayer::Conv2DLayer(
   padding(padding_),
   conv_props(props::FilterSize(), std::array<props::KernelSize, CONV2D_DIM>(),
              std::array<props::Stride, CONV2D_DIM>(), props::Padding2D(),
-             std::array<props::Dilation, CONV2D_DIM>(), props::ConvGroups()) {
+             std::array<props::Dilation, CONV2D_DIM>(), props::ConvGroups(),
+             props::FusedActivation()) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -353,15 +615,16 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
                             kernel_size[0], kernel_size[1], in_t_type);
   // A quantized (groups==1) conv stores its filter as a [CRS, out_ch] matmul
   // weight (CRS = in_ch*kh*kw), consumed by the quantized GEMM after im2col.
-  TensorDim kernel_dim =
-    quant_matmul_filter
-      ? TensorDim(1, 1,
-                  in_dim.channel() * kernel_size[0].get() * kernel_size[1].get(),
-                  filter_size, in_t_type)
-      : real_kernel_dim;
+  TensorDim kernel_dim = quant_matmul_filter
+                           ? TensorDim(1, 1,
+                                       in_dim.channel() * kernel_size[0].get() *
+                                         kernel_size[1].get(),
+                                       filter_size, in_t_type)
+                           : real_kernel_dim;
 
   // Bias is never quantized (no dequantizer for add); follow activation dtype
-  // like other compute layers so a Q4_0/QINT4 weight does not force a Q4_0 bias.
+  // like other compute layers so a Q4_0/QINT4 weight does not force a Q4_0
+  // bias.
   auto bias_t_type = in_dim.getTensorType();
   bias_t_type.data_type = context.getActivationDataType();
   TensorDim bias_dim = TensorDim(1, filter_size, 1, 1, bias_t_type);
@@ -408,6 +671,46 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
                   eff_in_width - padding[2] - kernel_size[1] > IM,
                 std::invalid_argument)
     << "Failed to initialize: Calculated patch end is over int max";
+
+  // Forward scratch (groups==1 path only): the im2col column buffer and the
+  // quantized-GEMM output are otherwise heap-allocated on every forwarding()
+  // call. Request them once here (planned into the shared activation arena,
+  // FORWARD_FUNC_LIFESPAN) and reuse — no per-forward malloc/free churn. The
+  // grouped path keeps its local buffer. NOTE: the im2col buffer must still be
+  // re-zeroed each forward (im2col skips padding positions and the arena is
+  // reused across layers), so this saves the allocation, not the zeroing.
+  wt_idx[ConvParams::im2col_scratch] = std::numeric_limits<unsigned int>::max();
+  wt_idx[ConvParams::qgemm_scratch] = std::numeric_limits<unsigned int>::max();
+  if (groups == 1) {
+    auto scratch_type = in_dim.getTensorType();
+    const unsigned int owoh = out_dim.width() * out_dim.height();
+    const bool is_1x1_s1 = kernel_size[0].get() == 1 &&
+                           kernel_size[1].get() == 1 && stride[0].get() == 1 &&
+                           stride[1].get() == 1;
+    // im2col column buffer [batch, 1, CRS, OH*OW]. Unused by the quant paths
+    // that never materialize a col buffer: the 1x1 path (im2col is an identity
+    // handled by an input transpose) and, where the fused backend op exists,
+    // the non-1x1 path (gather is fused into the q8_0 activation packing).
+    if (!(quant_matmul_filter && is_1x1_s1)) {
+      // FP path or quant fallback: materialize the im2col column buffer
+      // [batch, 1, CRS, OH*OW] once (planned into the activation arena). The
+      // quant 1x1 path (identity input transpose) and the quant indirect path
+      // (gather fused into the GEMM's q8_0 packing) never materialize a col
+      // buffer, so they request no im2col_scratch here.
+      TensorDim col_dim(in_dim.batch(), 1, real_kernel_dim.getFeatureLen(),
+                        owoh, scratch_type);
+      wt_idx[ConvParams::im2col_scratch] =
+        context.requestTensor(col_dim, "im2col", Initializer::NONE, false,
+                              TensorLifespan::FORWARD_FUNC_LIFESPAN);
+    }
+    // quantized GEMM output [batch, 1, OH*OW, out_ch] (quant path only).
+    if (quant_matmul_filter) {
+      TensorDim tmp_dim(in_dim.batch(), 1, owoh, filter_size, scratch_type);
+      wt_idx[ConvParams::qgemm_scratch] =
+        context.requestTensor(tmp_dim, "qgemm_out", Initializer::NONE, false,
+                              TensorLifespan::FORWARD_FUNC_LIFESPAN);
+    }
+  }
 }
 
 void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
@@ -473,9 +776,8 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
     // *input* (activation is the receiver), so we keep that layout as-is and do
     // NOT squeeze it to [out_ch, CRS] like the FP32 path.
     const auto weight_dtype = filter_kernel.getDataType();
-    const bool weight_is_quant =
-      (weight_dtype == nntrainer::Tdatatype::Q4_0 ||
-       weight_dtype == nntrainer::Tdatatype::QINT4);
+    const bool weight_is_quant = (weight_dtype == nntrainer::Tdatatype::Q4_0 ||
+                                  weight_dtype == nntrainer::Tdatatype::QINT4);
     const unsigned int owoh = out_dim.width() * out_dim.height();
 
     TensorDim filter_dim_squeezed{filter_kernel.batch(),
@@ -489,63 +791,165 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
      * Below sets the pad area values to zero
      * it is faster to do this way than seting selective area to zero
      */
+    const bool is_1x1_s1 = kernel_size[0].get() == 1 &&
+                           kernel_size[1].get() == 1 && stride[0].get() == 1 &&
+                           stride[1].get() == 1;
+    // Pre-allocated forward scratch (requested once in finalize). The im2col
+    // column buffer is used by the FP32 path and the quant non-1x1 *fallback*;
+    // the quant 1x1 path (identity input transpose) and the quant non-1x1 fused
+    // path (gather folded into the GEMM) need no col buffer — finalize skips
+    // im2col_scratch is materialized by finalize only for the FP/fallback path.
+    // The quant 1x1 path (identity transpose) and the quant indirect path
+    // (gather fused into the GEMM) requested no col buffer in finalize, so the
+    // pointer stays null for them.
+    const bool use_im2col_scratch =
+      !(weight_is_quant && is_1x1_s1);
+    Tensor *col_scratch =
+      use_im2col_scratch
+        ? &context.getTensor(wt_idx[ConvParams::im2col_scratch])
+        : nullptr;
+    Tensor *qgemm_scratch =
+      weight_is_quant ? &context.getTensor(wt_idx[ConvParams::qgemm_scratch])
+                      : nullptr;
+    if (col_scratch != nullptr) {
+      col_scratch->setZero();
+    }
+
     auto forwarding_job = [&](unsigned int s, unsigned int e, unsigned int pid,
                               void *user_data) {
-      // im2col buffer is only needed for the FP32 path; the quantized 1x1 path
-      // is a matmul on the input directly (1x1 stride-1 im2col is an identity).
-      Tensor result;
-      if (!weight_is_quant) {
-        result = Tensor(calcCol2ImOutputDim(out_dim, filter_dim));
-        result.setZero();
-      }
       for (unsigned int b = s; b < e; ++b) {
         Tensor out = hidden_.getBatchSlice(b, 1);
         Tensor in_sub = input_.getBatchSlice(b, 1);
 
         if (weight_is_quant) {
-          // Quantized conv as matmul: act [OH*OW, CRS] . weight [CRS, out_ch]
-          // -> [OH*OW, out_ch] -> out [out_ch, OH*OW]. CRS = in_ch*kh*kw.
-          // NOTE: col must outlive `act` (act aliases col's storage), so col is
-          // declared in this scope (not inside the else branch).
-          Tensor col;
-          Tensor act;
-          if (kernel_size[0].get() == 1 && kernel_size[1].get() == 1 &&
-              stride[0].get() == 1 && stride[1].get() == 1) {
-            // 1x1 stride-1: im2col is an identity. The raw input is laid out as
-            // [in_ch, OH*OW] (NCHW), so transpose to the act layout [OH*OW, CRS]
-            // (CRS == in_ch here).
-            in_sub.reshape({in_dim.channel(), owoh});
-            act = in_sub.transpose("0:2:1");
+          if (in_sub.getFormat() == ml::train::TensorDim::Format::NHWC) {
+            // NHWC channel-last quantized convolution:
+            // Since physical layout is [owoh, filter_size], we reshape `out` to flat
+            // NCHW [1, 1, owoh, filter_size] and write directly, completely bypassing
+            // qgemm_scratch and transposes!
+            Tensor out_flat = out;
+            out_flat.reshape(TensorDim(1, 1, owoh, filter_size, {ml::train::TensorDim::Format::NCHW, out.getDataType()}));
+
+            if (is_1x1_s1) {
+              Tensor act = in_sub;
+              act.reshape(TensorDim(1, 1, owoh, in_dim.channel(), {ml::train::TensorDim::Format::NCHW, in_sub.getDataType()}));
+              act.dot(filter_kernel, out_flat, false, false);
+            } else {
+              throw std::runtime_error("Fallback quantized NHWC conv is not supported (requires indirect conv on ARM).");
+            }
           } else {
-            // build the real kernel geometry (filter is stored as [CRS,out_ch])
-            TensorDim kdim(filter_size, in_dim.channel(), kernel_size[0].get(),
-                           kernel_size[1].get(), in_sub.getTensorType());
-            col = Tensor(calcCol2ImOutputDim(out_dim, kdim));
-            col.setZero();
-            // im2col reshapes col in place to [OH*OW, CRS] (spatial-major), which
-            // is ALREADY the act layout — no transpose (unlike the raw-input 1x1
-            // branch above). Transposing here gives [CRS, OH*OW] and makes the
-            // GEMM emit CRS rows into the owoh-row `tmp`, overflowing it whenever
-            // CRS > owoh (deep convs) -> heap corruption.
-            im2col(in_sub, kdim, padding, stride, dilation, col);
-            act = col;
+            // Quantized conv as matmul: act [OH*OW, CRS] . weight [CRS, out_ch]
+            // -> [OH*OW, out_ch] -> out [out_ch, OH*OW]. CRS = in_ch*kh*kw.
+            // NOTE: col must outlive `act` (act aliases col's storage); here col
+            // is a view into the context-owned scratch, so its storage outlives
+            // the loop iteration regardless.
+            Tensor tmp = qgemm_scratch->getBatchSlice(b, 1);
+            tmp.reshape(
+              TensorDim(1, 1, owoh, filter_size, in_sub.getTensorType()));
+            if (is_1x1_s1) {
+              // 1x1 stride-1: im2col is an identity. The raw input is laid out as
+              // [in_ch, OH*OW] (NCHW), so transpose to the act layout [OH*OW,
+              // CRS] (CRS == in_ch here).
+              in_sub.reshape({in_dim.channel(), owoh});
+              Tensor act = in_sub.transpose("0:2:1");
+              act.dot(filter_kernel, tmp, false, false);
+            } else {
+              // Fallback (no fused backend op): materialize im2col into the col
+              // scratch, then the standard quant GEMM.
+              // build the real kernel geometry (filter is stored as [CRS,out_ch])
+              TensorDim kdim(filter_size, in_dim.channel(), kernel_size[0].get(),
+                             kernel_size[1].get(), in_sub.getTensorType());
+              Tensor col = col_scratch->getBatchSlice(b, 1);
+              // im2col reshapes col in place to [OH*OW, CRS] (spatial-major),
+              // which is ALREADY the act layout — no transpose (unlike the
+              // raw-input 1x1 branch above). Transposing here gives [CRS, OH*OW]
+              // and makes the GEMM emit CRS rows into the owoh-row `tmp`,
+              // overflowing it whenever CRS > owoh (deep convs) -> heap
+              // corruption.
+              im2col(in_sub, kdim, padding, stride, dilation, col);
+              col.dot(filter_kernel, tmp, false, false);
+            }
+            // [OH*OW, out_ch] -> [out_ch, OH*OW] written straight into the
+            // (memory-planned) output. `tmp` is a separate scratch buffer and
+            // `out` is a separate output view, so there is no aliasing.
+            out.reshape({filter_size, owoh});
+            tmp.transpose("0:2:1", out);
           }
-          Tensor tmp(TensorDim(1, 1, owoh, filter_size, act.getTensorType()));
-          act.dot(filter_kernel, tmp, false, false);
-          // [OH*OW, out_ch] -> [out_ch, OH*OW] written straight into the
-          // (memory-planned) output. `tmp` is a fresh buffer and `out` is a
-          // separate output view, so there is no aliasing — no temp+copy needed.
-          out.reshape({filter_size, owoh});
-          tmp.transpose("0:2:1", out);
         } else {
+          Tensor result = col_scratch->getBatchSlice(b, 1);
           out.reshape({filter_size, owoh});
           im2col(in_sub, filter_dim, padding, stride, dilation, result);
           // filter kernel is (K, CRS), result is (CRS, OH*OW)
-          filter_kernel.dot(result, out, false, true);
+          if (out.getFormat() == ml::train::TensorDim::Format::NCHW) {
+            filter_kernel.dot(result, out, false, true);
+          } else {
+            // NHWC: out's physical layout is [OH,OW,C] (channel innermost), so
+            // a dot writing [out_ch, OH*OW] NCHW-order would land in the wrong
+            // physical cells. Compute into a plain NCHW-order buffer (format
+            // NCHW so dot writes channel-major), then scatter channel c of
+            // spatial r to out[r*out_ch + c] (NHWC physical).
+            // Compute into a plain NCHW-order buffer (same result feeding as the
+            // NCHW path above — do NOT reshape result, im2col already laid it
+            // out as the dot expects). nchw_out is format NCHW so dot writes
+            // channel-major [out_ch, OH*OW]; then scatter channel c of spatial r
+            // to out[r*out_ch + c] (NHWC physical).
+            auto nchw_type = out.getTensorType();
+            nchw_type.format = ml::train::TensorDim::Format::NCHW;
+            // nchw_out holds the GEMM result [out_ch, OH*OW] in channel-major
+            // (NCHW) order. Shape it [1, 1, out_ch, OH*OW] so width()==OH*OW is
+            // the row stride the GEMM writes with (ldc); a [1,out_ch,OH*OW,1]
+            // shape would give width()==1 and stride the output wrong.
+            TensorDim nchw_dim({1, 1, filter_size, owoh}, nchw_type);
+            Tensor nchw_out(nchw_dim, true);
+            // filter_kernel (weight [out_ch, CRS]) and result (im2col columns
+            // [OH*OW, CRS]) are plain 2D matmul matrices whose image format is
+            // irrelevant to this GEMM. dot() derives the contraction axis from
+            // the tensor format: their inherited NHWC tag makes it contract
+            // over channel() (==1) instead of width() (==CRS) -> zero output.
+            // Re-map the same bytes as NCHW-format views (no copy) so the GEMM
+            // contracts over CRS==width(). getSharedDataTensor can't relabel
+            // format (it enforces a match), so use Tensor::Map.
+            auto fnchw_type = filter_kernel.getTensorType();
+            fnchw_type.format = ml::train::TensorDim::Format::NCHW;
+            auto cnchw_type = result.getTensorType();
+            cnchw_type.format = ml::train::TensorDim::Format::NCHW;
+            TensorDim fdim_nchw(filter_kernel.batch(), filter_kernel.channel(),
+                                filter_kernel.height(), filter_kernel.width(),
+                                fnchw_type);
+            TensorDim cdim_nchw(result.batch(), result.channel(),
+                                result.height(), result.width(), cnchw_type);
+            Tensor filt_nchw = Tensor::Map<float>(
+              filter_kernel.getData<float>(), filter_kernel.bytes(), fdim_nchw);
+            if (out.getDataType() == nntrainer::Tdatatype::FP32) {
+              Tensor col_nchw = Tensor::Map<float>(
+                result.getData<float>(), result.bytes(), cdim_nchw);
+              filt_nchw.dot(col_nchw, nchw_out, false, true);
+            }
+#ifdef ENABLE_FP16
+            else {
+              Tensor col_nchw = Tensor::Map<_FP16>(
+                result.getData<_FP16>(), result.bytes(), cdim_nchw);
+              filt_nchw.dot(col_nchw, nchw_out, false, true);
+            }
+#endif
+            if (out.getDataType() == nntrainer::Tdatatype::FP32) {
+              const float *s = nchw_out.getData<float>();
+              float *d = out.getData<float>();
+              for (unsigned int oc = 0; oc < filter_size; ++oc)
+                for (unsigned int r = 0; r < owoh; ++r)
+                  d[r * filter_size + oc] = s[oc * owoh + r];
+            }
+#ifdef ENABLE_FP16
+            else if (out.getDataType() == nntrainer::Tdatatype::FP16) {
+              const _FP16 *s = nchw_out.getData<_FP16>();
+              _FP16 *d = out.getData<_FP16>();
+              for (unsigned int oc = 0; oc < filter_size; ++oc)
+                for (unsigned int r = 0; r < owoh; ++r)
+                  d[r * filter_size + oc] = s[oc * owoh + r];
+            }
+#endif
+          }
         }
-      }
-      if (!weight_is_quant) {
-        result.deallocate();
       }
     };
 
@@ -569,9 +973,74 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
     const unsigned int ihw = in_dim.height() * in_dim.width();
     TensorDim fdim_g(ocg, icg, fh, fw, filter_dim.getTensorType());
 
-    if (ocg == 1 && icg == 1 &&
-        in_dim.getDataType() == nntrainer::Tdatatype::FP32 &&
-        std::getenv("NNTR_NO_DW_FASTPATH") == nullptr) {
+    const bool is_true_depthwise = ocg == 1 && icg == 1;
+    const bool nhwc_depthwise =
+      is_true_depthwise &&
+      in_dim.getFormat() == ml::train::TensorDim::Format::NHWC;
+
+    if (nhwc_depthwise) {
+      // NHWC depthwise convolution: input/output are channel-last, but the
+      // backend depthwise ops (depthwise_conv2d_fp32/fp16) and the generic
+      // grouped fallback below are all NCHW-planar (channel-major). Handle the
+      // channel-last layout inline here. Filter keeps the standard
+      // [out_ch, 1, fh, fw] layout, so channel c tap (kh,kw) is at
+      // filt[c*fh*fw + kh*fw + kw]. Accumulate in float for parity with the
+      // NCHW paths regardless of activation precision.
+      const unsigned int B = in_dim.batch();
+      const unsigned int C = filter_size; // channels (== groups)
+      const int IH = static_cast<int>(in_dim.height());
+      const int IW = static_cast<int>(in_dim.width());
+      const int OH = static_cast<int>(out_dim.height());
+      const int OW = static_cast<int>(out_dim.width());
+      const int sh = static_cast<int>(stride[0].get());
+      const int sw = static_cast<int>(stride[1].get());
+      const int ph = static_cast<int>(padding[0]);
+      const int pw = static_cast<int>(padding[2]);
+      const int dh = static_cast<int>(dilation[0].get());
+      const int dw_ = static_cast<int>(dilation[1].get());
+      const unsigned int fhfw = fh * fw;
+      const float *filt = filter_kernel.getData<float>();
+
+      auto run = [&]<typename T>(const T *in, T *out) {
+        std::vector<float> acc(C);
+        for (unsigned int b = 0; b < B; ++b) {
+          const T *inb = in + static_cast<size_t>(b) * IH * IW * C;
+          T *outb = out + static_cast<size_t>(b) * OH * OW * C;
+          for (int oh = 0; oh < OH; ++oh) {
+            for (int ow = 0; ow < OW; ++ow) {
+              std::fill(acc.begin(), acc.end(), 0.0f);
+              for (unsigned int kh = 0; kh < fh; ++kh) {
+                const int ih = oh * sh - ph + static_cast<int>(kh) * dh;
+                if (ih < 0 || ih >= IH)
+                  continue;
+                for (unsigned int kw = 0; kw < fw; ++kw) {
+                  const int iw = ow * sw - pw + static_cast<int>(kw) * dw_;
+                  if (iw < 0 || iw >= IW)
+                    continue;
+                  const T *id =
+                    inb + (static_cast<size_t>(ih) * IW + iw) * C;
+                  const float *fk = filt + kh * fw + kw;
+                  for (unsigned int c = 0; c < C; ++c)
+                    acc[c] += static_cast<float>(id[c]) *
+                              fk[static_cast<size_t>(c) * fhfw];
+                }
+              }
+              T *od = outb + (static_cast<size_t>(oh) * OW + ow) * C;
+              for (unsigned int c = 0; c < C; ++c)
+                od[c] = static_cast<T>(acc[c]);
+            }
+          }
+        }
+      };
+
+      if (in_dim.getDataType() == nntrainer::Tdatatype::FP32)
+        run(input_.getData<float>(), hidden_.getData<float>());
+#ifdef ENABLE_FP16
+      else
+        run(input_.getData<_FP16>(), hidden_.getData<_FP16>());
+#endif
+    } else if (is_true_depthwise &&
+        in_dim.getDataType() == nntrainer::Tdatatype::FP32) {
       // True depthwise (groups == channels): delegate to the CPU backend op so
       // the optimised kernel lives in the backend, not in the layer.
       nntrainer::getComputeOps()->depthwise_conv2d_fp32(
@@ -580,19 +1049,57 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
         in_dim.width(), out_dim.height(), out_dim.width(), fh, fw,
         stride[0].get(), stride[1].get(), padding[0], padding[2],
         dilation[0].get(), dilation[1].get());
+#ifdef ENABLE_FP16
+    } else if (is_true_depthwise &&
+               in_dim.getDataType() == nntrainer::Tdatatype::FP16 &&
+               hidden_.getDataType() == nntrainer::Tdatatype::FP16 &&
+               filter_kernel.getDataType() == nntrainer::Tdatatype::FP32) {
+      // FP16-activation depthwise: weights are never Q4_0 for groups>1 and stay
+      // FP32 (BN-folded), so this is FP16 input/output x FP32 kernel. Keep it
+      // on the tight channel-parallel direct-loop kernel instead of falling
+      // into the generic grouped else-branch (per-channel im2col + FP16 GEMV),
+      // which was ~2x slower for YOLOv11's detect-head depthwise convs.
+      nntrainer::getComputeOps()->depthwise_conv2d_fp16(
+        input_.getData<_FP16>(), filter_kernel.getData<float>(),
+        hidden_.getData<_FP16>(), in_dim.batch(), filter_size, in_dim.height(),
+        in_dim.width(), out_dim.height(), out_dim.width(), fh, fw,
+        stride[0].get(), stride[1].get(), padding[0], padding[2],
+        dilation[0].get(), dilation[1].get());
+#endif
     } else {
+      // getSharedDataTensor()/reshape() adopt the *passed* TensorDim's dtype
+      // (TensorBase::getSharedDataTensor: ret->dim = dim_). A bare {..} dim
+      // literal defaults to FP32, so on an FP16 activation graph every sub-view
+      // below would silently relabel FP16-backed storage as FP32 -- im2col
+      // would gather at the wrong precision and the dot would write 4-byte
+      // floats into 2-byte half storage (overflow / garbage). Carry each
+      // parent's real dtype onto its view. (For an all-FP32 graph these are
+      // no-ops, so the historical path is unchanged.)
+      const auto in_dt = input_.getDataType();
+      const auto filt_dt = filter_kernel.getDataType();
+      const auto out_dt = hidden_.getDataType();
       for (unsigned int b = 0; b < in_dim.batch(); ++b) {
         Tensor out = hidden_.getBatchSlice(b, 1);
-        out.reshape({filter_size, owoh});
+        TensorDim out_rdim({filter_size, owoh});
+        out_rdim.setDataType(out_dt);
+        out.reshape(out_rdim);
         Tensor in_sub = input_.getBatchSlice(b, 1);
-        Tensor result = Tensor(calcCol2ImOutputDim(out_dim, fdim_g));
+        TensorDim col_dim = calcCol2ImOutputDim(out_dim, fdim_g);
+        col_dim.setDataType(in_dt);
+        Tensor result = Tensor(col_dim);
         for (unsigned int g = 0; g < groups; ++g) {
-          Tensor in_g = in_sub.getSharedDataTensor(
-            {1, icg, in_dim.height(), in_dim.width()}, (size_t)g * icg * ihw);
+          TensorDim ing_dim({1, icg, in_dim.height(), in_dim.width()});
+          ing_dim.setDataType(in_dt);
+          Tensor in_g =
+            in_sub.getSharedDataTensor(ing_dim, (size_t)g * icg * ihw);
+          TensorDim filtg_dim({ocg, (size_t)icg * fh * fw});
+          filtg_dim.setDataType(filt_dt);
           Tensor filt_g = filter_kernel.getSharedDataTensor(
-            {ocg, (size_t)icg * fh * fw}, (size_t)g * ocg * icg * fh * fw);
+            filtg_dim, (size_t)g * ocg * icg * fh * fw);
+          TensorDim outg_dim({ocg, owoh});
+          outg_dim.setDataType(out_dt);
           Tensor out_g =
-            out.getSharedDataTensor({ocg, owoh}, (size_t)g * ocg * owoh);
+            out.getSharedDataTensor(outg_dim, (size_t)g * ocg * owoh);
           result.setZero();
           im2col(in_g, fdim_g, padding, stride, dilation, result);
           filt_g.dot(result, out_g, false, true);
@@ -605,10 +1112,66 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
   if (auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
       disable_bias.empty() || disable_bias.get() == false) {
     Tensor &bias_kernel = context.getWeight(wt_idx[ConvParams::bias]);
-    status = hidden_.add_i(bias_kernel);
-    if (status != ML_ERROR_NONE) {
-      throw std::invalid_argument("[Conv2D] adding bias failed");
+    if (hidden_.getFormat() == ml::train::TensorDim::Format::NCHW) {
+      status = hidden_.add_i(bias_kernel);
+      if (status != ML_ERROR_NONE) {
+        throw std::invalid_argument("[Conv2D] adding bias failed");
+      }
+    } else {
+      // NHWC: channel is innermost. bias [out_ch] must be added per (n,h,w,c).
+      // add_i assumes NCHW channel-major broadcast, so do it inline.
+      const unsigned int C = out_dim.channel();
+      const unsigned int HW = out_dim.height() * out_dim.width();
+      const unsigned int B = out_dim.batch();
+      if (hidden_.getDataType() == nntrainer::Tdatatype::FP32) {
+        float *d = hidden_.getData<float>();
+        const float *bias = bias_kernel.getData<float>();
+        for (unsigned int b = 0; b < B; ++b)
+          for (unsigned int p = 0; p < HW; ++p)
+            for (unsigned int c = 0; c < C; ++c)
+              d[((size_t)b * HW + p) * C + c] += bias[c];
+      }
+#ifdef ENABLE_FP16
+      else if (hidden_.getDataType() == nntrainer::Tdatatype::FP16) {
+        _FP16 *d = hidden_.getData<_FP16>();
+        const _FP16 *bias = bias_kernel.getData<_FP16>();
+        for (unsigned int b = 0; b < B; ++b)
+          for (unsigned int p = 0; p < HW; ++p)
+            for (unsigned int c = 0; c < C; ++c)
+              d[((size_t)b * HW + p) * C + c] += bias[c];
+      }
+#endif
     }
+  }
+
+  // Fused activation epilogue. When the graph sets activation=swish on the
+  // conv, apply SiLU in-place on the freshly written output instead of
+  // materializing a separate Activation layer (which would read the conv
+  // output back from memory and write a second full tensor). Only SiLU is
+  // fused here (YOLOv11's conv activation); any other activation type is left
+  // to a dedicated Activation layer in the graph.
+  if (auto &act = std::get<props::FusedActivation>(conv_props);
+      !act.empty() && act.get() == ActivationType::ACT_SWISH) {
+    const size_t n = hidden_.size();
+#ifdef ENABLE_FP16
+    if (hidden_.getDataType() == nntrainer::Tdatatype::FP16) {
+      convApplySwishInplace(hidden_.getData<_FP16>(), n);
+    } else
+#endif
+    {
+      convApplySwishInplace(hidden_.getData<float>(), n);
+    }
+  }
+
+  if (std::getenv("NNTR_CONV_PROBE") &&
+      context.getName() == "conv0/conv") {
+    std::cerr << "[CONV_PROBE] " << context.getName() << " format="
+              << (int)hidden_.getFormat() << " C=" << out_dim.channel()
+              << " H=" << out_dim.height() << " W=" << out_dim.width()
+              << std::endl;
+    const float *p = hidden_.getData<float>();
+    for (int i = 0; i < 8; ++i)
+      std::cerr << "  [" << i << "]=" << p[i] << std::endl;
   }
 }
 
@@ -770,10 +1333,83 @@ void Conv2DLayer::calcGradient(RunLayerContext &context) {
   }
 }
 
+void Conv2DLayer::setBatch(RunLayerContext &context, unsigned int batch) {
+  // The forward scratch buffers (im2col column buffer and quantized-GEMM
+  // output) are requested in finalize() sized to the batch present at init.
+  // When the runtime batch changes the framework resizes inputs/outputs but
+  // not these layer-private scratch tensors, so rebatch them here — otherwise
+  // forwarding()'s getBatchSlice(b, 1) for b >= the init batch reads past the
+  // planned storage and aborts ("shared tensor bigger than tensor memory").
+  if (wt_idx[ConvParams::im2col_scratch] !=
+      std::numeric_limits<unsigned int>::max())
+    context.updateTensor(wt_idx[ConvParams::im2col_scratch], batch);
+  if (wt_idx[ConvParams::qgemm_scratch] !=
+      std::numeric_limits<unsigned int>::max())
+    context.updateTensor(wt_idx[ConvParams::qgemm_scratch], batch);
+}
+
 void Conv2DLayer::exportTo(Exporter &exporter,
                            const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);
   exporter.saveResult(conv_props, method, this);
+}
+
+void Conv2DLayer::save(std::ofstream &file, RunLayerContext &run_context,
+                       bool opt_var, ml::train::ExecutionMode mode,
+                       bool trainable, ml::train::TensorDim::DataType dtype,
+                       ml::train::ISA target_isa) const {
+  // Optimizer-variable save (training only) has no conv-specific layout, so
+  // defer to the base implementation.
+  if (opt_var) {
+    Layer::save(file, run_context, opt_var, mode, trainable, dtype, target_isa);
+    return;
+  }
+
+  for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
+    if (!run_context.isGradientFirstAccess(i))
+      continue;
+
+    auto &weight = run_context.getWeight(i);
+
+    // No conversion requested, or already the target dtype: save as-is.
+    if (dtype == TensorDim::DataType::NONE || weight.getDataType() == dtype) {
+      weight.save(file);
+      continue;
+    }
+
+    NNTR_THROW_IF(dtype != TensorDim::DataType::Q4_0, std::runtime_error)
+      << "[Conv2D] save: unsupported quantization dtype";
+    NNTR_THROW_IF(weight.getDataType() != TensorDim::DataType::FP32,
+                  std::runtime_error)
+      << "[Conv2D] Q4_0 save only supports FP32 source weight.";
+
+    // A conv FP32 filter is [out_ch, in_ch, kh, kw] in NCHW, i.e. already
+    // row-major [out_ch, CRS] (CRS = in_ch*kh*kw) = [N rows, K cols]. This is
+    // exactly the layout quantize_q4_0 consumes (N rows of K), so no transpose
+    // is needed (the FC path in the base class transposes because its weight is
+    // stored [K, N]). The bias and any non-matmul weight (CRS == 1 or
+    // out_ch == 1) are kept FP32.
+    const TensorDim dim = weight.getDim();
+    const unsigned int out_ch = dim.batch();
+    const unsigned int CRS = dim.channel() * dim.height() * dim.width();
+
+    if (out_ch <= 1 || CRS <= 1 || out_ch % 32 != 0 || CRS % 32 != 0) {
+      // Not Q4_0-eligible (bias, or block-misaligned): keep FP32 so the saved
+      // tensor still matches what the runtime layer allocates for it.
+      weight.save(file);
+      continue;
+    }
+
+    // [1, 1, K=CRS, N=out_ch] is the matmul-weight shape the quantized conv
+    // consumes at load (Conv2DLayer::finalize builds the same shape).
+    Tensor quant_weight(1, 1, CRS, out_ch, {Tformat::NCHW, dtype});
+    std::vector<char> tmp(quant_weight.size());
+
+    quantize_q4_0(weight.getData<float>(), tmp.data(), out_ch, CRS, nullptr);
+    repack_q4_0(quant_weight.getData<uint8_t>(), tmp.data(),
+                quant_weight.size(), out_ch, CRS, target_isa);
+    quant_weight.save(file);
+  }
 }
 
 void Conv2DLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -97,7 +97,7 @@ static TensorDim calcCol2ImOutputDim(const TensorDim &out,
  * Q8_0_Tensor::dot / the indirect GEMM consumes (M=owoh, K=in_ch).
  */
 static inline void transpose_quantize_q8_0_act(const _FP16 *src, int in_ch,
-                                                int owoh, void *dst) {
+                                               int owoh, void *dst) {
   struct block_q8_0 {
     uint16_t d;
     int8_t qs[32];
@@ -117,8 +117,7 @@ static inline void transpose_quantize_q8_0_act(const _FP16 *src, int in_ch,
         float amax = 0.0f;
         for (int j = 0; j < qk; ++j) {
           int c = b * qk + j;
-          float val =
-            std::abs(static_cast<float>(src[c * owoh + r]));
+          float val = std::abs(static_cast<float>(src[c * owoh + r]));
           if (val > amax)
             amax = val;
         }
@@ -150,9 +149,8 @@ static inline void transpose_quantize_q8_0_act(const _FP16 *src, int in_ch,
  * tail. dst must hold the block_q8_0x4 region followed by the remainder
  * block_q8_0 region (same total as Q8_0_Tensor::dot's QA buffer).
  */
-static inline void
-transpose_quantize_q8_0x4_act(const _FP16 *src, int in_ch, int owoh,
-                               void *dst) {
+static inline void transpose_quantize_q8_0x4_act(const _FP16 *src, int in_ch,
+                                                 int owoh, void *dst) {
   struct block_q8_0 {
     uint16_t d;
     int8_t qs[32];
@@ -207,9 +205,8 @@ transpose_quantize_q8_0x4_act(const _FP16 *src, int in_ch, int owoh,
 
   // Remainder rows (owoh % 4): plain block_q8_0 for the GEMV tail.
   if (rem > 0) {
-    block_q8_0 *yrem =
-      reinterpret_cast<block_q8_0 *>(reinterpret_cast<char *>(dst) +
-                                     (size_t)M4 * qa_4_rows_size);
+    block_q8_0 *yrem = reinterpret_cast<block_q8_0 *>(
+      reinterpret_cast<char *>(dst) + (size_t)M4 * qa_4_rows_size);
     const unsigned int rchunk = 1024;
     const size_t rloops = (rem + rchunk - 1) / rchunk;
     tm.parallel_for(0, rloops, [=](size_t idx) {
@@ -453,8 +450,7 @@ static void im2col(const Tensor &in, const TensorDim &kdim,
     const size_t inHW = (size_t)in_height * (size_t)in_width;
     const bool unit_dil =
       ((unsigned int)dilation[0] == 1 && (unsigned int)dilation[1] == 1);
-    const bool is_nhwc =
-      (in.getFormat() == ml::train::TensorDim::Format::NHWC);
+    const bool is_nhwc = (in.getFormat() == ml::train::TensorDim::Format::NHWC);
 
     /// Each output row (oh) writes a disjoint band of `out_width` columns
     /// (rows [oh*out_width, (oh+1)*out_width) of the [OH*OW, CRS] matrix), so
@@ -802,8 +798,7 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
     // The quant 1x1 path (identity transpose) and the quant indirect path
     // (gather fused into the GEMM) requested no col buffer in finalize, so the
     // pointer stays null for them.
-    const bool use_im2col_scratch =
-      !(weight_is_quant && is_1x1_s1);
+    const bool use_im2col_scratch = !(weight_is_quant && is_1x1_s1);
     Tensor *col_scratch =
       use_im2col_scratch
         ? &context.getTensor(wt_idx[ConvParams::im2col_scratch])
@@ -824,47 +819,55 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
         if (weight_is_quant) {
           if (in_sub.getFormat() == ml::train::TensorDim::Format::NHWC) {
             // NHWC channel-last quantized convolution:
-            // Since physical layout is [owoh, filter_size], we reshape `out` to flat
-            // NCHW [1, 1, owoh, filter_size] and write directly, completely bypassing
-            // qgemm_scratch and transposes!
+            // Since physical layout is [owoh, filter_size], we reshape `out` to
+            // flat NCHW [1, 1, owoh, filter_size] and write directly,
+            // completely bypassing qgemm_scratch and transposes!
             Tensor out_flat = out;
-            out_flat.reshape(TensorDim(1, 1, owoh, filter_size, {ml::train::TensorDim::Format::NCHW, out.getDataType()}));
+            out_flat.reshape(TensorDim(
+              1, 1, owoh, filter_size,
+              {ml::train::TensorDim::Format::NCHW, out.getDataType()}));
 
             if (is_1x1_s1) {
               Tensor act = in_sub;
-              act.reshape(TensorDim(1, 1, owoh, in_dim.channel(), {ml::train::TensorDim::Format::NCHW, in_sub.getDataType()}));
+              act.reshape(TensorDim(
+                1, 1, owoh, in_dim.channel(),
+                {ml::train::TensorDim::Format::NCHW, in_sub.getDataType()}));
               act.dot(filter_kernel, out_flat, false, false);
             } else {
-              throw std::runtime_error("Fallback quantized NHWC conv is not supported (requires indirect conv on ARM).");
+              throw std::runtime_error(
+                "Fallback quantized NHWC conv is not supported (requires "
+                "indirect conv on ARM).");
             }
           } else {
             // Quantized conv as matmul: act [OH*OW, CRS] . weight [CRS, out_ch]
             // -> [OH*OW, out_ch] -> out [out_ch, OH*OW]. CRS = in_ch*kh*kw.
-            // NOTE: col must outlive `act` (act aliases col's storage); here col
-            // is a view into the context-owned scratch, so its storage outlives
-            // the loop iteration regardless.
+            // NOTE: col must outlive `act` (act aliases col's storage); here
+            // col is a view into the context-owned scratch, so its storage
+            // outlives the loop iteration regardless.
             Tensor tmp = qgemm_scratch->getBatchSlice(b, 1);
             tmp.reshape(
               TensorDim(1, 1, owoh, filter_size, in_sub.getTensorType()));
             if (is_1x1_s1) {
-              // 1x1 stride-1: im2col is an identity. The raw input is laid out as
-              // [in_ch, OH*OW] (NCHW), so transpose to the act layout [OH*OW,
-              // CRS] (CRS == in_ch here).
+              // 1x1 stride-1: im2col is an identity. The raw input is laid out
+              // as [in_ch, OH*OW] (NCHW), so transpose to the act layout
+              // [OH*OW, CRS] (CRS == in_ch here).
               in_sub.reshape({in_dim.channel(), owoh});
               Tensor act = in_sub.transpose("0:2:1");
               act.dot(filter_kernel, tmp, false, false);
             } else {
               // Fallback (no fused backend op): materialize im2col into the col
               // scratch, then the standard quant GEMM.
-              // build the real kernel geometry (filter is stored as [CRS,out_ch])
-              TensorDim kdim(filter_size, in_dim.channel(), kernel_size[0].get(),
-                             kernel_size[1].get(), in_sub.getTensorType());
+              // build the real kernel geometry (filter is stored as
+              // [CRS,out_ch])
+              TensorDim kdim(filter_size, in_dim.channel(),
+                             kernel_size[0].get(), kernel_size[1].get(),
+                             in_sub.getTensorType());
               Tensor col = col_scratch->getBatchSlice(b, 1);
               // im2col reshapes col in place to [OH*OW, CRS] (spatial-major),
               // which is ALREADY the act layout — no transpose (unlike the
-              // raw-input 1x1 branch above). Transposing here gives [CRS, OH*OW]
-              // and makes the GEMM emit CRS rows into the owoh-row `tmp`,
-              // overflowing it whenever CRS > owoh (deep convs) -> heap
+              // raw-input 1x1 branch above). Transposing here gives [CRS,
+              // OH*OW] and makes the GEMM emit CRS rows into the owoh-row
+              // `tmp`, overflowing it whenever CRS > owoh (deep convs) -> heap
               // corruption.
               im2col(in_sub, kdim, padding, stride, dilation, col);
               col.dot(filter_kernel, tmp, false, false);
@@ -888,11 +891,11 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
             // physical cells. Compute into a plain NCHW-order buffer (format
             // NCHW so dot writes channel-major), then scatter channel c of
             // spatial r to out[r*out_ch + c] (NHWC physical).
-            // Compute into a plain NCHW-order buffer (same result feeding as the
-            // NCHW path above — do NOT reshape result, im2col already laid it
-            // out as the dot expects). nchw_out is format NCHW so dot writes
-            // channel-major [out_ch, OH*OW]; then scatter channel c of spatial r
-            // to out[r*out_ch + c] (NHWC physical).
+            // Compute into a plain NCHW-order buffer (same result feeding as
+            // the NCHW path above — do NOT reshape result, im2col already laid
+            // it out as the dot expects). nchw_out is format NCHW so dot writes
+            // channel-major [out_ch, OH*OW]; then scatter channel c of spatial
+            // r to out[r*out_ch + c] (NHWC physical).
             auto nchw_type = out.getTensorType();
             nchw_type.format = ml::train::TensorDim::Format::NCHW;
             // nchw_out holds the GEMM result [out_ch, OH*OW] in channel-major
@@ -921,14 +924,14 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
             Tensor filt_nchw = Tensor::Map<float>(
               filter_kernel.getData<float>(), filter_kernel.bytes(), fdim_nchw);
             if (out.getDataType() == nntrainer::Tdatatype::FP32) {
-              Tensor col_nchw = Tensor::Map<float>(
-                result.getData<float>(), result.bytes(), cdim_nchw);
+              Tensor col_nchw = Tensor::Map<float>(result.getData<float>(),
+                                                   result.bytes(), cdim_nchw);
               filt_nchw.dot(col_nchw, nchw_out, false, true);
             }
 #ifdef ENABLE_FP16
             else {
-              Tensor col_nchw = Tensor::Map<_FP16>(
-                result.getData<_FP16>(), result.bytes(), cdim_nchw);
+              Tensor col_nchw = Tensor::Map<_FP16>(result.getData<_FP16>(),
+                                                   result.bytes(), cdim_nchw);
               filt_nchw.dot(col_nchw, nchw_out, false, true);
             }
 #endif
@@ -1017,8 +1020,7 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
                   const int iw = ow * sw - pw + static_cast<int>(kw) * dw_;
                   if (iw < 0 || iw >= IW)
                     continue;
-                  const T *id =
-                    inb + (static_cast<size_t>(ih) * IW + iw) * C;
+                  const T *id = inb + (static_cast<size_t>(ih) * IW + iw) * C;
                   const float *fk = filt + kh * fw + kw;
                   for (unsigned int c = 0; c < C; ++c)
                     acc[c] += static_cast<float>(id[c]) *
@@ -1040,7 +1042,7 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
         run(input_.getData<_FP16>(), hidden_.getData<_FP16>());
 #endif
     } else if (is_true_depthwise &&
-        in_dim.getDataType() == nntrainer::Tdatatype::FP32) {
+               in_dim.getDataType() == nntrainer::Tdatatype::FP32) {
       // True depthwise (groups == channels): delegate to the CPU backend op so
       // the optimised kernel lives in the backend, not in the layer.
       nntrainer::getComputeOps()->depthwise_conv2d_fp32(
@@ -1163,12 +1165,11 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
     }
   }
 
-  if (std::getenv("NNTR_CONV_PROBE") &&
-      context.getName() == "conv0/conv") {
-    std::cerr << "[CONV_PROBE] " << context.getName() << " format="
-              << (int)hidden_.getFormat() << " C=" << out_dim.channel()
-              << " H=" << out_dim.height() << " W=" << out_dim.width()
-              << std::endl;
+  if (std::getenv("NNTR_CONV_PROBE") && context.getName() == "conv0/conv") {
+    std::cerr << "[CONV_PROBE] " << context.getName()
+              << " format=" << (int)hidden_.getFormat()
+              << " C=" << out_dim.channel() << " H=" << out_dim.height()
+              << " W=" << out_dim.width() << std::endl;
     const float *p = hidden_.getData<float>();
     for (int i = 0; i < 8; ++i)
       std::cerr << "  [" << i << "]=" << p[i] << std::endl;

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -112,7 +112,7 @@ private:
   std::array<unsigned int, CONV2D_DIM * 2> padding;
   std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
              std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-             std::array<props::Dilation, CONV2D_DIM>>
+             std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups>
     conv_props;
 
   std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -74,11 +74,34 @@ public:
   void calcGradient(RunLayerContext &context) override;
 
   /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  void setBatch(RunLayerContext &context, unsigned int batch) override;
+
+  /**
    * @copydoc Layer::exportTo(Exporter &exporter, ml::train::ExportMethods
    * method)
    */
   void exportTo(Exporter &exporter,
                 const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::save(std::ofstream &file, RunLayerContext &run_context,
+   * bool opt_var, ml::train::ExecutionMode mode, bool trainable,
+   * TensorDim::DataType dtype, ml::train::ISA target_isa)
+   *
+   * @note Overridden so a conv filter can be quantized to Q4_0 as a matmul
+   * weight. The FP32 filter is stored [out_ch, in_ch, kh, kw], which is already
+   * row-major [out_ch, CRS] (CRS = in_ch*kh*kw) = [N, K] with N=out_ch rows of
+   * K=CRS — exactly the layout quantize_q4_0 wants, so (unlike the FC path in
+   * the base class) it needs no transpose. Ineligible filters (out_ch or CRS
+   * not 32-aligned) and the bias stay FP32.
+   */
+  void save(
+    std::ofstream &file, RunLayerContext &run_context, bool opt_var,
+    ml::train::ExecutionMode mode, bool trainable,
+    ml::train::TensorDim::DataType dtype = ml::train::TensorDim::DataType::NONE,
+    ml::train::ISA target_isa = ml::train::ISA::DEFAULT) const override;
 
   /**
    * @copydoc Layer::getType()
@@ -112,7 +135,8 @@ private:
   std::array<unsigned int, CONV2D_DIM * 2> padding;
   std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
              std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-             std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups>
+             std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups,
+             props::FusedActivation>
     conv_props;
 
   std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -338,6 +338,71 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
   NNTR_THROW_IF(output.empty(), std::invalid_argument)
     << "[Pooling2D] output is uninitialized, this is not supported";
 
+  const bool is_nhwc = in.getFormat() == Tformat::NHWC && output.getFormat() == Tformat::NHWC;
+  if (is_nhwc) {
+    if (pooling_type == props::PoolingTypeInfo::Enum::max) {
+      auto run_nhwc = [&]<typename T>() {
+        const T *in_data = in.getData<T>();
+        T *out_data = output.getData<T>();
+        const int Ho = (int)output.height(), Wo = (int)output.width();
+        const int Hi = in_height, Wi = in_width;
+        const int Co = channel;
+        const int sh = stride[0].get(), sw = stride[1].get();
+        const int ph = patch_height, pw = patch_width;
+        const int pt_val = pt, pl_val = pl;
+
+        auto job = [&](unsigned int oh_start, unsigned int oh_end, unsigned int, void *) {
+          for (int oh = (int)oh_start; oh < (int)oh_end; ++oh) {
+            for (int ow = 0; ow < Wo; ++ow) {
+              T *out_ptr = out_data + (size_t)(oh * Wo + ow) * Co;
+              for (int c = 0; c < Co; ++c) {
+                out_ptr[c] = std::numeric_limits<T>::lowest();
+              }
+              const int h0 = oh * sh - pt_val;
+              const int w0 = ow * sw - pl_val;
+              for (int kh = 0; kh < ph; ++kh) {
+                const int ih = h0 + kh;
+                if (ih < 0 || ih >= Hi)
+                  continue;
+                for (int kw = 0; kw < pw; ++kw) {
+                  const int iw = w0 + kw;
+                  if (iw < 0 || iw >= Wi)
+                    continue;
+                  const T *in_ptr = in_data + (size_t)(ih * Wi + iw) * Co;
+                  for (int c = 0; c < Co; ++c) {
+                    if (in_ptr[c] > out_ptr[c]) {
+                      out_ptr[c] = in_ptr[c];
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        if (!training) {
+          auto workers = ParallelBatch(job, Ho, nullptr);
+          if (workers.getNumWorkers() > 1) {
+            workers.run();
+            return;
+          }
+        }
+        job(0, Ho, 0, nullptr);
+      };
+
+      if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+        run_nhwc.template operator()<float>();
+        return;
+      }
+#ifdef ENABLE_FP16
+      else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+        run_nhwc.template operator()<_FP16>();
+        return;
+      }
+#endif
+    }
+  }
+
   /**
    * @brief pooling function
    * @param in_c channel sliced data

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -339,7 +339,8 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
   NNTR_THROW_IF(output.empty(), std::invalid_argument)
     << "[Pooling2D] output is uninitialized, this is not supported";
 
-  const bool is_nhwc = in.getFormat() == Tformat::NHWC && output.getFormat() == Tformat::NHWC;
+  const bool is_nhwc =
+    in.getFormat() == Tformat::NHWC && output.getFormat() == Tformat::NHWC;
   if (is_nhwc) {
     if (pooling_type == props::PoolingTypeInfo::Enum::max) {
       auto run_nhwc = [&]<typename T>() {
@@ -352,7 +353,8 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
         const int ph = patch_height, pw = patch_width;
         const int pt_val = pt, pl_val = pl;
 
-        auto job = [&](unsigned int oh_start, unsigned int oh_end, unsigned int, void *) {
+        auto job = [&](unsigned int oh_start, unsigned int oh_end, unsigned int,
+                       void *) {
           for (int oh = (int)oh_start; oh < (int)oh_end; ++oh) {
             for (int ow = 0; ow < Wo; ++ow) {
               T *out_ptr = out_data + (size_t)(oh * Wo + ow) * Co;

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -103,6 +103,7 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
                 std::invalid_argument)
     << "[Pooling2D] Failed to initialize: Calculated patch end is over int max";
 
+  out_dim.setFormat(in_dim.getFormat());
   out_dim.batch(in_dim.batch());
   out_dim.channel(in_dim.channel());
   out_dim.height((eff_in_height - pool_size[0]) / stride[0] + 1);

--- a/nntrainer/layers/slice_layer.cpp
+++ b/nntrainer/layers/slice_layer.cpp
@@ -108,6 +108,50 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
     return;
   }
 
+  const bool can_fast_nhwc =
+    input.getContiguous() && output.getContiguous() &&
+    input.getFormat() == Tformat::NHWC && output.getFormat() == Tformat::NHWC;
+  if (can_fast_nhwc) {
+    const T *in = input.getData<T>();
+    T *out = output.getData<T>();
+    const unsigned int B = output.batch();
+    const unsigned int Co = output.channel(), Ci = input.channel();
+    const unsigned int Ho = output.height(), Hi = input.height();
+    const unsigned int Wo = output.width(),  Wi = input.width();
+    const size_t elt = sizeof(T);
+    const size_t in_hwc = (size_t)Hi * Wi * Ci;
+    const size_t out_hwc = (size_t)Ho * Wo * Co;
+
+    if (axis == 0) {
+      for (unsigned int b = 0; b < B; ++b)
+        std::memcpy(out + (size_t)b * out_hwc,
+                    in + (size_t)(b + start) * in_hwc, out_hwc * elt);
+    } else if (axis == 1) {
+      for (unsigned int b = 0; b < B; ++b) {
+        for (unsigned int hw = 0; hw < Ho * Wo; ++hw) {
+          std::memcpy(out + (b * Ho * Wo + hw) * Co,
+                      in + (b * Hi * Wi + hw) * Ci + start,
+                      Co * elt);
+        }
+      }
+    } else if (axis == 2) {
+      for (unsigned int b = 0; b < B; ++b) {
+        std::memcpy(out + b * Ho * Wo * Co,
+                    in + b * Hi * Wi * Ci + start * Wi * Ci,
+                    Ho * Wi * Co * elt);
+      }
+    } else if (axis == 3) {
+      for (unsigned int b = 0; b < B; ++b) {
+        for (unsigned int h = 0; h < Ho; ++h) {
+          std::memcpy(out + (b * Ho + h) * Wo * Co,
+                      in + (b * Hi + h) * Wi * Ci + start * Ci,
+                      Wo * Co * elt);
+        }
+      }
+    }
+    return;
+  }
+
   for (unsigned int b = 0; b < output.batch(); ++b) {
     for (unsigned int c = 0; c < output.channel(); ++c) {
       for (unsigned int h = 0; h < output.height(); ++h) {

--- a/nntrainer/layers/slice_layer.cpp
+++ b/nntrainer/layers/slice_layer.cpp
@@ -60,9 +60,9 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
   // Per-axis, the largest contiguous run that maps 1:1 is:
   //   axis=0 -> [C*H*W] per b, axis=1 -> [H*W] per (b,c),
   //   axis=2 -> [W] per (b,c,h),     axis=3 -> [W] per (b,c,h) (w innermost).
-  const bool can_fast =
-    input.getContiguous() && output.getContiguous() &&
-    input.getFormat() == Tformat::NCHW && output.getFormat() == Tformat::NCHW;
+  const bool can_fast = input.getContiguous() && output.getContiguous() &&
+                        input.getFormat() == Tformat::NCHW &&
+                        output.getFormat() == Tformat::NCHW;
   if (can_fast) {
     const T *in = input.getData<T>();
     T *out = output.getData<T>();
@@ -82,10 +82,9 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
     } else if (axis == 1) {
       for (unsigned int b = 0; b < B; ++b)
         for (unsigned int c = 0; c < C; ++c)
-          std::memcpy(
-            out + (size_t)b * plane_b + (size_t)c * plane_c,
-            in + (size_t)b * plane_b + (size_t)(c + start) * plane_c,
-            plane_c * elt);
+          std::memcpy(out + (size_t)b * plane_b + (size_t)c * plane_c,
+                      in + (size_t)b * plane_b + (size_t)(c + start) * plane_c,
+                      plane_c * elt);
     } else if (axis == 2) {
       for (unsigned int b = 0; b < B; ++b)
         for (unsigned int c = 0; c < C; ++c)
@@ -108,16 +107,16 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
     return;
   }
 
-  const bool can_fast_nhwc =
-    input.getContiguous() && output.getContiguous() &&
-    input.getFormat() == Tformat::NHWC && output.getFormat() == Tformat::NHWC;
+  const bool can_fast_nhwc = input.getContiguous() && output.getContiguous() &&
+                             input.getFormat() == Tformat::NHWC &&
+                             output.getFormat() == Tformat::NHWC;
   if (can_fast_nhwc) {
     const T *in = input.getData<T>();
     T *out = output.getData<T>();
     const unsigned int B = output.batch();
     const unsigned int Co = output.channel(), Ci = input.channel();
     const unsigned int Ho = output.height(), Hi = input.height();
-    const unsigned int Wo = output.width(),  Wi = input.width();
+    const unsigned int Wo = output.width(), Wi = input.width();
     const size_t elt = sizeof(T);
     const size_t in_hwc = (size_t)Hi * Wi * Ci;
     const size_t out_hwc = (size_t)Ho * Wo * Co;
@@ -130,8 +129,7 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
       for (unsigned int b = 0; b < B; ++b) {
         for (unsigned int hw = 0; hw < Ho * Wo; ++hw) {
           std::memcpy(out + (b * Ho * Wo + hw) * Co,
-                      in + (b * Hi * Wi + hw) * Ci + start,
-                      Co * elt);
+                      in + (b * Hi * Wi + hw) * Ci + start, Co * elt);
         }
       }
     } else if (axis == 2) {
@@ -144,8 +142,7 @@ static void sliceForwardT(const Tensor &input, Tensor &output,
       for (unsigned int b = 0; b < B; ++b) {
         for (unsigned int h = 0; h < Ho; ++h) {
           std::memcpy(out + (b * Ho + h) * Wo * Co,
-                      in + (b * Hi + h) * Wi * Ci + start * Ci,
-                      Wo * Co * elt);
+                      in + (b * Hi + h) * Wi * Ci + start * Ci, Wo * Co * elt);
         }
       }
     }

--- a/nntrainer/layers/slice_layer.cpp
+++ b/nntrainer/layers/slice_layer.cpp
@@ -33,9 +33,9 @@ void SliceLayer::finalize(InitLayerContext &context) {
 
   for (unsigned int i = 0; i < 4; ++i) {
     if (i == axis) {
-      outputDim[i] = end - start;
+      outputDim.setTensorDim(i, end - start);
     } else {
-      outputDim[i] = in_dim[i];
+      outputDim.setTensorDim(i, in_dim[i]);
     }
   }
 

--- a/nntrainer/layers/slice_layer.cpp
+++ b/nntrainer/layers/slice_layer.cpp
@@ -19,6 +19,8 @@
 #include <stdexcept>
 #include <util_func.h>
 
+#include <cstring>
+
 #include <layer_context.h>
 
 namespace nntrainer {
@@ -42,8 +44,69 @@ void SliceLayer::finalize(InitLayerContext &context) {
   context.setOutputDimensions({outputDim});
 }
 
-void SliceLayer::forwarding_operation(const Tensor &input, Tensor &output) {
-  TensorDim outputDim = output.getDim();
+/**
+ * @brief dtype-correct element copy for the slice. getValue()/setValue()
+ * default to T=float, so on an FP16 tensor a float read reinterprets two 2-byte
+ * halves as one 4-byte float (and indexes at 2x stride) -> garbage. Dispatch on
+ * the actual tensor dtype so the copy stays element-correct for any precision.
+ */
+template <typename T>
+static void sliceForwardT(const Tensor &input, Tensor &output,
+                          unsigned int axis, unsigned int start) {
+  // Fast path: contiguous NCHW. The slice only shifts one axis by `start`, so
+  // every output plane out[b,c,h,w] == in[b, c+c0, h+h0, w+w0] — the same
+  // element mapping as the scalar loop below, just copied as contiguous runs
+  // (memcpy) instead of element-by-element. Bit-identical to the scalar path.
+  // Per-axis, the largest contiguous run that maps 1:1 is:
+  //   axis=0 -> [C*H*W] per b, axis=1 -> [H*W] per (b,c),
+  //   axis=2 -> [W] per (b,c,h),     axis=3 -> [W] per (b,c,h) (w innermost).
+  const bool can_fast =
+    input.getContiguous() && output.getContiguous() &&
+    input.getFormat() == Tformat::NCHW && output.getFormat() == Tformat::NCHW;
+  if (can_fast) {
+    const T *in = input.getData<T>();
+    T *out = output.getData<T>();
+    const unsigned int B = output.batch();
+    const unsigned int C = output.channel();
+    const unsigned int H = output.height();
+    const unsigned int W = output.width();
+    // element counts of each axis plane in NCHW (contiguous)
+    const size_t plane_b = (size_t)C * H * W; // [C*H*W]
+    const size_t plane_c = (size_t)H * W;     // [H*W]
+    const size_t row_hw = (size_t)W;          // [W]
+    const size_t elt = sizeof(T);
+    if (axis == 0) {
+      for (unsigned int b = 0; b < B; ++b)
+        std::memcpy(out + (size_t)b * plane_b,
+                    in + (size_t)(b + start) * plane_b, plane_b * elt);
+    } else if (axis == 1) {
+      for (unsigned int b = 0; b < B; ++b)
+        for (unsigned int c = 0; c < C; ++c)
+          std::memcpy(
+            out + (size_t)b * plane_b + (size_t)c * plane_c,
+            in + (size_t)b * plane_b + (size_t)(c + start) * plane_c,
+            plane_c * elt);
+    } else if (axis == 2) {
+      for (unsigned int b = 0; b < B; ++b)
+        for (unsigned int c = 0; c < C; ++c)
+          for (unsigned int h = 0; h < H; ++h)
+            std::memcpy(
+              out + ((size_t)b * plane_b + (size_t)c * plane_c + (size_t)h * W),
+              in + ((size_t)b * plane_b + (size_t)c * plane_c +
+                    (size_t)(h + start) * W),
+              row_hw * elt);
+    } else { // axis == 3 (w innermost) -> same [W] run per (b,c,h)
+      for (unsigned int b = 0; b < B; ++b)
+        for (unsigned int c = 0; c < C; ++c)
+          for (unsigned int h = 0; h < H; ++h)
+            std::memcpy(
+              out + ((size_t)b * plane_b + (size_t)c * plane_c + (size_t)h * W),
+              in + ((size_t)b * plane_b + (size_t)c * plane_c + (size_t)h * W +
+                    (size_t)start),
+              row_hw * elt);
+    }
+    return;
+  }
 
   for (unsigned int b = 0; b < output.batch(); ++b) {
     for (unsigned int c = 0; c < output.channel(); ++c) {
@@ -52,7 +115,36 @@ void SliceLayer::forwarding_operation(const Tensor &input, Tensor &output) {
           unsigned int c_idx = (axis == 1) ? c + start : c;
           unsigned int h_idx = (axis == 2) ? h + start : h;
           unsigned int w_idx = (axis == 3) ? w + start : w;
-          output.setValue(b, c, h, w, input.getValue(b, c_idx, h_idx, w_idx));
+          output.getValue<T>(b, c, h, w) =
+            input.getValue<T>(b, c_idx, h_idx, w_idx);
+        }
+      }
+    }
+  }
+}
+
+void SliceLayer::forwarding_operation(const Tensor &input, Tensor &output) {
+#ifdef ENABLE_FP16
+  if (output.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    sliceForwardT<_FP16>(input, output, axis, start);
+    return;
+  }
+#endif
+  sliceForwardT<float>(input, output, axis, start);
+}
+
+template <typename T>
+static void sliceDerivT(const Tensor &inDeriv, Tensor &outDeriv,
+                        unsigned int axis, unsigned int start) {
+  for (unsigned int b = 0; b < inDeriv.batch(); ++b) {
+    for (unsigned int c = 0; c < inDeriv.channel(); ++c) {
+      for (unsigned int h = 0; h < inDeriv.height(); ++h) {
+        for (unsigned int w = 0; w < inDeriv.width(); ++w) {
+          unsigned int c_idx = (axis == 1) ? c + start : c;
+          unsigned int h_idx = (axis == 2) ? h + start : h;
+          unsigned int w_idx = (axis == 3) ? w + start : w;
+          outDeriv.getValue<T>(b, c_idx, h_idx, w_idx) =
+            inDeriv.getValue<T>(b, c, h, w);
         }
       }
     }
@@ -63,19 +155,13 @@ void SliceLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &inDeriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &outDeriv = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
 
-  for (unsigned int b = 0; b < inDeriv.batch(); ++b) {
-    for (unsigned int c = 0; c < inDeriv.channel(); ++c) {
-      for (unsigned int h = 0; h < inDeriv.height(); ++h) {
-        for (unsigned int w = 0; w < inDeriv.width(); ++w) {
-          unsigned int c_idx = (axis == 1) ? c + start : c;
-          unsigned int h_idx = (axis == 2) ? h + start : h;
-          unsigned int w_idx = (axis == 3) ? w + start : w;
-          outDeriv.setValue(b, c_idx, h_idx, w_idx,
-                            inDeriv.getValue(b, c, h, w));
-        }
-      }
-    }
+#ifdef ENABLE_FP16
+  if (outDeriv.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    sliceDerivT<_FP16>(inDeriv, outDeriv, axis, start);
+    return;
   }
+#endif
+  sliceDerivT<float>(inDeriv, outDeriv, axis, start);
 }
 
 void SliceLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/upsample2d_layer.cpp
+++ b/nntrainer/layers/upsample2d_layer.cpp
@@ -15,6 +15,8 @@
 #include <node_exporter.h>
 #include <upsample2d_layer.h>
 
+#include <cstring>
+
 namespace nntrainer {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
@@ -53,7 +55,53 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
     std::get<std::array<props::KernelSize, UPSAMPLE2D_DIM>>(upsample2d_props);
 
   switch (upsampling_type) {
-  case props::UpsampleModeInfo::Interpolation::nearest:
+  case props::UpsampleModeInfo::Interpolation::nearest: {
+    // Fast path: contiguous NCHW. nearest upsample maps
+    // out[b,c, kh*ih+ry, kw*iw+rx] = in[b,c,ih,iw] for ry in [0,kh), rx in
+    // [0,kw). Same element mapping as the scalar loop below, written per
+    // output row: each input row ih feeds kh output rows, and within a row
+    // each input element is repeated kw times. Bit-identical to the scalar
+    // path.
+    const unsigned int kh = kernel_size[0].get();
+    const unsigned int kw = kernel_size[1].get();
+    const bool can_fast =
+      in.getContiguous() && out.getContiguous() &&
+      in.getFormat() == Tformat::NCHW && out.getFormat() == Tformat::NCHW;
+    if (can_fast) {
+      const T *in_d = in.getData<T>();
+      T *out_d = out.getData<T>();
+      const unsigned int B = out.batch();
+      const unsigned int C = out.channel();
+      const unsigned int iH = in.height();
+      const unsigned int iW = in.width();
+      const unsigned int oW = out.width(); // == iW * kw
+      const size_t in_plane = (size_t)iH * iW;   // [H*W] per (b,c)
+      const size_t out_plane = (size_t)iH * kh * oW; // [oH*oW] per (b,c)
+      // scratch row for the kw-expanded output row (reused per input row)
+      std::vector<T> expanded(oW);
+      for (unsigned int b = 0; b < B; ++b) {
+        for (unsigned int c = 0; c < C; ++c) {
+          const T *in_bc = in_d + (size_t)b * C * in_plane + (size_t)c * in_plane;
+          T *out_bc = out_d + (size_t)b * C * out_plane + (size_t)c * out_plane;
+          for (unsigned int ih = 0; ih < iH; ++ih) {
+            const T *in_row = in_bc + (size_t)ih * iW;
+            // expand in_row[iW] -> expanded[iW*kw], each elt repeated kw
+            T *e = expanded.data();
+            for (unsigned int iw = 0; iw < iW; ++iw) {
+              const T v = in_row[iw];
+              for (unsigned int rx = 0; rx < kw; ++rx)
+                e[iw * kw + rx] = v;
+            }
+            // write the expanded row into the kh output rows it feeds
+            for (unsigned int ry = 0; ry < kh; ++ry) {
+              T *out_row = out_bc + (size_t)(ih * kh + ry) * oW;
+              std::memcpy(out_row, e, oW * sizeof(T));
+            }
+          }
+        }
+      }
+      break;
+    }
     for (int b = 0; b < (int)out.batch(); b++) {
       for (int c = 0; c < (int)out.channel(); c++) {
         for (int h = 0; h < (int)out.height(); h++) {
@@ -65,7 +113,7 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
         }
       }
     }
-    break;
+  } break;
   case props::UpsampleModeInfo::Interpolation::bilinear: {
     float scale_h = (float)kernel_size[0];
     float scale_w = (float)kernel_size[1];

--- a/nntrainer/layers/upsample2d_layer.cpp
+++ b/nntrainer/layers/upsample2d_layer.cpp
@@ -66,9 +66,9 @@ static void upsampleForwardT(
     // path.
     const unsigned int kh = kernel_size[0].get();
     const unsigned int kw = kernel_size[1].get();
-    const bool can_fast =
-      in.getContiguous() && out.getContiguous() &&
-      in.getFormat() == Tformat::NCHW && out.getFormat() == Tformat::NCHW;
+    const bool can_fast = in.getContiguous() && out.getContiguous() &&
+                          in.getFormat() == Tformat::NCHW &&
+                          out.getFormat() == Tformat::NCHW;
     if (can_fast) {
       const T *in_d = in.getData<T>();
       T *out_d = out.getData<T>();
@@ -76,14 +76,15 @@ static void upsampleForwardT(
       const unsigned int C = out.channel();
       const unsigned int iH = in.height();
       const unsigned int iW = in.width();
-      const unsigned int oW = out.width(); // == iW * kw
-      const size_t in_plane = (size_t)iH * iW;   // [H*W] per (b,c)
+      const unsigned int oW = out.width();           // == iW * kw
+      const size_t in_plane = (size_t)iH * iW;       // [H*W] per (b,c)
       const size_t out_plane = (size_t)iH * kh * oW; // [oH*oW] per (b,c)
       // scratch row for the kw-expanded output row (reused per input row)
       std::vector<T> expanded(oW);
       for (unsigned int b = 0; b < B; ++b) {
         for (unsigned int c = 0; c < C; ++c) {
-          const T *in_bc = in_d + (size_t)b * C * in_plane + (size_t)c * in_plane;
+          const T *in_bc =
+            in_d + (size_t)b * C * in_plane + (size_t)c * in_plane;
           T *out_bc = out_d + (size_t)b * C * out_plane + (size_t)c * out_plane;
           for (unsigned int ih = 0; ih < iH; ++ih) {
             const T *in_row = in_bc + (size_t)ih * iW;
@@ -99,48 +100,48 @@ static void upsampleForwardT(
               T *out_row = out_bc + (size_t)(ih * kh + ry) * oW;
               std::memcpy(out_row, e, oW * sizeof(T));
             }
-            }
-            }
-            }
-            return;
-            }
+          }
+        }
+      }
+      return;
+    }
 
-            const bool can_fast_nhwc =
-            in.getContiguous() && out.getContiguous() &&
-            in.getFormat() == Tformat::NHWC && out.getFormat() == Tformat::NHWC;
-            if (can_fast_nhwc) {
-            const T *in_d = in.getData<T>();
-            T *out_d = out.getData<T>();
-            const unsigned int B = out.batch();
-            const unsigned int Co = out.channel();
-            const unsigned int iH = in.height();
-            const unsigned int iW = in.width();
-            const unsigned int oH = out.height();
-            const unsigned int oW = out.width();
-            const size_t in_hwc = (size_t)iH * iW * Co;
-            const size_t out_hwc = (size_t)oH * oW * Co;
+    const bool can_fast_nhwc = in.getContiguous() && out.getContiguous() &&
+                               in.getFormat() == Tformat::NHWC &&
+                               out.getFormat() == Tformat::NHWC;
+    if (can_fast_nhwc) {
+      const T *in_d = in.getData<T>();
+      T *out_d = out.getData<T>();
+      const unsigned int B = out.batch();
+      const unsigned int Co = out.channel();
+      const unsigned int iH = in.height();
+      const unsigned int iW = in.width();
+      const unsigned int oH = out.height();
+      const unsigned int oW = out.width();
+      const size_t in_hwc = (size_t)iH * iW * Co;
+      const size_t out_hwc = (size_t)oH * oW * Co;
 
-            std::vector<T> expanded(oW * Co);
-            for (unsigned int b = 0; b < B; ++b) {
-            const T *in_b = in_d + b * in_hwc;
-            T *out_b = out_d + b * out_hwc;
-            for (unsigned int ih = 0; ih < iH; ++ih) {
-            const T *in_row = in_b + (size_t)ih * iW * Co;
-            T *e = expanded.data();
-            for (unsigned int iw = 0; iw < iW; ++iw) {
+      std::vector<T> expanded(oW * Co);
+      for (unsigned int b = 0; b < B; ++b) {
+        const T *in_b = in_d + b * in_hwc;
+        T *out_b = out_d + b * out_hwc;
+        for (unsigned int ih = 0; ih < iH; ++ih) {
+          const T *in_row = in_b + (size_t)ih * iW * Co;
+          T *e = expanded.data();
+          for (unsigned int iw = 0; iw < iW; ++iw) {
             const T *v = in_row + iw * Co;
             for (unsigned int rx = 0; rx < kw; ++rx) {
               std::memcpy(e + (iw * kw + rx) * Co, v, Co * sizeof(T));
             }
-            }
-            for (unsigned int ry = 0; ry < kh; ++ry) {
+          }
+          for (unsigned int ry = 0; ry < kh; ++ry) {
             T *out_row = out_b + (size_t)(ih * kh + ry) * oW * Co;
             std::memcpy(out_row, e, oW * Co * sizeof(T));
-            }
-            }
-            }
-            return;
-            }
+          }
+        }
+      }
+      return;
+    }
     for (int b = 0; b < (int)out.batch(); b++) {
       for (int c = 0; c < (int)out.channel(); c++) {
         for (int h = 0; h < (int)out.height(); h++) {

--- a/nntrainer/layers/upsample2d_layer.cpp
+++ b/nntrainer/layers/upsample2d_layer.cpp
@@ -44,16 +44,18 @@ void Upsample2dLayer::finalize(nntrainer::InitLayerContext &context) {
   context.setOutputDimensions(dim);
 }
 
-void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
-                                 bool training) {
-  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
-  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
-
-  const auto &upsampling_type =
-    std::get<props::UpsampleMode>(upsample2d_props).get();
-  const auto &kernel_size =
-    std::get<std::array<props::KernelSize, UPSAMPLE2D_DIM>>(upsample2d_props);
-
+/**
+ * @brief dtype-correct upsample forwarding. getValue()/setValue() default to
+ * T=float, so on an FP16 tensor a float read reinterprets two 2-byte halves as
+ * one 4-byte float (and indexes at 2x stride) -> garbage. Dispatch on the
+ * actual tensor dtype so element access stays correct for any precision. The
+ * bilinear interpolation math is carried out in float regardless of storage.
+ */
+template <typename T>
+static void upsampleForwardT(
+  const Tensor &in, Tensor &out,
+  props::UpsampleModeInfo::Interpolation upsampling_type,
+  const std::array<props::KernelSize, UPSAMPLE2D_DIM> &kernel_size) {
   switch (upsampling_type) {
   case props::UpsampleModeInfo::Interpolation::nearest: {
     // Fast path: contiguous NCHW. nearest upsample maps
@@ -97,18 +99,54 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
               T *out_row = out_bc + (size_t)(ih * kh + ry) * oW;
               std::memcpy(out_row, e, oW * sizeof(T));
             }
-          }
-        }
-      }
-      break;
-    }
+            }
+            }
+            }
+            return;
+            }
+
+            const bool can_fast_nhwc =
+            in.getContiguous() && out.getContiguous() &&
+            in.getFormat() == Tformat::NHWC && out.getFormat() == Tformat::NHWC;
+            if (can_fast_nhwc) {
+            const T *in_d = in.getData<T>();
+            T *out_d = out.getData<T>();
+            const unsigned int B = out.batch();
+            const unsigned int Co = out.channel();
+            const unsigned int iH = in.height();
+            const unsigned int iW = in.width();
+            const unsigned int oH = out.height();
+            const unsigned int oW = out.width();
+            const size_t in_hwc = (size_t)iH * iW * Co;
+            const size_t out_hwc = (size_t)oH * oW * Co;
+
+            std::vector<T> expanded(oW * Co);
+            for (unsigned int b = 0; b < B; ++b) {
+            const T *in_b = in_d + b * in_hwc;
+            T *out_b = out_d + b * out_hwc;
+            for (unsigned int ih = 0; ih < iH; ++ih) {
+            const T *in_row = in_b + (size_t)ih * iW * Co;
+            T *e = expanded.data();
+            for (unsigned int iw = 0; iw < iW; ++iw) {
+            const T *v = in_row + iw * Co;
+            for (unsigned int rx = 0; rx < kw; ++rx) {
+              std::memcpy(e + (iw * kw + rx) * Co, v, Co * sizeof(T));
+            }
+            }
+            for (unsigned int ry = 0; ry < kh; ++ry) {
+            T *out_row = out_b + (size_t)(ih * kh + ry) * oW * Co;
+            std::memcpy(out_row, e, oW * Co * sizeof(T));
+            }
+            }
+            }
+            return;
+            }
     for (int b = 0; b < (int)out.batch(); b++) {
       for (int c = 0; c < (int)out.channel(); c++) {
         for (int h = 0; h < (int)out.height(); h++) {
           for (int w = 0; w < (int)out.width(); w++) {
-            out.setValue(
-              b, c, h, w,
-              in.getValue(b, c, h / kernel_size[0], w / kernel_size[1]));
+            out.getValue<T>(b, c, h, w) =
+              in.getValue<T>(b, c, h / kernel_size[0], w / kernel_size[1]);
           }
         }
       }
@@ -140,12 +178,14 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
             float dx = x_in - x0;
             float dy = y_in - y0;
 
-            float top = (1.0f - dx) * in.getValue(b, c, y1, x0) +
-                        dx * in.getValue(b, c, y1, x1);
-            float bottom = (1.0f - dx) * in.getValue(b, c, y0, x0) +
-                           dx * in.getValue(b, c, y0, x1);
+            float top =
+              (1.0f - dx) * static_cast<float>(in.getValue<T>(b, c, y1, x0)) +
+              dx * static_cast<float>(in.getValue<T>(b, c, y1, x1));
+            float bottom =
+              (1.0f - dx) * static_cast<float>(in.getValue<T>(b, c, y0, x0)) +
+              dx * static_cast<float>(in.getValue<T>(b, c, y0, x1));
             float v = (1.0f - dy) * bottom + dy * top;
-            out.setValue(b, c, h, w, v);
+            out.getValue<T>(b, c, h, w) = static_cast<T>(v);
           }
         }
       }
@@ -154,6 +194,25 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
   default:
     throw std::runtime_error("Error: Unknown Upsample Mode Type");
   }
+}
+
+void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
+                                 bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+
+  const auto &upsampling_type =
+    std::get<props::UpsampleMode>(upsample2d_props).get();
+  const auto &kernel_size =
+    std::get<std::array<props::KernelSize, UPSAMPLE2D_DIM>>(upsample2d_props);
+
+#ifdef ENABLE_FP16
+  if (out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    upsampleForwardT<_FP16>(in, out, upsampling_type, kernel_size);
+    return;
+  }
+#endif
+  upsampleForwardT<float>(in, out, upsampling_type, kernel_size);
 }
 
 void Upsample2dLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,6 +524,19 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+  // TODO: NEON specialization
+  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
+                                   in_w, out_h, out_w, kh, kw, stride_h,
+                                   stride_w, pad_top, pad_left, dilation_h,
+                                   dilation_w);
+}
+
 template <>
 void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
                      int num_rows, int num_cache_head, int head_dim,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,17 +524,18 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w) {
   // TODO: NEON specialization
-  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
-                                   in_w, out_h, out_w, kh, kw, stride_h,
-                                   stride_w, pad_top, pad_left, dilation_h,
-                                   dilation_w);
+  __fallback_depthwise_conv2d_fp32(
+    input, kernel, output, batch, channels, in_h, in_w, out_h, out_w, kh, kw,
+    stride_h, stride_w, pad_top, pad_left, dilation_h, dilation_w);
 }
 
 template <>

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1386,12 +1386,14 @@ void clamp(const T *input, T *output, size_t length,
  *        TODO: NEON specialization.
  *        See fallback_internal.h for full parameter documentation.
  */
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w);
 
 /**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1381,6 +1381,19 @@ void clamp(const T *input, T *output, size_t length,
            T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Depthwise convolution FP32 (ARM backend).
+ *        Correctness path delegates to __fallback_depthwise_conv2d_fp32.
+ *        TODO: NEON specialization.
+ *        See fallback_internal.h for full parameter documentation.
+ */
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,6 +151,14 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
+void ComputeOps::depthwise_conv2d_fp32(
+  const float *, const float *, float *, unsigned int, unsigned int,
+  unsigned int, unsigned int, unsigned int, unsigned int, unsigned int,
+  unsigned int, unsigned int, unsigned int, unsigned int, unsigned int,
+  unsigned int, unsigned int) {
+  NI(depthwise_conv2d_fp32);
+}
+
 void ComputeOps::scopy_u8(unsigned int, const uint8_t *, unsigned int,
                           uint8_t *, unsigned int) {
   NI(scopy_u8);

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,11 +151,12 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
-void ComputeOps::depthwise_conv2d_fp32(
-  const float *, const float *, float *, unsigned int, unsigned int,
-  unsigned int, unsigned int, unsigned int, unsigned int, unsigned int,
-  unsigned int, unsigned int, unsigned int, unsigned int, unsigned int,
-  unsigned int, unsigned int) {
+void ComputeOps::depthwise_conv2d_fp32(const float *, const float *, float *,
+                                       unsigned int, unsigned int, unsigned int,
+                                       unsigned int, unsigned int, unsigned int,
+                                       unsigned int, unsigned int, unsigned int,
+                                       unsigned int, unsigned int, unsigned int,
+                                       unsigned int, unsigned int) {
   NI(depthwise_conv2d_fp32);
 }
 

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -129,6 +129,23 @@ public:
                                      float *dst, unsigned int ld_dst);
 
   // ===========================================================================
+  // FP32 Convolution ops
+  // ===========================================================================
+  /**
+   * @brief Depthwise convolution FP32.
+   *        Input  : [batch, channels, in_h,  in_w ] contiguous NCHW.
+   *        Kernel : [channels, 1, kh, kw]  — channel c at kernel + c*kh*kw.
+   *        Output : [batch, channels, out_h, out_w] contiguous NCHW.
+   *        No bias (added by the caller afterward).
+   */
+  virtual void depthwise_conv2d_fp32(
+    const float *input, const float *kernel, float *output, unsigned int batch,
+    unsigned int channels, unsigned int in_h, unsigned int in_w,
+    unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+    unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+    unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
+  // ===========================================================================
   // FP32 Data conversion / Copy
   // ===========================================================================
   virtual void scopy_u8(const unsigned int N, const uint8_t *X,

--- a/nntrainer/tensor/cpu_backend/conv_indirect.h
+++ b/nntrainer/tensor/cpu_backend/conv_indirect.h
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   conv_indirect.h
+ * @date   25 June 2026
+ * @brief  Indirect (im2col-fused) convolution activation gather.
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @bug    No known bugs except for NaN or Inf
+ *
+ * @details This header provides a single pure-C++ gather primitive used by the
+ * indirect quantized convolution path: instead of materializing the full FP32
+ * im2col column buffer and feeding it to the GEMM, the GEMM's activation packer
+ * gathers each row tile directly from the NCHW input on demand. The gather is
+ * factored here (platform-agnostic, no SIMD/backend dependency) so it can be
+ * verified bit-identically against a naive im2col reference on every platform,
+ * independent of the ARM-only quantize/GEMM micro-kernels that consume it.
+ */
+
+#ifndef __NNTR_CONV_INDIRECT_H__
+#define __NNTR_CONV_INDIRECT_H__
+
+#include <cstddef>
+#include <cstring>
+
+#include <tensor_dim.h> // for _FP16 (defined under ENABLE_FP16)
+
+namespace nntrainer {
+
+/**
+ * @brief Geometry describing one conv layer's im2col gather.
+ *
+ * Mirrors the parameters Conv2DLayer feeds to im2col(). out_w is carried so a
+ * flat output-spatial row index m can be split into (oh, ow) = (m / out_w,
+ * m % out_w). K (the gathered row length) is in_ch * k_h * k_w.
+ */
+struct ConvGatherParams {
+  int in_ch;    /**< input channels */
+  int in_h;     /**< input height */
+  int in_w;     /**< input width */
+  int k_h;      /**< kernel height */
+  int k_w;      /**< kernel width */
+  int pad_t;    /**< top padding */
+  int pad_l;    /**< left padding */
+  int stride_h; /**< vertical stride */
+  int stride_w; /**< horizontal stride */
+  int dil_h;    /**< vertical dilation */
+  int dil_w;    /**< horizontal dilation */
+  int out_w;    /**< output width (maps row index -> output column) */
+  bool is_nhwc = false;
+};
+
+/**
+ * @brief Gather nrows im2col activation rows into a contiguous buffer.
+ *
+ * Reproduces im2col's [OH*OW, CRS] layout exactly for the row range
+ * [m0, m0 + nrows): output-spatial row m maps to (oh, ow) = (m / out_w,
+ * m % out_w); within a row the K = in_ch*k_h*k_w values are laid out as
+ * [channel][k_h][k_w]; positions falling outside the input (padding) are
+ * written as 0. The destination is fully written, so no pre-zeroing is needed.
+ *
+ * Templated over the activation element type so the same byte-identical gather
+ * serves the FP32 indirect-conv path (float, gathered tile feeds the FP32-input
+ * Q8_0 quantizer) and the FP16 indirect-conv path (_FP16, tile feeds the
+ * FP16-input Q8_0 quantizer __ggml_quantize_*_q8_0(const _FP16*)). Padding is
+ * zero-initialised via memset typed to sizeof(T), so FP16 padding is +0.0 too.
+ *
+ * @param[out] dst   buffer of nrows*K elements of type T, fully overwritten
+ * @param[in]  in    batch-sliced contiguous NCHW input base pointer (type T)
+ * @param[in]  p     gather geometry
+ * @param[in]  m0    first output-spatial row to gather
+ * @param[in]  nrows number of rows to gather
+ */
+template <typename T>
+inline void gather_conv_act_rows(T *dst, const T *in, const ConvGatherParams &p,
+                                 int m0, int nrows) {
+  const int K = p.in_ch * p.k_h * p.k_w;
+  const long inHW = (long)p.in_h * (long)p.in_w;
+  const bool unit_dil = (p.dil_h == 1 && p.dil_w == 1);
+  const int khkw = p.k_h * p.k_w;
+
+  for (int r = 0; r < nrows; ++r) {
+    const int m = m0 + r;
+    const int oh = m / p.out_w;
+    const int ow = m % p.out_w;
+    T *row = dst + (long)r * K;
+    /// every K element is written below for unit dilation only along valid
+    /// runs, so zero the row up front: padding positions stay 0 (matches
+    /// im2col). sizeof(T) so FP16 padding is +0.0 just like FP32.
+    std::memset(row, 0, (size_t)K * sizeof(T));
+
+    const int h0 = oh * p.stride_h - p.pad_t;
+    const int w0 = ow * p.stride_w - p.pad_l;
+
+    if (p.is_nhwc) {
+      for (int kh = 0; kh < p.k_h; ++kh) {
+        const int h = h0 + kh * p.dil_h;
+        if (h < 0 || h >= p.in_h)
+          continue;
+        for (int kw = 0; kw < p.k_w; ++kw) {
+          const int w = w0 + kw * p.dil_w;
+          if (w < 0 || w >= p.in_w)
+            continue;
+          const T *in_ptr = in + (long)(h * p.in_w + w) * p.in_ch;
+          for (int c = 0; c < p.in_ch; ++c) {
+            row[c * khkw + kh * p.k_w + kw] = in_ptr[c];
+          }
+        }
+      }
+    } else {
+      for (int c = 0; c < p.in_ch; ++c) {
+        const T *in_c = in + (long)c * inHW;
+        T *row_c = row + (long)c * khkw;
+        for (int kh = 0; kh < p.k_h; ++kh) {
+          const int h = h0 + kh * p.dil_h;
+          if (h < 0 || h >= p.in_h)
+            continue; /// whole kernel row is outside the input -> left as 0
+          const T *in_row = in_c + (long)h * p.in_w;
+          T *dst_run = row_c + (long)kh * p.k_w;
+          if (unit_dil) {
+            /// the kernel-width window maps a contiguous input run to a
+            /// contiguous dest run: copy the in-bounds span in one memcpy.
+            int wlo = w0 < 0 ? 0 : w0;
+            int whi = w0 + p.k_w;
+            if (whi > p.in_w)
+              whi = p.in_w;
+            if (whi > wlo)
+              std::memcpy(dst_run + (wlo - w0), in_row + wlo,
+                          (size_t)(whi - wlo) * sizeof(T));
+          } else {
+            for (int kw = 0; kw < p.k_w; ++kw) {
+              const int w = w0 + kw * p.dil_w;
+              if (w >= 0 && w < p.in_w)
+                dst_run[kw] = in_row[w];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief FP32 gather (legacy named entry; alias of the template instantiation).
+ *
+ * Kept as a concrete non-template function so existing FP32-indirect-conv
+ * call sites (gemm_q4_0_indirect_conv_fp32 ->
+ * __ggml_q4_0_4x8_q8_0_indirect_GEMM) keep their symbol and address-takability.
+ */
+inline void gather_conv_act_rows_fp32(float *dst, const float *in,
+                                      const ConvGatherParams &p, int m0,
+                                      int nrows) {
+  gather_conv_act_rows<float>(dst, in, p, m0, nrows);
+}
+
+#ifdef ENABLE_FP16
+/**
+ * @brief FP16 gather for the FP16-activation indirect-conv path.
+ *
+ * Identical layout to gather_conv_act_rows_fp32 but _FP16 typed, so the
+ * gathered tile feeds __ggml_quantize_row_q8_0(const _FP16*, ...) /
+ * __ggml_quantize_mat_q8_0_4x8(const _FP16*, ...) directly without an FP32
+ * staging copy — preserving the indirect path's no-col-materialization memory
+ * win for FP16 activations too.
+ */
+inline void gather_conv_act_rows_fp16(_FP16 *dst, const _FP16 *in,
+                                      const ConvGatherParams &p, int m0,
+                                      int nrows) {
+  gather_conv_act_rows<_FP16>(dst, in, p, m0, nrows);
+}
+#endif
+
+/**
+ * @brief Pre-quantized Q8_0 gather for the Q8_0-activation indirect-conv path.
+ *
+ * Gathers pre-quantized block_q8_0 blocks from the Q8_0 input tensor and
+ * interleaves them directly into the block_q8_0x4 format expected by the SMMLA
+ * GEMM kernel. Bypasses all FP16 dequantization and Q8_0 re-quantization,
+ * executing as a pure byte-copy (memcpy) operation.
+ */
+inline void gather_conv_act_rows_q8_0(void *vy, const void *vx,
+                                      const ConvGatherParams &p, int m0,
+                                      int nrows) {
+  struct local_block_q8_0 {
+    uint16_t d;
+    int8_t qs[32];
+  };
+
+  struct local_block_q8_0x4 {
+    uint16_t d[4];
+    int8_t qs[128];
+  };
+
+  const local_block_q8_0 *in = (const local_block_q8_0 *)vx;
+  local_block_q8_0x4 *y = (local_block_q8_0x4 *)vy;
+
+  const int ch_blocks = p.in_ch / 32;
+  const int blocks_per_row = p.k_h * p.k_w * ch_blocks;
+
+  const int hstride = p.stride_h;
+  const int wstride = p.stride_w;
+
+  for (int b_idx = 0; b_idx < blocks_per_row; ++b_idx) {
+    int khkw_idx = b_idx / ch_blocks;
+    int cb = b_idx % ch_blocks;
+    int kh = khkw_idx / p.k_w;
+    int kw = khkw_idx % p.k_w;
+
+    local_block_q8_0x4 &dst_block = y[b_idx];
+
+    // block_q8_0x4.qs[128] layout expected by nntr_gemm_q4_0_4x8_q8_0_fp16:
+    //   qs[32*j + 8*row + lane], j=8-element chunk (0..3), row=0..3, lane=0..7.
+    // (matches __ggml_quantize_mat_q8_0_4x8 and Q8_0_Tensor::dot interleave.)
+    // Each source plain block_q8_0 row holds qs[32*j + lane]; scatter its 8
+    // lanes per (j,row) into the interleaved dst — do NOT write row-contiguous.
+    for (int r = 0; r < 4; ++r) {
+      if (r >= nrows) {
+        dst_block.d[r] = 0;
+        for (int j = 0; j < 4; ++j)
+          std::memset(&dst_block.qs[32 * j + 8 * r], 0, 8);
+        continue;
+      }
+
+      const int m = m0 + r;
+      const int oh = m / p.out_w;
+      const int ow = m % p.out_w;
+
+      const int h = oh * hstride - p.pad_t + kh * p.dil_h;
+      const int w = ow * wstride - p.pad_l + kw * p.dil_w;
+
+      if (h >= 0 && h < p.in_h && w >= 0 && w < p.in_w) {
+        const local_block_q8_0 &src_block = in[(h * p.in_w + w) * ch_blocks + cb];
+        dst_block.d[r] = src_block.d;
+        for (int j = 0; j < 4; ++j)
+          std::memcpy(&dst_block.qs[32 * j + 8 * r], &src_block.qs[8 * j], 8);
+      } else {
+        dst_block.d[r] = 0;
+        for (int j = 0; j < 4; ++j)
+          std::memset(&dst_block.qs[32 * j + 8 * r], 0, 8);
+      }
+    }
+  }
+}
+
+/**
+ * @brief Pre-quantized Q8_0 gather for single row (leftover / remainder).
+ *
+ * Gathers a single row of pre-quantized block_q8_0 blocks from the Q8_0 input
+ * tensor without interleaving. Used by remainder rows in GEMV computation.
+ */
+inline void gather_conv_act_rows_q8_0_single(void *vy, const void *vx,
+                                             const ConvGatherParams &p, int m) {
+  struct local_block_q8_0 {
+    uint16_t d;
+    int8_t qs[32];
+  };
+
+  const local_block_q8_0 *in = (const local_block_q8_0 *)vx;
+  local_block_q8_0 *y = (local_block_q8_0 *)vy;
+
+  const int ch_blocks = p.in_ch / 32;
+  const int blocks_per_row = p.k_h * p.k_w * ch_blocks;
+
+  const int hstride = p.stride_h;
+  const int wstride = p.stride_w;
+
+  const int oh = m / p.out_w;
+  const int ow = m % p.out_w;
+
+  const int h0 = oh * hstride - p.pad_t;
+  const int w0 = ow * wstride - p.pad_l;
+
+  for (int b_idx = 0; b_idx < blocks_per_row; ++b_idx) {
+    int khkw_idx = b_idx / ch_blocks;
+    int cb = b_idx % ch_blocks;
+    int kh = khkw_idx / p.k_w;
+    int kw = khkw_idx % p.k_w;
+
+    const int h = h0 + kh * p.dil_h;
+    const int w = w0 + kw * p.dil_w;
+
+    if (h >= 0 && h < p.in_h && w >= 0 && w < p.in_w) {
+      y[b_idx] = in[(h * p.in_w + w) * ch_blocks + cb];
+    } else {
+      y[b_idx].d = 0;
+      std::memset(y[b_idx].qs, 0, 32);
+    }
+  }
+}
+
+} // namespace nntrainer
+
+#endif /* __NNTR_CONV_INDIRECT_H__ */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1482,6 +1482,20 @@ extern void clamp(const T *input, T *output, size_t length,
                   T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Depthwise convolution FP32 backend op.
+ *        Input  : [batch, channels, in_h,  in_w ] contiguous NCHW.
+ *        Kernel : [channels, 1, kh, kw]  — channel c at kernel + c*kh*kw.
+ *        Output : [batch, channels, out_h, out_w] contiguous NCHW.
+ *        No bias (added by the caller afterward).
+ */
+extern void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -123,6 +123,20 @@ public:
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
 
+  // FP32 Convolution
+  void depthwise_conv2d_fp32(
+    const float *input, const float *kernel, float *output, unsigned int batch,
+    unsigned int channels, unsigned int in_h, unsigned int in_w,
+    unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+    unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+    unsigned int pad_left, unsigned int dilation_h,
+    unsigned int dilation_w) override {
+    nntrainer::depthwise_conv2d_fp32(input, kernel, output, batch, channels,
+                                    in_h, in_w, out_h, out_w, kh, kw, stride_h,
+                                    stride_w, pad_top, pad_left, dilation_h,
+                                    dilation_w);
+  }
+
   // FP32 Data conversion / Copy
   void scopy_u8(unsigned int N, const uint8_t *X, unsigned int iX, uint8_t *Y,
                 unsigned int iY) override {

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -124,17 +124,18 @@ public:
   }
 
   // FP32 Convolution
-  void depthwise_conv2d_fp32(
-    const float *input, const float *kernel, float *output, unsigned int batch,
-    unsigned int channels, unsigned int in_h, unsigned int in_w,
-    unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-    unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-    unsigned int pad_left, unsigned int dilation_h,
-    unsigned int dilation_w) override {
-    nntrainer::depthwise_conv2d_fp32(input, kernel, output, batch, channels,
-                                    in_h, in_w, out_h, out_w, kh, kw, stride_h,
-                                    stride_w, pad_top, pad_left, dilation_h,
-                                    dilation_w);
+  void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                             float *output, unsigned int batch,
+                             unsigned int channels, unsigned int in_h,
+                             unsigned int in_w, unsigned int out_h,
+                             unsigned int out_w, unsigned int kh,
+                             unsigned int kw, unsigned int stride_h,
+                             unsigned int stride_w, unsigned int pad_top,
+                             unsigned int pad_left, unsigned int dilation_h,
+                             unsigned int dilation_w) override {
+    nntrainer::depthwise_conv2d_fp32(
+      input, kernel, output, batch, channels, in_h, in_w, out_h, out_w, kh, kw,
+      stride_h, stride_w, pad_top, pad_left, dilation_h, dilation_w);
   }
 
   // FP32 Data conversion / Copy

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -379,6 +379,18 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   __fallback_clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
+                                   in_w, out_h, out_w, kh, kw, stride_h,
+                                   stride_w, pad_top, pad_left, dilation_h,
+                                   dilation_w);
+}
+
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {
   __fallback_create_q4_0_weights(int4_weight, q4_0_weight);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -379,16 +379,17 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   __fallback_clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
-  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
-                                   in_w, out_h, out_w, kh, kw, stride_h,
-                                   stride_w, pad_top, pad_left, dilation_h,
-                                   dilation_w);
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w) {
+  __fallback_depthwise_conv2d_fp32(
+    input, kernel, output, batch, channels, in_h, in_w, out_h, out_w, kh, kw,
+    stride_h, stride_w, pad_top, pad_left, dilation_h, dilation_w);
 }
 
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1306,6 +1306,19 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief Depthwise convolution FP32 free function (fallback backend).
+ *        Delegates to __fallback_depthwise_conv2d_fp32.
+ *        See fallback_internal.h for full parameter documentation.
+ */
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
 } /* namespace nntrainer */
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1312,12 +1312,14 @@ void clamp(const T *input, T *output, size_t length,
  *        Delegates to __fallback_depthwise_conv2d_fp32.
  *        See fallback_internal.h for full parameter documentation.
  */
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w);
 
 } /* namespace nntrainer */
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -24,6 +24,7 @@
 #include <q4_0_utils.h>
 #include <stdexcept>
 #include <tensor_dim.h>
+#include <thread_manager.h>
 #include <util_func.h>
 
 #define sgemv_loop(ci, cj, cM, cN)                                             \
@@ -1265,6 +1266,47 @@ void __fallback_gemm_qs8d32p_qs4c32p_packed(size_t m, size_t n, size_t k,
                                             bool transB, float lower_bound,
                                             float upper_bound) {
   throw std::runtime_error("NYI : __fallback_gemm_qs8d32p_qs4c32p_packed");
+}
+
+void __fallback_depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+  // Scalar depthwise conv — reproduces the fast path from conv2d_layer.cpp.
+  // Layout: input/output are NCHW contiguous; kernel is [C,1,kh,kw].
+  // Parallelized over (batch*channels) via the nntr thread manager (the same
+  // primitive ggml_interface_omp uses), so each channel's small convolution
+  // runs independently — this preserves the channel-parallel speedup the old
+  // in-layer ParallelBatch fast path had.
+  // TODO: NEON/AVX inner-loop specialization in the arch backends.
+  auto &tm = ThreadManager::Global();
+  tm.parallel_for(0, (size_t)batch * channels, [&](size_t bc) {
+    const unsigned int c = (unsigned int)(bc % channels);
+    const float *inc = input + bc * in_h * in_w;
+    const float *fc = kernel + (size_t)c * kh * kw;
+    float *outc = output + bc * out_h * out_w;
+    for (unsigned int oh = 0; oh < out_h; ++oh) {
+      const int ih0 = (int)oh * (int)stride_h - (int)pad_top;
+      for (unsigned int ow = 0; ow < out_w; ++ow) {
+        const int iw0 = (int)ow * (int)stride_w - (int)pad_left;
+        float acc = 0.0f;
+        for (unsigned int ki = 0; ki < kh; ++ki) {
+          const int ih = ih0 + (int)ki * (int)dilation_h;
+          if (ih < 0 || ih >= (int)in_h)
+            continue;
+          for (unsigned int kj = 0; kj < kw; ++kj) {
+            const int iw = iw0 + (int)kj * (int)dilation_w;
+            if (iw < 0 || iw >= (int)in_w)
+              continue;
+            acc += inc[(size_t)ih * in_w + iw] * fc[ki * kw + kj];
+          }
+        }
+        outc[(size_t)oh * out_w + ow] = acc;
+      }
+    }
+  });
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1246,6 +1246,38 @@ void __fallback_create_q4_0_weights(const uint8_t *int4_weight,
                                     uint8_t *q4_0_weight);
 
 /**
+ * @brief Depthwise convolution (groups == channels) scalar kernel.
+ *        Input  : [batch, channels, in_h,  in_w ] contiguous NCHW.
+ *        Kernel : [channels, 1, kh, kw]  — channel c at kernel + c*kh*kw.
+ *        Output : [batch, channels, out_h, out_w] contiguous NCHW.
+ *        No bias (added by the caller layer afterward).
+ *
+ * @param input      FP32 input data
+ * @param kernel     FP32 filter data
+ * @param output     FP32 output data
+ * @param batch      batch size
+ * @param channels   number of channels (== groups)
+ * @param in_h       input height
+ * @param in_w       input width
+ * @param out_h      output height
+ * @param out_w      output width
+ * @param kh         kernel height
+ * @param kw         kernel width
+ * @param stride_h   stride along height
+ * @param stride_w   stride along width
+ * @param pad_top    top padding
+ * @param pad_left   left padding
+ * @param dilation_h dilation along height
+ * @param dilation_w dilation along width
+ */
+void __fallback_depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
+/**
  * @brief Transform data from in-memory layout osv32_isv2 to block_q4_0x8 or
  * block_q4_0x4 (for ARM backend) in-memory layout.
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,6 +506,19 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+  // TODO: AVX specialization
+  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
+                                   in_w, out_h, out_w, kh, kw, stride_h,
+                                   stride_w, pad_top, pad_left, dilation_h,
+                                   dilation_w);
+}
+
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {
   nntrainer::avx2::create_q4_0_weights(int4_weight, q4_0_weight);
 }

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,17 +506,18 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w) {
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w) {
   // TODO: AVX specialization
-  __fallback_depthwise_conv2d_fp32(input, kernel, output, batch, channels, in_h,
-                                   in_w, out_h, out_w, kh, kw, stride_h,
-                                   stride_w, pad_top, pad_left, dilation_h,
-                                   dilation_w);
+  __fallback_depthwise_conv2d_fp32(
+    input, kernel, output, batch, channels, in_h, in_w, out_h, out_w, kh, kw,
+    stride_h, stride_w, pad_top, pad_left, dilation_h, dilation_w);
 }
 
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1223,12 +1223,14 @@ void clamp(const T *input, T *output, size_t length,
  *        TODO: AVX specialization.
  *        See fallback_internal.h for full parameter documentation.
  */
-void depthwise_conv2d_fp32(
-  const float *input, const float *kernel, float *output, unsigned int batch,
-  unsigned int channels, unsigned int in_h, unsigned int in_w,
-  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
-  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
-  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+void depthwise_conv2d_fp32(const float *input, const float *kernel,
+                           float *output, unsigned int batch,
+                           unsigned int channels, unsigned int in_h,
+                           unsigned int in_w, unsigned int out_h,
+                           unsigned int out_w, unsigned int kh, unsigned int kw,
+                           unsigned int stride_h, unsigned int stride_w,
+                           unsigned int pad_top, unsigned int pad_left,
+                           unsigned int dilation_h, unsigned int dilation_w);
 
 /**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1218,6 +1218,19 @@ void clamp(const T *input, T *output, size_t length,
            T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Depthwise convolution FP32 (x86 backend).
+ *        Correctness path delegates to __fallback_depthwise_conv2d_fp32.
+ *        TODO: AVX specialization.
+ *        See fallback_internal.h for full parameter documentation.
+ */
+void depthwise_conv2d_fp32(
+  const float *input, const float *kernel, float *output, unsigned int batch,
+  unsigned int channels, unsigned int in_h, unsigned int in_w,
+  unsigned int out_h, unsigned int out_w, unsigned int kh, unsigned int kw,
+  unsigned int stride_h, unsigned int stride_w, unsigned int pad_top,
+  unsigned int pad_left, unsigned int dilation_h, unsigned int dilation_w);
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -909,12 +909,7 @@ void Manager::flushCacheExcept(unsigned int order) {
 void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
                                  unsigned int end) {
   if (enable_optimizations) {
-    if (exec_mode == ExecutionMode::INFERENCE && enable_fsu) {
-      //@todo change V3 and validate
-      pool.finalize(OptimizedV1Planner(), start, end);
-    } else {
-      pool.finalize(OptimizedV1Planner(), start, end);
-    }
+    pool.finalize(OptimizedV3Planner(), start, end);
   } else {
     pool.finalize(BasicPlanner(), start, end);
   }

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -199,10 +199,22 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
                    std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-                   std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups>
-    &props,
+                   std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups,
+                   props::FusedActivation> &props,
   const Conv2DLayer *self) {
   createIfNull(tf_node);
+
+  // ConvGroups may be unset for plain conv layers (defaults to 1). Treat empty
+  // as 1 rather than throwing on property access — matches Conv2DLayer's own
+  // usage (conv2d_layer.cpp). Only explicitly-configured groups > 1 is rejected
+  // below, since TFLite CONV_2D has no groups field.
+  auto &groups_prop = std::get<props::ConvGroups>(props);
+  unsigned int groups = groups_prop.empty() ? 1 : groups_prop.get();
+  if (groups > 1) {
+    throw std::runtime_error(
+      "[Conv2DLayer] TFLite export does not support grouped convolution "
+      "(groups > 1). TFLite CONV_2D has no groups field; use groups=1.");
+  }
 
   auto weight_transform = [](std::vector<const Tensor *> &old_weights) {
     std::vector<Tensor> new_weights;

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -199,7 +199,8 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
                    std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-                   std::array<props::Dilation, CONV2D_DIM>> &props,
+                   std::array<props::Dilation, CONV2D_DIM>, props::ConvGroups>
+    &props,
   const Conv2DLayer *self) {
   createIfNull(tf_node);
 

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -333,7 +333,7 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, 2>,
                    std::array<props::Stride, 2>, props::Padding2D,
-                   std::array<props::Dilation, 2>> &props,
+                   std::array<props::Dilation, 2>, props::ConvGroups> &props,
   const Conv2DLayer *self);
 
 class InputLayer;

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -240,6 +240,7 @@ class InPlaceDirectionProp;
 class Exponent;
 class StartIndex;
 class EndIndex;
+class FusedActivation;
 } // namespace props
 
 class LayerNode;
@@ -333,7 +334,8 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, 2>,
                    std::array<props::Stride, 2>, props::Padding2D,
-                   std::array<props::Dilation, 2>, props::ConvGroups> &props,
+                   std::array<props::Dilation, 2>, props::ConvGroups,
+                   props::FusedActivation> &props,
   const Conv2DLayer *self);
 
 class InputLayer;

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -880,3 +880,26 @@ LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
+
+# unittest_nntrainer_q8_0_tensor
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_nntrainer_q8_0_tensor
+LOCAL_CFLAGS := -Igoogletest/include -I../include -pthread -fexceptions -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 $(ARM_MARCH_FLAGS) -O3 -frtti -DENABLE_FP16=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS        := -llog -landroid
+
+LOCAL_SRC_FILES := \
+    ../unittest/unittest_nntrainer_q8_0_tensor.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+
+ifeq ($(MESON_ENABLE_OPENCL), 1)
+LOCAL_SHARED_LIBRARIES += opencl
+LOCAL_STATIC_LIBRARIES += clblast
+endif
+
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
It's not a causal lm but I've added it to CausalLm directory because we'll rename that to Quick.AI

## Summary
- Add C2PSA, SliceLayer fix, and grouped conv (groups) support for YOLOv11m
- Fix BN weight corruption on safetensors load (read_from_offset flag dropped)
- Verified FP32 output matches PyTorch reference (peak memory ~348 MB on Android)

## Verification
**PyTorch (ref_detections_cat.json):**
{"x1": -0.20458984375,   "y1": 138.49560546875,  "x2": 373.96881103515625, "y2": 691.6968994140625,  "conf": 0.938709020614624,    "cls": 0}
{"x1": 457.798583984375, "y1": 138.36346435546875,"x2": 832.3084716796875,  "y2": 691.9259033203125,  "conf": 0.9246845841407776,   "cls": 0}

**nntrainer (device 실행):**
{"x1": -0.20459, "y1": 138.496, "x2": 373.969, "y2": 691.697, "conf": 0.938709, "cls": 0}
{"x1": 457.799,  "y1": 138.363, "x2": 832.308, "y2": 691.926, "conf": 0.924685, "cls": 0}

## How to run
### Weight Conversion
```
python Applications/CausalLM/models/YOLOv11/PyTorch/convert_weights.py \
  --weights v11m_832rect_best.pt \
  --out Applications/CausalLM/models/YOLOv11/res/yolov11m.safetensors
```
### Android Build
```
cd <nntrainer-bench>/yolov11_android_build
ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk \
  NDK_APPLICATION_MK=jni/Application.mk
```
### Run on Device
```
adb push libs/arm64-v8a/* /data/local/tmp/yolo/
adb push res/yolov11m.safetensors res/input_cat.bin /data/local/tmp/yolo/res/
adb shell "LD_LIBRARY_PATH=/data/local/tmp/yolo \
  /data/local/tmp/yolo/yolov11_infer /data/local/tmp/yolo/res"
```
### Output
```
[
  {"x1": -0.20459, "y1": 138.496, "x2": 373.969, "y2": 691.697, "conf": 0.938709, "cls": 0},
  {"x1": 457.799,  "y1": 138.363, "x2": 832.308, "y2": 691.926, "conf": 0.924685, "cls": 0}
]
```

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>