### PR TITLE
[acti_func] Accelerate SiLU/swish with vectorized swiglu kernel

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -398,6 +398,35 @@ public:
    */
   template <typename T = float>
   static Tensor &swish(Tensor const &t_in, Tensor &t_out) {
+    /**
+     * Fused SiLU/swish: out = x * sigmoid(x) = x / (1 + exp(-x)).
+     * Fast path for contiguous FP32: SiLU is exactly swiglu(out, x, ones) where
+     * swiglu computes X = (Y / (1 + exp(-Y))) * Z. Reuse the vectorized
+     * cpu_backend swiglu (NEON exp_ps on ARM) by streaming a small reusable
+     * ones buffer, which avoids an N-sized allocation while keeping the fast
+     * exp path.
+     */
+    if (t_in.getDataType() == TensorDim::DataType::FP32 &&
+        t_out.getDataType() == TensorDim::DataType::FP32 &&
+        t_in.getContiguous() && t_out.getContiguous()) {
+      const unsigned int n = t_in.size();
+      float *in = t_in.getData<float>();
+      float *out = t_out.getData<float>();
+      constexpr unsigned int CH = 8192;
+      static thread_local float ones[CH];
+      static thread_local bool ones_init = false;
+      if (!ones_init) {
+        for (unsigned int i = 0; i < CH; ++i)
+          ones[i] = 1.0f;
+        ones_init = true;
+      }
+      for (unsigned int off = 0; off < n; off += CH) {
+        unsigned int m = (n - off < CH) ? (n - off) : CH;
+        swiglu(m, out + off, in + off, ones);
+      }
+      return t_out;
+    }
+
     t_in.apply<T>([&](T x) { return sigmoid<T>(x); }, t_out);
     t_out.multiply_i(t_in);
 


### PR DESCRIPTION
# Description

## Summary
Speed up the SiLU/swish activation by routing its contiguous FP32 path through
the existing vectorized `cpu_backend` `swiglu` kernel (NEON `exp_ps` on ARM)
instead of a scalar, double-precision, two-pass implementation.

## Motivation
`ActiFunc::swish` computed `sigmoid(x)` through `Tensor::apply` with a
`std::function` callback (no inlining/vectorization) in **double** precision,
then multiplied by `x` in a **separate second pass** over the buffer:

```cpp
t_in.apply<T>([&](T x){ return sigmoid<T>(x); }, t_out); // std::function, double exp
t_out.multiply_i(t_in);                                   // 2nd pass

For conv-heavy vision models (e.g. YOLOv11) swish is a meaningful share of
inference time, and all three of these are avoidable.

Changes

- nntrainer/layers/acti_func.h: for contiguous FP32 in/out, compute SiLU as swiglu(out, x, ones) — swiglu computes X = (Y / (1 + exp(-Y))) * Z, which is exactly SiLU when Z = 1. A small thread_local ones buffer is streamed in 8192-element chunks, so there is no N-sized allocation while still using the vectorized exp path.
- Non-contiguous / non-FP32 inputs fall back to the original implementation.
- Backward (swishPrime) is unchanged.

Results (Galaxy S25 / SM-S938N, YOLOv11m @832, FP32, 4 threads)

┌────────┬──────────────────────────────┐
│        │ swish (activation) time/iter │
├────────┼──────────────────────────────┤
│ before │                      ~290 ms │
├────────┼──────────────────────────────┤
│ after  │               ~92 ms (~3.1×) │
└────────┴──────────────────────────────┘


Signed-off-by: SeungHui Lee shsh1004.lee@samsung.com
Co-authored-by: Claude noreply@anthropic.com