### PR TITLE
fix(causallm): hold split multi-byte UTF-8 tokens during streaming

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -41,6 +41,7 @@
 
 #include <causal_lm.h>
 #include <llm_util.hpp>
+#include <utf8_stream_util.h>
 
 namespace causallm {
 
@@ -233,9 +234,7 @@ void CausalLM::registerOutputs(
       if (std::find(puncts.begin(), puncts.end(), decoded_str.back()) !=
           puncts.end()) {
         // last symbol is a punctuation, hold on
-      } else if (decoded_str.size() >= 3 &&
-                 decoded_str.compare(decoded_str.size() - 3, 3, "") == 0) {
-        // ends with an incomplete token, hold on
+      } else if (utf8stream::shouldHold(decoded_str, pending_ids_.size())) {
       } else {
         if (log_output) {
           std::cout << decoded_str;

--- a/Applications/CausalLM/utf8_stream_util.h
+++ b/Applications/CausalLM/utf8_stream_util.h
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   utf8_stream_util.h
+ * @brief  Helpers for holding incomplete multi-byte UTF-8 characters during
+ *         streaming detokenization.
+ * @date   24 June 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Joonseok Oh <jrock.oh@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * A multi-byte UTF-8 character (e.g. a Korean syllable like '똻', 3 bytes) can
+ * be generated as several consecutive byte-fallback tokens. Decoding only a
+ * prefix of those tokens yields either incomplete raw bytes (native BPE) or a
+ * trailing U+FFFD replacement character (HuggingFace/Rust tokenizer, which
+ * decodes partial bytes via String::from_utf8_lossy). Streaming such a partial
+ * result renders as broken glyphs.
+ *
+ * Usage: accumulate tokens into a pending buffer, Decode the whole buffer each
+ * step, then call shouldHold() to decide whether to emit or keep buffering.
+ * Used by CausalLM::registerOutputs() (CPU path) and the QNN generation loops
+ * (Transformer-derived models that run their own decoding).
+ */
+#ifndef __CAUSALLM_UTF8_STREAM_UTIL_H__
+#define __CAUSALLM_UTF8_STREAM_UTIL_H__
+
+#include <cstddef>
+#include <string>
+
+namespace causallm {
+namespace utf8stream {
+
+// Upper bound on how many tokens we hold while a multi-byte character is being
+// assembled. A UTF-8 code point is at most 4 bytes, so a valid character always
+// resolves within this window; the cap keeps genuinely invalid model output (a
+// stray byte that never completes) from stalling the stream forever.
+constexpr size_t kMaxHeldByteTokens = 6;
+
+// True if `s` ends with an incomplete UTF-8 byte sequence — a multi-byte lead
+// byte whose continuation bytes have not all arrived yet (native BPE decode).
+inline bool endsWithIncompleteUtf8(const std::string &s) {
+  const size_t n = s.size();
+  if (n == 0)
+    return false;
+
+  size_t lead = n - 1;
+  size_t trailing_cont = 0;
+  while ((static_cast<unsigned char>(s[lead]) & 0xc0) == 0x80) {
+    ++trailing_cont;
+    if (lead == 0 || trailing_cont >= 4)
+      return false;
+    --lead;
+  }
+
+  const unsigned char head = static_cast<unsigned char>(s[lead]);
+  size_t expected;
+  if ((head & 0x80) == 0x00)
+    expected = 1;
+  else if ((head & 0xe0) == 0xc0)
+    expected = 2;
+  else if ((head & 0xf0) == 0xe0)
+    expected = 3;
+  else if ((head & 0xf8) == 0xf0)
+    expected = 4;
+  else
+    return false;
+
+  return (n - lead) < expected;
+}
+
+// True if `s` ends with the UTF-8 replacement character U+FFFD (EF BF BD).
+// The HuggingFace (Rust) tokenizer substitutes U+FFFD for byte-fallback bytes
+// that do not yet form a complete code point, so a trailing U+FFFD signals
+// "the character is still being assembled".
+inline bool endsWithReplacementChar(const std::string &s) {
+  return s.size() >= 3 && static_cast<unsigned char>(s[s.size() - 3]) == 0xef &&
+         static_cast<unsigned char>(s[s.size() - 2]) == 0xbf &&
+         static_cast<unsigned char>(s[s.size() - 1]) == 0xbd;
+}
+
+// Decide whether `decoded` (the text of all currently-buffered tokens) should
+// be HELD rather than streamed now. `held_count` is how many tokens are
+// currently buffered. Holds while the text is empty or ends mid-character,
+// bounded by kMaxHeldByteTokens.
+inline bool shouldHold(const std::string &decoded, size_t held_count) {
+  if (decoded.empty())
+    return true;
+  return held_count <= kMaxHeldByteTokens &&
+         (endsWithIncompleteUtf8(decoded) || endsWithReplacementChar(decoded));
+}
+
+} // namespace utf8stream
+} // namespace causallm
+
+#endif /* __CAUSALLM_UTF8_STREAM_UTIL_H__ */


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>7f91b7e — fix(causallm): hold split multi-byte UTF-8 tokens during streaming</summary><br />

fix(causallm): hold split multi-byte UTF-8 tokens during streaming

A multi-byte UTF-8 character (e.g. a Korean syllable such as '똻') can be
split across consecutive byte-fallback tokens during generation. The
streaming detokenizer in registerOutputs() flushed each token's decoded
text immediately, emitting a half-formed code point that rendered as
broken glyphs (U+FFFD).

The previous incomplete-token guard compared the tail against an empty
string literal and never fired. Replace it with a real check that holds
the delta while the decoded text ends in either an incomplete raw UTF-8
sequence (native BPE decode) or a trailing U+FFFD replacement character
(the HuggingFace/Rust tokenizer decodes partial byte-fallback bytes via
from_utf8_lossy). Holding is bounded by kMaxHeldByteTokens so genuinely
invalid output still drains instead of stalling the stream.

This feature was made into additional header file, so it can be used by external projects
(e.g. QuickAI)

Verified on device with gemma4-cpu: Korean syllables that previously
streamed as broken glyphs now render correctly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jayden0701 <jrock.oh@samsung.com>

</details>

### Summary

- Fix broken glyph rendering when multi-byte UTF-8 characters (e.g. Korean syllables) are split across consecutive byte-fallback tokens during streaming generation. The previous guard (`decoded_str.compare(size-3, 3, "") == 0`) was a dead branch that never fired because it compared against an empty string literal. Replace it with proper UTF-8 incompleteness detection (`endsWithIncompleteUtf8` for native BPE decode, `endsWithReplacementChar` for HuggingFace/Rust tokenizer) and a bounded hold mechanism (`kMaxHeldByteTokens = 6`) that prevents stalling on genuinely invalid output.
- Extract the UTF-8 stream-hold logic into a standalone header (`utf8_stream_util.h` under `causallm::utf8stream` namespace) so it can be reused by external projects (e.g. QuickAI) and the QNN generation loops without depending on `causal_lm.cpp` internals.

Signed-off-by: jayden0701 <jrock.oh@samsung.com>
