### PR TITLE
fix(layers): generalize incremental_forwarding for multi-token prefill

### DIFF
--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -121,10 +121,9 @@ void EmbeddingLayer::incremental_forwarding(RunLayerContext &context,
   unsigned int out_dim = std::get<props::OutDim>(embedding_props);
 
   if (from) {
-    NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-      << "incremental step size is not 1";
+    // Normalize to 0-based while preserving step size for multi-token prefill
+    to = to - from;
     from = 0;
-    to = 1;
   }
 
   Tensor &weight = context.getWeight(weight_idx);

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -44,10 +44,9 @@ void MultiOutLayer::incremental_forwarding(RunLayerContext &context,
                                            bool training) {
   if (!context.getInPlace()) {
     if (from) {
-      NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-        << "incremental step size is not 1";
+      // Normalize to 0-based while preserving step size for multi-token prefill
+      to = to - from;
       from = 0;
-      to = 1;
     }
 
     const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/operation_layer.h
+++ b/nntrainer/layers/operation_layer.h
@@ -50,10 +50,9 @@ public:
   void incremental_forwarding(RunLayerContext &context, unsigned int from,
                               unsigned int to, bool training) override {
     if (from) {
-      NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-        << "incremental step size is not 1";
+      // Normalize to 0-based while preserving step size for multi-token prefill
+      to = to - from;
       from = 0;
-      to = 1;
     }
 
     Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
@@ -116,10 +115,9 @@ public:
   void incremental_forwarding(RunLayerContext &context, unsigned int from,
                               unsigned int to, bool training) override {
     if (from) {
-      NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-        << "incremental step size is not 1";
+      // Normalize to 0-based while preserving step size for multi-token prefill
+      to = to - from;
       from = 0;
-      to = 1;
     }
 
     Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);


### PR DESCRIPTION
## Summary

- Fix incremental_forwarding in BinaryOperationLayer, UnaryOperationLayer, EmbeddingLayer, and MultiOutLayer to support multi-token prefill steps when from > 0
- These layers unconditionally rejected any step size greater than 1 once from > 0, causing a crash on the second consecutive run() call in multi-turn inference

## Root cause

After the first run, global_token_len accumulates so the second run's prefill arrives with from > 0 and step = to - from > 1 simultaneously. All four layers threw here:

NNTR_THROW_IF(to - from != 1, std::invalid_argument)
  << "incremental step size is not 1";
from = 0;
to = 1;  // step forcibly clamped to 1

The fix normalizes the window to 0-based coordinates while preserving the step size — consistent with how AdditionLayer, FCLayer, ActivationLayer, and other layers already behave:

to = to - from;
from = 0;