### PR TITLE
[CausalLM] Add SmallThinker MoE model (base / slim / cachedslim)

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -108,6 +108,7 @@ LOCAL_SRC_FILES := \
     ../layers/shared_fully_connected_layer.cpp \
     ../models/smallthinker/smallthinker_causallm.cpp \
     ../models/smallthinker/smallthinker_moe_layer.cpp \
+    ../models/smallthinker/smallthinker_moe_layer_slim.cpp \
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
@@ -242,7 +243,8 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp \
     ../models/smallthinker/smallthinker_causallm.cpp \
-    ../models/smallthinker/smallthinker_moe_layer.cpp
+    ../models/smallthinker/smallthinker_moe_layer.cpp \
+    ../models/smallthinker/smallthinker_moe_layer_slim.cpp
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -109,6 +109,7 @@ LOCAL_SRC_FILES := \
     ../models/smallthinker/smallthinker_causallm.cpp \
     ../models/smallthinker/smallthinker_moe_layer.cpp \
     ../models/smallthinker/smallthinker_moe_layer_slim.cpp \
+    ../models/smallthinker/smallthinker_moe_layer_cached_slim.cpp \
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
@@ -244,7 +245,8 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../layers/shared_fully_connected_layer.cpp \
     ../models/smallthinker/smallthinker_causallm.cpp \
     ../models/smallthinker/smallthinker_moe_layer.cpp \
-    ../models/smallthinker/smallthinker_moe_layer_slim.cpp
+    ../models/smallthinker/smallthinker_moe_layer_slim.cpp \
+    ../models/smallthinker/smallthinker_moe_layer_cached_slim.cpp
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -29,6 +29,7 @@ CAUSALLM_COMMON_INCLUDES := \
     $(LOCAL_PATH)/../models/timm_vit \
     $(LOCAL_PATH)/../models/deberta_v2 \
     $(LOCAL_PATH)/../models/gemma4 \
+    $(LOCAL_PATH)/../models/smallthinker \
     $(LOCAL_PATH)/../third_party/minja/include \
     $(LOCAL_PATH)/../third_party \
 
@@ -105,6 +106,8 @@ LOCAL_SRC_FILES := \
     ../models/deberta_v2/deberta_v2.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp \
+    ../models/smallthinker/smallthinker_causallm.cpp \
+    ../models/smallthinker/smallthinker_moe_layer.cpp \
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
@@ -237,7 +240,9 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../models/gemma3/function.cpp \
     ../models/deberta_v2/deberta_v2.cpp \
     ../layers/deberta_attention_layer.cpp \
-    ../layers/shared_fully_connected_layer.cpp
+    ../layers/shared_fully_connected_layer.cpp \
+    ../models/smallthinker/smallthinker_causallm.cpp \
+    ../models/smallthinker/smallthinker_moe_layer.cpp
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
@@ -256,6 +261,7 @@ LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES) \
     $(LOCAL_PATH)/../models/gemma3 \
     $(LOCAL_PATH)/../models/deberta_v2 \
     $(LOCAL_PATH)/../models/gemma4 \
+    $(LOCAL_PATH)/../models/smallthinker \
 
 include $(BUILD_EXECUTABLE)
 

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -53,6 +53,7 @@
 #include "qwen3_embedding.h"
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
+#include "smallthinker_causallm.h"
 #include "timm_vit/timm_vit_transformer.h"
 #include <models/gemma3/function.h>
 #if !defined(_WIN32)
@@ -230,6 +231,12 @@ int main(int argc, char *argv[]) {
     "Qwen3SlimMoeForCausalLM",
     [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::Qwen3SlimMoECausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+  causallm::Factory::Instance().registerModel(
+    "SmallThinkerForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerCausalLM>(
         cfg, generation_cfg, nntr_cfg);
     });
 #if !defined(_WIN32)

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -247,6 +247,12 @@ int main(int argc, char *argv[]) {
     });
 #if !defined(_WIN32)
   causallm::Factory::Instance().registerModel(
+    "SmallThinkerCachedSlimForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerCachedSlimCausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+  causallm::Factory::Instance().registerModel(
     "Qwen3CachedSlimMoeForCausalLM",
     [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::Qwen3CachedSlimMoECausalLM>(

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -239,6 +239,12 @@ int main(int argc, char *argv[]) {
       return std::make_unique<causallm::SmallThinkerCausalLM>(
         cfg, generation_cfg, nntr_cfg);
     });
+  causallm::Factory::Instance().registerModel(
+    "SmallThinkerSlimForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerSlimCausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
 #if !defined(_WIN32)
   causallm::Factory::Instance().registerModel(
     "Qwen3CachedSlimMoeForCausalLM",

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -15,6 +15,7 @@ subdir('qwen3_slim_moe')
 subdir('gemma3')
 subdir('timm_vit')
 subdir('gemma4')
+subdir('smallthinker')
 if get_option('platform') != 'windows'
     subdir('bert')
     subdir('gpt_oss_cached_slim')

--- a/Applications/CausalLM/models/smallthinker/README.md
+++ b/Applications/CausalLM/models/smallthinker/README.md
@@ -1,0 +1,23 @@
+# SmallThinker Model
+
+This directory contains the SmallThinker Causal LM integration.
+
+Supported architecture:
+
+- `SmallThinkerForCausalLM`
+- `SmallThinkerSlimForCausalLM`
+
+The implementation follows SmallThinker's MoE decoder shape: GQA attention,
+top-k primary routing, ReLU-gated experts, and a separate pre-attention router
+input for the MoE block.
+
+- `smallthinker_moe_layer.cpp`: SmallThinker-specific MoE layer with separate
+  expert and router inputs.
+- `smallthinker_moe_layer_slim.cpp`: Slim MoE variant that maps expert weights
+  on demand and releases them after each active expert is computed.
+
+Supported model configs:
+
+- `SmallThinker-4BA0.6B-Instruct`: full RoPE attention layout.
+- `SmallThinker-21BA3B-Instruct`: hybrid NoPE/RoPE and sliding-window layout
+  from `rope_layout` and `sliding_window_layout`.

--- a/Applications/CausalLM/models/smallthinker/meson.build
+++ b/Applications/CausalLM/models/smallthinker/meson.build
@@ -7,7 +7,7 @@ smallthinker_inc = include_directories('.')
 causallm_smallthinker_moe_layer_src = [
     meson.current_source_dir() / 'smallthinker_moe_layer.cpp',
     meson.current_source_dir() / 'smallthinker_moe_layer_slim.cpp',
-
+    meson.current_source_dir() / 'smallthinker_moe_layer_cached_slim.cpp',
 ]
 
 causallm_smallthinker_moe_layer = shared_library(

--- a/Applications/CausalLM/models/smallthinker/meson.build
+++ b/Applications/CausalLM/models/smallthinker/meson.build
@@ -6,6 +6,8 @@ smallthinker_inc = include_directories('.')
 
 causallm_smallthinker_moe_layer_src = [
     meson.current_source_dir() / 'smallthinker_moe_layer.cpp',
+    meson.current_source_dir() / 'smallthinker_moe_layer_slim.cpp',
+
 ]
 
 causallm_smallthinker_moe_layer = shared_library(

--- a/Applications/CausalLM/models/smallthinker/meson.build
+++ b/Applications/CausalLM/models/smallthinker/meson.build
@@ -1,0 +1,27 @@
+smallthinker_src = [
+    meson.current_source_dir() / 'smallthinker_causallm.cpp',
+]
+
+smallthinker_inc = include_directories('.')
+
+causallm_smallthinker_moe_layer_src = [
+    meson.current_source_dir() / 'smallthinker_moe_layer.cpp',
+]
+
+causallm_smallthinker_moe_layer = shared_library(
+    'smallthinker_moe_layer',
+    causallm_smallthinker_moe_layer_src,
+    include_directories: [causallm_layer_inc, smallthinker_inc],
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_smallthinker_moe_layer_dep = declare_dependency(
+    link_with: causallm_smallthinker_moe_layer,
+    include_directories: smallthinker_inc
+)
+
+causallm_src += smallthinker_src
+causallm_inc += smallthinker_inc
+causallm_layer_dependencies += [causallm_smallthinker_moe_layer_dep]

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <smallthinker_causallm.h>
 #include <smallthinker_moe_layer.h>
+#include <smallthinker_moe_layer_slim.h>
 #include <stdexcept>
 
 namespace causallm {
@@ -214,6 +215,22 @@ void SmallThinkerCausalLM::registerCustomLayers() {
   try {
     app_context->registerFactory(
       nntrainer::createLayer<causallm::SmallThinkerMoELayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
+  }
+}
+
+void SmallThinkerSlimCausalLM::registerCustomLayers() {
+  CausalLM::registerCustomLayers();
+
+  auto &ct_engine = nntrainer::Engine::Global();
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::SmallThinkerSlimMoELayer>);
   } catch (std::invalid_argument &e) {
     std::cerr << "failed to register factory, reason: " << e.what()
               << std::endl;

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file   smallthinker_causallm.cpp
+ * @date   28 April 2026
+ * @brief  SmallThinker causal language model.
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#include <app_context.h>
+#include <engine.h>
+#include <llm_util.hpp>
+#include <model.h>
+
+#include <algorithm>
+#include <climits>
+#include <iostream>
+#include <smallthinker_causallm.h>
+#include <smallthinker_moe_layer.h>
+#include <stdexcept>
+
+namespace causallm {
+
+namespace {
+
+std::vector<bool> parseLayerLayout(const json &cfg, const char *key,
+                                   int num_layers, bool default_value) {
+  std::vector<bool> layout(num_layers, default_value);
+  if (!cfg.contains(key) || !cfg[key].is_array())
+    return layout;
+
+  const int limit = std::min<int>(num_layers, cfg[key].size());
+  for (int i = 0; i < limit; ++i) {
+    const json &value = cfg[key][i];
+    if (value.is_boolean())
+      layout[i] = value.get<bool>();
+    else if (value.is_number_integer())
+      layout[i] = value.get<int>() != 0;
+  }
+  return layout;
+}
+
+} // namespace
+
+json &SmallThinkerCausalLM::normalizeConfig(json &cfg) {
+  if (!cfg.contains("intermediate_size") &&
+      cfg.contains("moe_ffn_hidden_size")) {
+    cfg["intermediate_size"] = cfg["moe_ffn_hidden_size"];
+  }
+  if (!cfg.contains("sliding_window") && cfg.contains("sliding_window_size")) {
+    cfg["sliding_window"] = cfg["sliding_window_size"];
+  }
+  if (!cfg.contains("tie_word_embeddings") ||
+      !cfg["tie_word_embeddings"].is_boolean()) {
+    cfg["tie_word_embeddings"] = true;
+  }
+  if (cfg.contains("sliding_window_pattern") &&
+      !cfg["sliding_window_pattern"].is_number_unsigned()) {
+    cfg["sliding_window_pattern"] = 1;
+  }
+
+  return cfg;
+}
+
+void SmallThinkerCausalLM::setupParameters(json &cfg, json &generation_cfg,
+                                           json &nntr_cfg) {
+  CausalLM::setupParameters(cfg, generation_cfg, nntr_cfg);
+
+  if (cfg.contains("sliding_window_layout") &&
+      cfg["sliding_window_layout"].is_array() &&
+      std::none_of(cfg["sliding_window_layout"].begin(),
+                   cfg["sliding_window_layout"].end(), [](const json &enabled) {
+                     return enabled.is_number_integer() &&
+                            enabled.get<int>() != 0;
+                   })) {
+    SLIDING_WINDOW = UINT_MAX;
+  }
+
+  try {
+    NUM_EXPERTS = cfg["moe_num_primary_experts"];
+    NUM_EXPERTS_PER_TOK = cfg["moe_num_active_primary_experts"];
+    INTERMEDIATE_SIZE = cfg["moe_ffn_hidden_size"];
+    ROUTER_APPLY_SOFTMAX =
+      cfg.contains("moe_primary_router_apply_softmax")
+        ? cfg["moe_primary_router_apply_softmax"].get<bool>()
+        : false;
+  } catch (const std::exception &e) {
+    throw std::runtime_error(
+      "SmallThinker: required MoE config keys are missing");
+  }
+
+  rope_layout_ = parseLayerLayout(cfg, "rope_layout", NUM_LAYERS, true);
+  sliding_window_layout_ =
+    parseLayerLayout(cfg, "sliding_window_layout", NUM_LAYERS, false);
+}
+
+Tensor SmallThinkerCausalLM::createAttention(const int layer_id, int seq_len,
+                                             int n_heads, int head_dim,
+                                             Tensor query, Tensor key,
+                                             Tensor value) {
+
+  LayerHandle wq(createLayer(
+    "fully_connected",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_wq"),
+     withKey("unit", head_dim * n_heads), withKey("disable_bias", "true"),
+     withKey("weight_initializer", "ones")}));
+  Tensor q = wq(query);
+
+  LayerHandle wk(createLayer(
+    "fully_connected",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_wk"),
+     withKey("unit", head_dim * n_heads / GQA_SIZE),
+     withKey("disable_bias", "true"), withKey("weight_initializer", "ones")}));
+  Tensor k = wk(key);
+
+  LayerHandle wv(createLayer(
+    "fully_connected",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_wv"),
+     withKey("unit", head_dim * n_heads / GQA_SIZE),
+     withKey("disable_bias", "true"), withKey("weight_initializer", "ones")}));
+  Tensor v = wv(value);
+
+  auto [cache_k, cache_v] = createKVCachePlaceholders(layer_id, n_heads);
+
+  const bool use_sliding_window =
+    layer_id < static_cast<int>(sliding_window_layout_.size())
+      ? sliding_window_layout_[layer_id]
+      : false;
+  const bool use_rope = layer_id < static_cast<int>(rope_layout_.size())
+                          ? rope_layout_[layer_id]
+                          : true;
+
+  LayerHandle mha(createLayer(
+    "mha_core",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_attention"),
+     withKey("num_heads", n_heads), withKey("num_heads_kv", n_heads / GQA_SIZE),
+     withKey("max_timestep", std::to_string(MAX_SEQ_LEN)),
+     withKey("sliding_window", use_sliding_window ? SLIDING_WINDOW : UINT_MAX),
+     withKey("rope_theta", ROPE_THETA),
+     withKey("max_new_tokens", std::to_string(NUM_TO_GENERATE)),
+     withKey("is_causal", IS_CAUSAL ? "true" : "false"),
+     withKey("use_rope", use_rope ? "true" : "false")}));
+  Tensor a = mha({q, k, v, cache_k, cache_v});
+
+  LayerHandle wo(createLayer(
+    "fully_connected",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_attention_out"),
+     withKey("unit", DIM), withKey("disable_bias", "true"),
+     withKey("weight_initializer", "ones")}));
+  return wo(a);
+}
+
+Tensor SmallThinkerCausalLM::createTransformerDecoderBlock(const int layer_id,
+                                                           Tensor input) {
+
+  LayerHandle attn_norm(createLayer(
+    "rms_norm",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("packed", "false")}));
+  Tensor normed = attn_norm(input);
+
+  Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
+                                   normed, normed, normed);
+
+  LayerHandle decoder_add(createLayer(
+    "addition",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_decoder_add")}));
+  Tensor residual = decoder_add({input, att_out});
+
+  LayerHandle ffn_norm(createLayer(
+    "rms_norm",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("packed", "false")}));
+  Tensor ffn_normed = ffn_norm(residual);
+
+  // SmallThinker MoE uses 2 inputs: expert input (ffn_normed) and router input
+  // (pre-attention residual). The router is applied on the block's input before
+  // the attention norm, matching the HF reference implementation.
+  LayerHandle moe(createLayer(
+    getMoELayerType(),
+    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_down"),
+     withKey("unit", INTERMEDIATE_SIZE), withKey("num_experts", NUM_EXPERTS),
+     withKey("num_experts_per_token", NUM_EXPERTS_PER_TOK),
+     withKey("moe_activation", "relu"),
+     withKey("moe_router_apply_softmax",
+             ROUTER_APPLY_SOFTMAX ? "true" : "false")}));
+  Tensor ffn_out = moe({ffn_normed, input});
+
+  LayerHandle decoder_output(createLayer(
+    "addition",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_decoder_output")}));
+  return decoder_output({residual, ffn_out});
+}
+
+void SmallThinkerCausalLM::registerCustomLayers() {
+  CausalLM::registerCustomLayers();
+
+  auto &ct_engine = nntrainer::Engine::Global();
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::SmallThinkerMoELayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <smallthinker_causallm.h>
 #include <smallthinker_moe_layer.h>
+#include <smallthinker_moe_layer_cached_slim.h>
 #include <smallthinker_moe_layer_slim.h>
 #include <stdexcept>
 
@@ -231,6 +232,22 @@ void SmallThinkerSlimCausalLM::registerCustomLayers() {
   try {
     app_context->registerFactory(
       nntrainer::createLayer<causallm::SmallThinkerSlimMoELayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
+  }
+}
+
+void SmallThinkerCachedSlimCausalLM::registerCustomLayers() {
+  CausalLM::registerCustomLayers();
+
+  auto &ct_engine = nntrainer::Engine::Global();
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::SmallThinkerCachedSlimMoELayer>);
   } catch (std::invalid_argument &e) {
     std::cerr << "failed to register factory, reason: " << e.what()
               << std::endl;

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   smallthinker_causallm.h
+ * @date   28 April 2026
+ * @brief  SmallThinker causal language model.
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#ifndef __SMALLTHINKER_CAUSAL_LM_H__
+#define __SMALLTHINKER_CAUSAL_LM_H__
+
+#include <causal_lm.h>
+
+namespace causallm {
+
+/**
+ * @brief SmallThinkerCausalLM class
+ * @note  Implements SmallThinker's MoE decoder structure.
+ */
+class SmallThinkerCausalLM : public CausalLM {
+public:
+  static constexpr const char *architectures = "SmallThinkerForCausalLM";
+
+  SmallThinkerCausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(normalizeConfig(cfg), generation_cfg, nntr_cfg,
+                ModelType::CAUSALLM),
+    CausalLM(cfg, generation_cfg, nntr_cfg) {
+    setupParameters(cfg, generation_cfg, nntr_cfg);
+  }
+
+  virtual ~SmallThinkerCausalLM() = default;
+
+protected:
+  Tensor createTransformerDecoderBlock(const int layer_id,
+                                       Tensor input) override;
+
+  Tensor createAttention(const int layer_id, int seq_len, int n_heads,
+                         int head_dim, Tensor query, Tensor key,
+                         Tensor value) override;
+
+  void setupParameters(json &cfg, json &generation_cfg,
+                       json &nntr_cfg) override;
+
+  void registerCustomLayers() override;
+
+  virtual const char *getMoELayerType() const { return "smallthinker_moe"; }
+
+  static json &normalizeConfig(json &cfg);
+
+private:
+  unsigned int NUM_EXPERTS;
+  unsigned int NUM_EXPERTS_PER_TOK;
+  bool ROUTER_APPLY_SOFTMAX;
+  std::vector<bool> rope_layout_;
+  std::vector<bool> sliding_window_layout_;
+};
+
+} // namespace causallm
+
+#endif /* __SMALLTHINKER_CAUSAL_LM_H__ */

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
@@ -57,6 +57,30 @@ private:
   std::vector<bool> sliding_window_layout_;
 };
 
+/**
+ * @brief SmallThinkerSlimCausalLM class
+ * @note  Uses virtual expert weights; each expert is loaded, computed, and
+ *        immediately unloaded (no persistent cache).
+ */
+class SmallThinkerSlimCausalLM : public SmallThinkerCausalLM {
+public:
+  static constexpr const char *architectures = "SmallThinkerSlimForCausalLM";
+
+  SmallThinkerSlimCausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(normalizeConfig(cfg), generation_cfg, nntr_cfg,
+                ModelType::CAUSALLM),
+    SmallThinkerCausalLM(cfg, generation_cfg, nntr_cfg) {}
+
+  virtual ~SmallThinkerSlimCausalLM() = default;
+
+protected:
+  const char *getMoELayerType() const override {
+    return "smallthinker_moe_slim";
+  }
+
+  void registerCustomLayers() override;
+};
+
 } // namespace causallm
 
 #endif /* __SMALLTHINKER_CAUSAL_LM_H__ */

--- a/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_causallm.h
@@ -81,6 +81,32 @@ protected:
   void registerCustomLayers() override;
 };
 
+/**
+ * @brief SmallThinkerCachedSlimCausalLM class
+ * @note  Uses virtual expert weights with an LRU cache to keep recently-used
+ *        experts mapped across tokens, reducing repeated mmap overhead.
+ */
+class SmallThinkerCachedSlimCausalLM : public SmallThinkerCausalLM {
+public:
+  static constexpr const char *architectures =
+    "SmallThinkerCachedSlimForCausalLM";
+
+  SmallThinkerCachedSlimCausalLM(json &cfg, json &generation_cfg,
+                                 json &nntr_cfg) :
+    Transformer(normalizeConfig(cfg), generation_cfg, nntr_cfg,
+                ModelType::CAUSALLM),
+    SmallThinkerCausalLM(cfg, generation_cfg, nntr_cfg) {}
+
+  virtual ~SmallThinkerCachedSlimCausalLM() = default;
+
+protected:
+  const char *getMoELayerType() const override {
+    return "smallthinker_moe_cached_slim";
+  }
+
+  void registerCustomLayers() override;
+};
+
 } // namespace causallm
 
 #endif /* __SMALLTHINKER_CAUSAL_LM_H__ */

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer.cpp
@@ -1,0 +1,614 @@
+
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * @file	smallthinker_moe_layer.cpp
+ * @date	28 April 2026
+ * @brief	SmallThinker Mixture of Expert Layer
+ * @see		https://github.com/nnstreamer/
+ * @author	Jungwon-Lee <jungone.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <acti_func.h>
+#include <algorithm>
+#include <cmath>
+#include <cpu_backend.h>
+#include <cstring>
+#include <node_exporter.h>
+#include <smallthinker_moe_layer.h>
+#include <stdexcept>
+#include <thread_manager.h>
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+SmallThinkerMoELayer::SmallThinkerMoELayer() :
+  LayerImpl(),
+  num_experts(0),
+  topk(0),
+  router_apply_softmax(true),
+  moe_props(causallm::props::NumExperts(),
+            causallm::props::NumExpertsPerToken(), nntrainer::props::Unit(),
+            causallm::props::MoEActivation(), props::MoERouterApplySoftmax()),
+  expert_gate_proj_indices({}),
+  expert_up_proj_indices({}),
+  expert_down_proj_indices({}),
+  gate_idx(std::numeric_limits<unsigned>::max()),
+  router_logits_idx(std::numeric_limits<unsigned>::max()),
+  expert_mask_idx(std::numeric_limits<unsigned>::max()) {}
+
+void SmallThinkerMoELayer::finalize(nntrainer::InitLayerContext &context) {
+
+  NNTR_THROW_IF(context.getNumInputs() != 2, std::invalid_argument)
+    << "SmallThinker MoE layer requires expert input and router input";
+
+  auto &weight_regularizer =
+    std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
+  auto &weight_regularizer_constant =
+    std::get<nntrainer::props::WeightRegularizerConstant>(*layer_impl_props);
+  auto &weight_initializer =
+    std::get<nntrainer::props::WeightInitializer>(*layer_impl_props);
+  auto &weight_decay =
+    std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
+
+  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  const bool is_nchw = context.getFormat() == nntrainer::Tformat::NCHW;
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  context.setOutputDimensions(output_dims);
+
+  num_experts = std::get<causallm::props::NumExperts>(moe_props).get();
+  topk = std::get<causallm::props::NumExpertsPerToken>(moe_props).get();
+  router_apply_softmax =
+    std::get<props::MoERouterApplySoftmax>(moe_props).get();
+  const unsigned int intermediate_size =
+    std::get<nntrainer::props::Unit>(moe_props).get();
+  const unsigned int hidden_size = in_dim.width();
+
+  if (std::get<causallm::props::MoEActivation>(moe_props).empty()) {
+    throw std::runtime_error("Activation type is not set for MoE layer");
+  }
+  switch (context.getActivationDataType()) {
+  case ml::train::TensorDim::DataType::FP32:
+    acti_func.setActiFunc<float>(
+      std::get<causallm::props::MoEActivation>(moe_props).get());
+    break;
+  default:
+    throw std::runtime_error("Unsupported activation data type for MoE layer");
+  }
+
+  // Router (gate) weight is always kept FP32 — quantizing the router to 4-bit
+  // scrambles top-k expert selection and produces garbage output. save() keeps
+  // this weight FP32 on disk even when the expert weights are quantized.
+  nntrainer::TensorDim gate_dim(
+    1, is_nchw ? 1 : num_experts, is_nchw ? hidden_size : 1,
+    is_nchw ? num_experts : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     nntrainer::TensorDim::DataType::FP32),
+    is_nchw ? 0b0011 : 0b0101);
+
+  gate_idx = context.requestWeight(
+    gate_dim, weight_initializer, weight_regularizer,
+    weight_regularizer_constant, weight_decay, "gate", true);
+
+  expert_gate_proj_indices.reserve(num_experts);
+  expert_up_proj_indices.reserve(num_experts);
+  expert_down_proj_indices.reserve(num_experts);
+
+  nntrainer::TensorDim expert_gate_dim(
+    1, is_nchw ? 1 : intermediate_size, is_nchw ? hidden_size : 1,
+    is_nchw ? intermediate_size : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  nntrainer::TensorDim expert_down_dim(
+    1, is_nchw ? 1 : hidden_size, is_nchw ? intermediate_size : 1,
+    is_nchw ? hidden_size : intermediate_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  for (unsigned int i = 0; i < num_experts; ++i) {
+    expert_up_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_up_" + std::to_string(i), false));
+
+    expert_gate_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_gate_" + std::to_string(i), false));
+
+    expert_down_proj_indices.push_back(context.requestWeight(
+      expert_down_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_down_" + std::to_string(i), false));
+  }
+
+  const unsigned batch_size = in_dim.batch();
+  const unsigned seq_len = in_dim.height();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  router_logits_idx =
+    context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
+                          nntrainer::Initializer::NONE, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+
+  expert_mask_idx =
+    context.requestTensor({num_experts, 1, topk, total_tokens}, "expert_mask",
+                          nntrainer::Initializer::ZEROS, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+}
+
+void SmallThinkerMoELayer::forwarding(nntrainer::RunLayerContext &context,
+                                      bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input = context.getInput(1);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  const unsigned batch_size = input.batch();
+  const unsigned seq_len = input.height();
+  const unsigned hidden_size = input.width();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  input.reshape({total_tokens, 1, 1, hidden_size});
+  router_input.reshape({total_tokens, 1, 1, hidden_size});
+  output.reshape({total_tokens, 1, 1, hidden_size});
+  output.setZero();
+
+  // Routing via separate router input
+  nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+  router_input.dot(gate_weights, router_logits);
+
+  auto topk_result = router_logits.topK(topk);
+  auto topk_values = std::get<0>(topk_result);
+  auto topk_indices = std::get<1>(topk_result);
+
+  if (router_apply_softmax) {
+    topk_values.apply(nntrainer::ActiFunc::softmax<float>, topk_values);
+  } else {
+    float *values_data = topk_values.getData<float>();
+    for (unsigned int i = 0; i < total_tokens; ++i) {
+      float sum = 0.0f;
+      for (unsigned int k = 0; k < topk; ++k) {
+        float &value = values_data[i * topk + k];
+        value = 1.0f / (1.0f + std::exp(-value));
+        sum += value;
+      }
+      for (unsigned int k = 0; k < topk; ++k) {
+        values_data[i * topk + k] /= sum;
+      }
+    }
+  }
+
+  const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+  {
+    auto &tm = nntrainer::ThreadManager::Global();
+    size_t total_iters =
+      static_cast<size_t>(total_tokens) * static_cast<size_t>(topk);
+    tm.parallel_for(0, total_iters, [&](size_t idx) {
+      int k = idx % topk;
+      int i = idx / topk;
+      expert_mask.setValue(indices_data[idx], 0, k, i, 1.0f);
+    });
+  }
+
+  std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+    num_experts);
+  for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+    for (int k = 0; k < static_cast<int>(topk); ++k) {
+      unsigned expert_idx = indices_data[i * topk + k];
+      float weight = topk_values.getValue<float>(i, 0, 0, k);
+      expert_assignments[expert_idx].emplace_back(i, weight);
+    }
+  }
+
+  // Batch all tokens per expert into a single GEMM (M=num_tokens_for_expert).
+  // Expert loop is serial; each expert's GEMM uses tm.parallel_for at top
+  // level.
+  for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
+       ++expert_idx) {
+    const auto &assignments = expert_assignments[expert_idx];
+    if (assignments.empty())
+      continue;
+    compute_expert_forward_batched(
+      input, output, assignments,
+      context.getWeight(expert_gate_proj_indices[expert_idx]),
+      context.getWeight(expert_up_proj_indices[expert_idx]),
+      context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
+  }
+
+  output.reshape({batch_size, 1, seq_len, hidden_size});
+  input.reshape({batch_size, 1, seq_len, hidden_size});
+  router_input.reshape({batch_size, 1, seq_len, hidden_size});
+}
+
+inline void SmallThinkerMoELayer::compute_expert_forward(
+  const nntrainer::Tensor &input, nntrainer::Tensor &output,
+  const std::vector<std::pair<unsigned, float>> &token_assignments,
+  const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+  const nntrainer::Tensor &down_proj, unsigned int hidden_size) {
+
+  const unsigned intermediate_size = gate_proj.width();
+  const unsigned num_tokens = token_assignments.size();
+
+  if (num_tokens == 0)
+    return;
+
+  nntrainer::TensorDim token_input_dim({1, 1, 1, hidden_size},
+                                       input.getTensorType());
+  nntrainer::TensorDim intermediate_dim({1, 1, 1, intermediate_size},
+                                        input.getTensorType());
+  nntrainer::TensorDim token_output_dim({1, 1, 1, hidden_size},
+                                        input.getTensorType());
+
+  nntrainer::Tensor expert_output(output.batch(), output.channel(),
+                                  output.height(), output.width(),
+                                  output.getTensorType());
+  expert_output.setZero();
+
+  for (size_t i = 0; i < num_tokens; ++i) {
+    const unsigned token_idx = token_assignments[i].first;
+    const float weight = token_assignments[i].second;
+
+    size_t token_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_input =
+      input.getSharedDataTensor(token_input_dim, token_offset, true);
+
+    nntrainer::Tensor gate_out(intermediate_dim);
+    nntrainer::Tensor acti_out(intermediate_dim);
+    nntrainer::Tensor up_out(intermediate_dim);
+
+    token_input.dot(gate_proj, gate_out);
+    acti_func.run_fn(gate_out, acti_out);
+    token_input.dot(up_proj, up_out);
+    acti_out.multiply_i(up_out);
+
+    nntrainer::Tensor token_expert_output(token_output_dim);
+    acti_out.dot(down_proj, token_expert_output);
+    token_expert_output.multiply_i(weight);
+
+    size_t output_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_output =
+      expert_output.getSharedDataTensor(token_output_dim, output_offset, true);
+    token_output.add_i(token_expert_output);
+  }
+
+  output.add_i(expert_output);
+}
+
+inline void SmallThinkerMoELayer::compute_expert_forward_no_critical(
+  const nntrainer::Tensor &input, nntrainer::Tensor &expert_output,
+  const std::vector<std::pair<unsigned, float>> &token_assignments,
+  const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+  const nntrainer::Tensor &down_proj, unsigned int hidden_size) {
+
+  const unsigned intermediate_size = gate_proj.width();
+  const unsigned num_tokens = token_assignments.size();
+
+  if (num_tokens == 0)
+    return;
+
+  nntrainer::TensorDim token_input_dim({1, 1, 1, hidden_size},
+                                       input.getTensorType());
+  nntrainer::TensorDim intermediate_dim({1, 1, 1, intermediate_size},
+                                        input.getTensorType());
+  nntrainer::TensorDim token_output_dim({1, 1, 1, hidden_size},
+                                        input.getTensorType());
+
+  for (size_t i = 0; i < num_tokens; ++i) {
+    const unsigned token_idx = token_assignments[i].first;
+    const float weight = token_assignments[i].second;
+
+    size_t token_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_input =
+      input.getSharedDataTensor(token_input_dim, token_offset, true);
+
+    nntrainer::Tensor gate_out(intermediate_dim);
+    nntrainer::Tensor acti_out(intermediate_dim);
+    nntrainer::Tensor up_out(intermediate_dim);
+
+    token_input.dot(gate_proj, gate_out);
+    acti_func.run_fn(gate_out, acti_out);
+    token_input.dot(up_proj, up_out);
+    acti_out.multiply_i(up_out);
+
+    nntrainer::Tensor token_expert_output(token_output_dim);
+    acti_out.dot(down_proj, token_expert_output);
+    token_expert_output.multiply_i(weight);
+
+    size_t output_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_output =
+      expert_output.getSharedDataTensor(token_output_dim, output_offset, true);
+    token_output.add_i(token_expert_output);
+  }
+}
+
+inline void SmallThinkerMoELayer::compute_expert_forward_batched(
+  const nntrainer::Tensor &input, nntrainer::Tensor &output,
+  const std::vector<std::pair<unsigned, float>> &token_assignments,
+  const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+  const nntrainer::Tensor &down_proj, unsigned int hidden_size) {
+
+  const unsigned intermediate_size = gate_proj.width();
+  const unsigned num_tokens = token_assignments.size();
+
+  if (num_tokens == 0)
+    return;
+
+  nntrainer::TensorDim::TensorType tt = input.getTensorType();
+  nntrainer::TensorDim::TensorType ft(nntrainer::Tformat::NHWC,
+                                      nntrainer::Tdatatype::FP32);
+
+  nntrainer::TensorDim gathered_dim(
+    {1, 1, num_tokens, hidden_size},
+    nntrainer::TensorDim::TensorType(tt.format, tt.data_type));
+  nntrainer::TensorDim intermed_dim(
+    {1, 1, num_tokens, intermediate_size},
+    nntrainer::TensorDim::TensorType(nntrainer::Tformat::NHWC,
+                                     nntrainer::Tdatatype::FP32));
+  nntrainer::TensorDim down_dim(
+    {1, 1, num_tokens, hidden_size},
+    nntrainer::TensorDim::TensorType(nntrainer::Tformat::NHWC,
+                                     nntrainer::Tdatatype::FP32));
+
+  // Gather assigned token rows into a contiguous matrix (num_tokens × hidden)
+  nntrainer::Tensor gathered(gathered_dim);
+  float *g_data = gathered.getData<float>();
+  const float *in_data = input.getData<float>();
+  for (size_t i = 0; i < num_tokens; ++i) {
+    std::memcpy(g_data + i * hidden_size,
+                in_data + token_assignments[i].first * hidden_size,
+                hidden_size * sizeof(float));
+  }
+
+  // Batched GEMMs: M = num_tokens (single GEMM instead of num_tokens GEMVs)
+  nntrainer::Tensor gate_out(intermed_dim);
+  nntrainer::Tensor up_out(intermed_dim);
+  nntrainer::Tensor acti_out(intermed_dim);
+
+  gathered.dot(gate_proj, gate_out);
+  acti_func.run_fn(gate_out, acti_out);
+  gathered.dot(up_proj, up_out);
+  acti_out.multiply_i(up_out);
+
+  nntrainer::Tensor down_out(down_dim);
+  acti_out.dot(down_proj, down_out);
+
+  // Scatter results back with routing weights (caller guarantees serial access)
+  const float *d_data = down_out.getData<float>();
+  float *out_data = output.getData<float>();
+  for (size_t i = 0; i < num_tokens; ++i) {
+    const unsigned token_idx = token_assignments[i].first;
+    const float weight = token_assignments[i].second;
+    const float *src = d_data + i * hidden_size;
+    float *dst = out_data + token_idx * hidden_size;
+    for (unsigned j = 0; j < hidden_size; ++j)
+      dst[j] += src[j] * weight;
+  }
+}
+
+void SmallThinkerMoELayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+
+  nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input_ = context.getInput(1);
+  nntrainer::Tensor &output_ = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits_ = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  nntrainer::TensorDim input_step_dim = input_.getDim();
+  nntrainer::TensorDim output_step_dim = output_.getDim();
+  nntrainer::TensorDim router_logits_step_dim = router_logits_.getDim();
+
+  input_step_dim.batch(1);
+  output_step_dim.batch(1);
+  router_logits_step_dim.batch(to - from);
+  input_step_dim.height(to - from);
+  output_step_dim.height(to - from);
+
+  for (unsigned int b = 0; b < input_.batch(); ++b) {
+
+    auto input = input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto router_input = router_input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto output = output_.getSharedDataTensor(
+      output_step_dim, b * output_step_dim.getFeatureLen(), true);
+    auto router_logits =
+      router_logits_.getSharedDataTensor(router_logits_step_dim, 0, true);
+
+    const unsigned seq_len = input.height();
+    const unsigned hidden_size = input.width();
+    const unsigned total_tokens = seq_len; // batch=1 slice
+
+    input.reshape({total_tokens, 1, 1, hidden_size});
+    router_input.reshape({total_tokens, 1, 1, hidden_size});
+    output.reshape({total_tokens, 1, 1, hidden_size});
+    output.setZero();
+    expert_mask.setZero();
+
+    nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+    router_input.dot(gate_weights, router_logits);
+
+    auto topk_result = router_logits.topK(topk);
+    auto topk_values = std::get<0>(topk_result);
+    auto topk_indices = std::get<1>(topk_result);
+
+    if (router_apply_softmax) {
+      topk_values.apply(nntrainer::ActiFunc::softmax<float>, topk_values);
+    } else {
+      float *values_data = topk_values.getData<float>();
+      for (unsigned int i = 0; i < total_tokens; ++i) {
+        float sum = 0.0f;
+        for (unsigned int k = 0; k < topk; ++k) {
+          float &value = values_data[i * topk + k];
+          value = 1.0f / (1.0f + std::exp(-value));
+          sum += value;
+        }
+        for (unsigned int k = 0; k < topk; ++k) {
+          values_data[i * topk + k] /= sum;
+        }
+      }
+    }
+
+    const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+    {
+      auto &tm = nntrainer::ThreadManager::Global();
+      size_t total_iters =
+        static_cast<size_t>(total_tokens) * static_cast<size_t>(topk);
+      tm.parallel_for(0, total_iters, [&](size_t idx) {
+        int k = idx % topk;
+        int i = idx / topk;
+        expert_mask.setValue(indices_data[idx], 0, k, i, 1.0f);
+      });
+    }
+
+    std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+      num_experts);
+    for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+      for (int k = 0; k < static_cast<int>(topk); ++k) {
+        unsigned expert_idx = indices_data[i * topk + k];
+        float weight = topk_values.getValue<float>(i, 0, 0, k);
+        expert_assignments[expert_idx].emplace_back(i, weight);
+      }
+    }
+
+    // Compact list of ACTIVE experts only. Dispatching parallel_for over the
+    // active set (typically == topk) gives perfect 1-expert-per-thread load
+    // balance, vs scanning all num_experts (mostly empty) with static range
+    // splitting which can pile multiple active experts onto one thread.
+    std::vector<unsigned> active_experts;
+    active_experts.reserve(num_experts);
+    for (unsigned e = 0; e < num_experts; ++e)
+      if (!expert_assignments[e].empty())
+        active_experts.push_back(e);
+
+    nntrainer::TensorDim expert_out_dim = output.getDim();
+    std::vector<nntrainer::Tensor> expert_outputs(active_experts.size());
+    for (size_t a = 0; a < active_experts.size(); ++a) {
+      expert_outputs[a] = nntrainer::Tensor(expert_out_dim);
+      expert_outputs[a].setZero();
+    }
+
+    // Serial outer loop: Q4_0 GEMV parallelizes internally via ThreadManager,
+    // and nesting parallel_for deadlocks.
+    for (size_t a = 0; a < active_experts.size(); ++a) {
+      const unsigned expert_idx = active_experts[a];
+      compute_expert_forward_no_critical(
+        input, expert_outputs[a], expert_assignments[expert_idx],
+        context.getWeight(expert_gate_proj_indices[expert_idx]),
+        context.getWeight(expert_up_proj_indices[expert_idx]),
+        context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
+    }
+
+    for (size_t a = 0; a < active_experts.size(); ++a)
+      output.add_i(expert_outputs[a]);
+
+    output.reshape({1, 1, seq_len, hidden_size});
+  }
+}
+
+void SmallThinkerMoELayer::setProperty(const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, moe_props);
+  nntrainer::LayerImpl::setProperty(remain_props);
+}
+
+void SmallThinkerMoELayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support derivative calculation");
+}
+
+void SmallThinkerMoELayer::calcGradient(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support gradient calculation");
+}
+
+void SmallThinkerMoELayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  nntrainer::LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(moe_props, method, this);
+}
+
+void SmallThinkerMoELayer::save(std::ofstream &file,
+                                nntrainer::RunLayerContext &run_context,
+                                bool opt_var, ml::train::ExecutionMode mode,
+                                bool trainable,
+                                nntrainer::TensorDim::DataType dtype,
+                                ml::train::ISA target_isa) const {
+  // Optimizer variables follow the default path unchanged.
+  if (opt_var) {
+    nntrainer::LayerImpl::save(file, run_context, opt_var, mode, trainable,
+                               dtype, target_isa);
+    return;
+  }
+
+  for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
+    // Shared weights are written only on first access.
+    if (!run_context.isGradientFirstAccess(i))
+      continue;
+
+    auto &weight = run_context.getWeight(i);
+
+    // Router (gate) is always FP32 on disk; never quantize it. Also fall back
+    // to a verbatim save when no quantization is requested or the in-memory
+    // dtype already matches the target.
+    if (i == gate_idx || dtype == nntrainer::TensorDim::DataType::NONE ||
+        weight.getDataType() == dtype) {
+      weight.save(file);
+      continue;
+    }
+
+    NNTR_THROW_IF(dtype != nntrainer::TensorDim::DataType::Q4_0,
+                  std::runtime_error)
+      << "SmallThinker MoE save supports only Q4_0 quantization, got dtype "
+      << static_cast<int>(dtype);
+    NNTR_THROW_IF(weight.getDataType() != nntrainer::TensorDim::DataType::FP32,
+                  std::runtime_error)
+      << "Save with quantization only supports FP32 source weights.";
+
+    const nntrainer::TensorDim dim = weight.getDim();
+    const unsigned int K = dim.height();
+    const unsigned int N = dim.width();
+
+    // Bias-like (height == 1) tensors are not Q4_0-block-quantizable.
+    if (K == 1) {
+      weight.save(file);
+      continue;
+    }
+
+    NNTR_THROW_IF(N % 32 != 0 || K % 32 != 0, std::invalid_argument)
+      << "Q4_0 requires height and width divisible by 32, got height=" << K
+      << ", width=" << N;
+
+    nntrainer::Tensor weight_t = weight.transpose("0:2:1");
+    nntrainer::Tensor quant_weight(dim.batch(), dim.channel(), K, N,
+                                   {nntrainer::Tformat::NCHW, dtype});
+    std::vector<char> tmp(quant_weight.size());
+    nntrainer::quantize_q4_0(weight_t.getData<float>(), tmp.data(), N, K,
+                             nullptr);
+    nntrainer::repack_q4_0(quant_weight.getData<uint8_t>(), tmp.data(),
+                           quant_weight.size(), N, K, target_isa);
+    quant_weight.save(file);
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer.h
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   smallthinker_moe_layer.h
+ * @date   28 April 2026
+ * @brief  This is SmallThinker Mixture of Expert Layer Class of Neural Network
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @note   This file is part of the SmallThinker Mixture of Expert Layer
+ *         implementation.
+ *         It does not support shared experts.
+ *         This layer is implemented based on the LLama-MoE.
+ *         For more information, please refer to the following link:
+ *         https://arxiv.org/pdf/2406.16554
+ * @todo   This layer does not support backwarding yet.
+ */
+
+#ifndef __SMALLTHINKER_MOE_LAYER_H__
+#define __SMALLTHINKER_MOE_LAYER_H__
+#ifdef __cplusplus
+
+#include <acti_func.h>
+#include <causallm_common_properties.h>
+#include <common_properties.h>
+#include <layer_impl.h>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief MoERouterApplySoftmax, whether router logits use softmax or sigmoid
+ */
+class MoERouterApplySoftmax : public nntrainer::Property<bool> {
+public:
+  MoERouterApplySoftmax(bool value = true) { set(value); }
+  static constexpr const char *key =
+    "moe_router_apply_softmax";              /**< unique key to access */
+  using prop_tag = nntrainer::bool_prop_tag; /**< property type */
+};
+
+/**
+ * @brief MoECacheSize, max number of experts kept resident (mmap'd) by the
+ *        slim MoE layer's LRU cache. Only used by the on-demand slim path.
+ */
+class MoECacheSize : public nntrainer::Property<unsigned int> {
+public:
+  MoECacheSize(unsigned int value = 32) { set(value); }
+  static constexpr const char *key = "moe_cache_size"; /**< unique key */
+  using prop_tag = nntrainer::uint_prop_tag;           /**< property type */
+};
+
+} // namespace props
+
+/**
+ * @class   SmallThinkerMoELayer
+ * @brief   SmallThinker Mixture of Expert Layer
+ */
+class SmallThinkerMoELayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief     Constructor of SmallThinker Mixture of Expert Layer
+   */
+  SmallThinkerMoELayer();
+
+  /**
+   * @brief     Destructor of SmallThinker Mixture of Expert Layer
+   */
+  ~SmallThinkerMoELayer() = default;
+
+  /**
+   * @brief  Move constructor.
+   *  @param[in] SmallThinkerMoELayer &&
+   */
+  SmallThinkerMoELayer(SmallThinkerMoELayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @param[in] rhs SmallThinkerMoELayer to be moved.
+   */
+  SmallThinkerMoELayer &operator=(SmallThinkerMoELayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, const ml::train::ExportMethods
+   * &methods)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return SmallThinkerMoELayer::type;
+  };
+
+  /**
+   * @copydoc Layer::save()
+   * @note Overridden so the router (gate) weight is always written as FP32,
+   *       while expert weights honor the requested quantization dtype. A 4-bit
+   *       router corrupts top-k expert selection and yields garbage output.
+   */
+  void save(
+    std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
+    ml::train::ExecutionMode mode, bool trainable,
+    nntrainer::TensorDim::DataType dtype = nntrainer::TensorDim::DataType::NONE,
+    ml::train::ISA target_isa = ml::train::ISA::DEFAULT) const override;
+
+  /**
+   * @brief Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return false; }
+
+  static constexpr const char *type =
+    "smallthinker_moe"; /**< type of the layer */
+
+private:
+  unsigned int num_experts;      /**< number of experts */
+  unsigned int topk;             /**< number of experts per token, i.e., topk */
+  bool router_apply_softmax;     /**< whether router uses softmax or sigmoid */
+  nntrainer::ActiFunc acti_func; /**< activation function for the expert */
+  std::tuple<causallm::props::NumExperts, causallm::props::NumExpertsPerToken,
+             nntrainer::props::Unit, causallm::props::MoEActivation,
+             props::MoERouterApplySoftmax>
+    moe_props;
+
+  // weight indices
+  std::vector<unsigned int> expert_gate_proj_indices;
+  std::vector<unsigned int> expert_up_proj_indices;
+  std::vector<unsigned int> expert_down_proj_indices;
+  unsigned int gate_idx;
+
+  // Intermediate tensor indices
+  unsigned int router_logits_idx;
+  unsigned int expert_mask_idx;
+
+  inline void compute_expert_forward(
+    const nntrainer::Tensor &input, nntrainer::Tensor &output,
+    const std::vector<std::pair<unsigned, float>> &token_assignments,
+    const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+    const nntrainer::Tensor &down_proj, unsigned int hidden_size);
+
+  inline void compute_expert_forward_no_critical(
+    const nntrainer::Tensor &input, nntrainer::Tensor &expert_output,
+    const std::vector<std::pair<unsigned, float>> &token_assignments,
+    const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+    const nntrainer::Tensor &down_proj, unsigned int hidden_size);
+
+  // Batched GEMM variant: gathers all assigned tokens into a contiguous matrix
+  // and performs 3 GEMMs (gate, up, down) instead of N separate GEMVs.
+  // Significantly faster during prefill (M = num_tokens > 1).
+  inline void compute_expert_forward_batched(
+    const nntrainer::Tensor &input, nntrainer::Tensor &output,
+    const std::vector<std::pair<unsigned, float>> &token_assignments,
+    const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+    const nntrainer::Tensor &down_proj, unsigned int hidden_size);
+};
+} // namespace causallm
+
+#endif /* __cplusplus */
+#endif /* __SMALLTHINKER_MOE_LAYER_H__ */

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_cached_slim.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_cached_slim.cpp
@@ -1,0 +1,555 @@
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file   smallthinker_moe_layer_cached_slim.cpp
+ * @date   26 June 2026
+ * @brief  SmallThinker MoE layer with on-demand expert loading and LRU cache.
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#ifdef DEBUG
+#include <iostream>
+#endif
+#include <node_exporter.h>
+#include <smallthinker_moe_layer_cached_slim.h>
+#include <stdexcept>
+#include <thread_manager.h>
+
+using std::chrono::duration_cast;
+using std::chrono::high_resolution_clock;
+using std::chrono::nanoseconds;
+
+namespace causallm {
+
+namespace {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+void normalize_router_weights(nntrainer::Tensor &topk_values,
+                              unsigned int total_tokens, unsigned int topk,
+                              bool router_apply_softmax) {
+  if (router_apply_softmax) {
+    topk_values.apply(nntrainer::ActiFunc::softmax<float>, topk_values);
+    return;
+  }
+
+  float *values_data = topk_values.getData<float>();
+  for (unsigned int i = 0; i < total_tokens; ++i) {
+    float sum = 0.0f;
+    for (unsigned int k = 0; k < topk; ++k) {
+      float &value = values_data[i * topk + k];
+      value = 1.0f / (1.0f + std::exp(-value));
+      sum += value;
+    }
+    for (unsigned int k = 0; k < topk; ++k) {
+      values_data[i * topk + k] /= sum;
+    }
+  }
+}
+
+// Collect the top (topk + extra) expert indices across all tokens, used as the
+// LRU prediction set. Indices only; routing weights are computed separately.
+std::vector<unsigned int> collect_predicted(nntrainer::Tensor &router_logits,
+                                            unsigned int total_tokens,
+                                            unsigned int topk,
+                                            unsigned int num_experts) {
+  const unsigned int extra =
+    std::min(topk + 5u, num_experts); // a few near-misses kept warm
+  auto extra_topk_result = router_logits.topK(extra);
+  auto extra_topk_indices = std::get<1>(extra_topk_result);
+  const uint32_t *idx = extra_topk_indices.getData<uint32_t>();
+
+  std::vector<unsigned int> predicted;
+  predicted.reserve(total_tokens * extra);
+  for (unsigned int i = 0; i < total_tokens; ++i)
+    for (unsigned int k = 0; k < extra; ++k)
+      predicted.push_back(idx[i * extra + k]);
+  return predicted;
+}
+
+} // namespace
+
+SmallThinkerCachedSlimMoELayer::SmallThinkerCachedSlimMoELayer() :
+  LayerImpl(),
+  num_experts(0),
+  topk(0),
+  router_apply_softmax(true),
+  cache_size(32),
+  moe_props(props::NumExperts(), props::NumExpertsPerToken(),
+            nntrainer::props::Unit(), props::MoEActivation(),
+            props::MoERouterApplySoftmax(), props::MoECacheSize()),
+  expert_gate_proj_indices({}),
+  expert_up_proj_indices({}),
+  expert_down_proj_indices({}),
+  gate_idx(std::numeric_limits<unsigned>::max()),
+  router_logits_idx(std::numeric_limits<unsigned>::max()),
+  expert_mask_idx(std::numeric_limits<unsigned>::max()) {}
+
+void SmallThinkerCachedSlimMoELayer::finalize(
+  nntrainer::InitLayerContext &context) {
+
+  NNTR_THROW_IF(context.getNumInputs() != 2, std::invalid_argument)
+    << "SmallThinker cached-slim MoE layer requires expert input and router "
+       "input";
+
+  auto &weight_regularizer =
+    std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
+  auto &weight_regularizer_constant =
+    std::get<nntrainer::props::WeightRegularizerConstant>(*layer_impl_props);
+  auto &weight_initializer =
+    std::get<nntrainer::props::WeightInitializer>(*layer_impl_props);
+  auto &weight_decay =
+    std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
+
+  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  const bool is_nchw = context.getFormat() == nntrainer::Tformat::NCHW;
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  context.setOutputDimensions(output_dims);
+
+  num_experts = std::get<props::NumExperts>(moe_props).get();
+  topk = std::get<props::NumExpertsPerToken>(moe_props).get();
+  router_apply_softmax =
+    std::get<props::MoERouterApplySoftmax>(moe_props).get();
+  cache_size = std::get<props::MoECacheSize>(moe_props).get();
+  // Optional runtime override for tuning / A-B measurement. cache_size==0
+  // reproduces the old behavior (evict every expert after each token).
+  if (const char *env = std::getenv("NNTR_MOE_CACHE_SIZE"))
+    cache_size = static_cast<unsigned int>(std::stoul(env));
+  const unsigned int intermediate_size =
+    std::get<nntrainer::props::Unit>(moe_props).get();
+  const unsigned int hidden_size = in_dim.width();
+
+  if (std::get<props::MoEActivation>(moe_props).empty()) {
+    throw std::runtime_error("Activation type is not set for MoE layer");
+  }
+  switch (context.getActivationDataType()) {
+  case ml::train::TensorDim::DataType::FP32:
+    acti_func.setActiFunc<float>(
+      std::get<props::MoEActivation>(moe_props).get());
+    break;
+  default:
+    throw std::runtime_error("Unsupported activation data type for MoE layer");
+  }
+
+  nntrainer::TensorDim gate_dim(
+    1, is_nchw ? 1 : num_experts, is_nchw ? hidden_size : 1,
+    is_nchw ? num_experts : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     nntrainer::TensorDim::DataType::FP32),
+    is_nchw ? 0b0011 : 0b0101);
+
+  gate_idx = context.requestWeight(
+    gate_dim, weight_initializer, weight_regularizer,
+    weight_regularizer_constant, weight_decay, "gate", true);
+
+  expert_gate_proj_indices.reserve(num_experts);
+  expert_up_proj_indices.reserve(num_experts);
+  expert_down_proj_indices.reserve(num_experts);
+
+  nntrainer::TensorDim expert_gate_dim(
+    1, is_nchw ? 1 : intermediate_size, is_nchw ? hidden_size : 1,
+    is_nchw ? intermediate_size : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  nntrainer::TensorDim expert_down_dim(
+    1, is_nchw ? 1 : hidden_size, is_nchw ? intermediate_size : 1,
+    is_nchw ? hidden_size : intermediate_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  for (unsigned int i = 0; i < num_experts; ++i) {
+    expert_up_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_up_" + std::to_string(i), false, true));
+
+    expert_gate_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_gate_" + std::to_string(i), false, true));
+
+    expert_down_proj_indices.push_back(context.requestWeight(
+      expert_down_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_down_" + std::to_string(i), false, true));
+  }
+
+  // All experts start unloaded; the LRU cache populates them on first use.
+  need_load.assign(num_experts, true);
+
+  const unsigned batch_size = in_dim.batch();
+  const unsigned seq_len = in_dim.height();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  router_logits_idx =
+    context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
+                          nntrainer::Initializer::NONE, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+
+  expert_mask_idx =
+    context.requestTensor({num_experts, 1, topk, total_tokens}, "expert_mask",
+                          nntrainer::Initializer::ZEROS, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+}
+
+void SmallThinkerCachedSlimMoELayer::forwarding(
+  nntrainer::RunLayerContext &context, bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input = context.getInput(1);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  const unsigned batch_size = input.batch();
+  const unsigned seq_len = input.height();
+  const unsigned hidden_size = input.width();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  input.reshape({total_tokens, 1, 1, hidden_size});
+  router_input.reshape({total_tokens, 1, 1, hidden_size});
+  output.reshape({total_tokens, 1, 1, hidden_size});
+  output.setZero();
+
+  nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+  router_input.dot(gate_weights, router_logits);
+  auto topk_result = router_logits.topK(topk);
+  auto topk_values = std::get<0>(topk_result);
+  auto topk_indices = std::get<1>(topk_result);
+
+  normalize_router_weights(topk_values, total_tokens, topk,
+                           router_apply_softmax);
+
+  expert_mask.setZero();
+  const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+  auto &tm = nntrainer::ThreadManager::Global();
+  tm.parallel_for(0, total_tokens * topk, [&](size_t idx) {
+    const size_t i = idx / topk;
+    const size_t k = idx % topk;
+    expert_mask.setValue(indices_data[i * topk + k], 0, k, i, 1.0f);
+  });
+
+  std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+    num_experts);
+  for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+    for (int k = 0; k < static_cast<int>(topk); ++k) {
+      unsigned expert_idx = indices_data[i * topk + k];
+      float weight = topk_values.getValue<float>(i, 0, 0, k);
+      expert_assignments[expert_idx].emplace_back(i, weight);
+    }
+  }
+
+  std::vector<unsigned int> predicted =
+    collect_predicted(router_logits, total_tokens, topk, num_experts);
+
+  long long activate_ns = 0, compute_ns = 0;
+  for (unsigned int expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+    const auto &assignments = expert_assignments[expert_idx];
+    if (assignments.empty())
+      continue;
+
+    run_active_expert(context, input, output, assignments, expert_idx,
+                      hidden_size, activate_ns, compute_ns);
+  }
+  (void)activate_ns;
+  (void)compute_ns;
+
+  touch_predicted(predicted);
+  evict_experts(context);
+
+  output.reshape({batch_size, 1, seq_len, hidden_size});
+  input.reshape({batch_size, 1, seq_len, hidden_size});
+  router_input.reshape({batch_size, 1, seq_len, hidden_size});
+}
+
+inline void SmallThinkerCachedSlimMoELayer::compute_expert_forward(
+  const nntrainer::Tensor &input, nntrainer::Tensor &output,
+  const std::vector<std::pair<unsigned, float>> &token_assignments,
+  const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+  const nntrainer::Tensor &down_proj, unsigned int hidden_size) {
+
+  const unsigned intermediate_size = gate_proj.width();
+  const unsigned num_tokens = token_assignments.size();
+
+  if (num_tokens == 0)
+    return;
+
+  nntrainer::TensorDim token_input_dim({1, 1, 1, hidden_size},
+                                       input.getTensorType());
+  nntrainer::TensorDim intermediate_dim({1, 1, 1, intermediate_size},
+                                        input.getTensorType());
+  nntrainer::TensorDim token_output_dim({1, 1, 1, hidden_size},
+                                        input.getTensorType());
+
+  nntrainer::Tensor expert_output(output.batch(), output.channel(),
+                                  output.height(), output.width(),
+                                  output.getTensorType());
+  expert_output.setZero();
+
+  for (size_t i = 0; i < num_tokens; ++i) {
+    const unsigned token_idx = token_assignments[i].first;
+    const float weight = token_assignments[i].second;
+
+    size_t token_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_input =
+      input.getSharedDataTensor(token_input_dim, token_offset, true);
+
+    nntrainer::Tensor gate_out(intermediate_dim);
+    nntrainer::Tensor acti_out(intermediate_dim);
+    nntrainer::Tensor up_out(intermediate_dim);
+
+    token_input.dot(gate_proj, gate_out);
+    acti_func.run_fn(gate_out, acti_out);
+    token_input.dot(up_proj, up_out);
+    acti_out.multiply_i(up_out);
+
+    nntrainer::Tensor token_expert_output(token_output_dim);
+    acti_out.dot(down_proj, token_expert_output);
+
+    token_expert_output.multiply_i(weight);
+    size_t output_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_output =
+      expert_output.getSharedDataTensor(token_output_dim, output_offset, true);
+
+    token_output.add_i(token_expert_output);
+  }
+
+  output.add_i(expert_output);
+}
+
+bool SmallThinkerCachedSlimMoELayer::run_active_expert(
+  nntrainer::RunLayerContext &context, const nntrainer::Tensor &input,
+  nntrainer::Tensor &output,
+  const std::vector<std::pair<unsigned, float>> &assignments,
+  unsigned int expert_idx, unsigned int hidden_size, long long &activate_ns,
+  long long &compute_ns) {
+
+  bool is_miss;
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    is_miss = need_load[expert_idx];
+  }
+
+  // On a miss, page the expert in and record it as the most-recently-used.
+  // activate()/deactivate() must operate on the persistent context weight so
+  // that eviction can later munmap the same mapping. We never deactivate here;
+  // eviction is deferred to evict_experts().
+  if (is_miss) {
+    auto ta0 = high_resolution_clock::now();
+    context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
+    context.getWeight(expert_up_proj_indices[expert_idx]).activate();
+    context.getWeight(expert_down_proj_indices[expert_idx]).activate();
+    auto ta1 = high_resolution_clock::now();
+    activate_ns += duration_cast<nanoseconds>(ta1 - ta0).count();
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    loaded_expert_deque.push_back(expert_idx);
+    iteration_map[expert_idx] = --loaded_expert_deque.end();
+    need_load[expert_idx] = false;
+  }
+
+  auto tc0 = high_resolution_clock::now();
+  compute_expert_forward(
+    input, output, assignments,
+    context.getWeight(expert_gate_proj_indices[expert_idx]),
+    context.getWeight(expert_up_proj_indices[expert_idx]),
+    context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
+  auto tc1 = high_resolution_clock::now();
+  compute_ns += duration_cast<nanoseconds>(tc1 - tc0).count();
+
+  return is_miss;
+}
+
+void SmallThinkerCachedSlimMoELayer::touch_predicted(
+  const std::vector<unsigned int> &predicted) {
+  // Move already-resident predicted experts (this token's top-k plus a few
+  // near-misses) to the MRU end so eviction prefers genuinely cold experts.
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  for (auto it = predicted.rbegin(); it != predicted.rend(); ++it) {
+    auto found = iteration_map.find(static_cast<int>(*it));
+    if (found != iteration_map.end()) {
+      loaded_expert_deque.erase(found->second);
+      loaded_expert_deque.push_back(static_cast<int>(*it));
+      iteration_map[static_cast<int>(*it)] = --loaded_expert_deque.end();
+    }
+  }
+}
+
+void SmallThinkerCachedSlimMoELayer::evict_experts(
+  nntrainer::RunLayerContext &context) {
+  while (true) {
+    int target_idx;
+    {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      if (loaded_expert_deque.size() <= cache_size)
+        break;
+      target_idx = loaded_expert_deque.front();
+      loaded_expert_deque.pop_front();
+      iteration_map.erase(target_idx);
+      need_load[target_idx] = true;
+    }
+    context.getWeight(expert_gate_proj_indices[target_idx]).deactivate();
+    context.getWeight(expert_up_proj_indices[target_idx]).deactivate();
+    context.getWeight(expert_down_proj_indices[target_idx]).deactivate();
+  }
+}
+
+void SmallThinkerCachedSlimMoELayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+
+  nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input_ = context.getInput(1);
+  nntrainer::Tensor &output_ = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits_ = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  nntrainer::TensorDim input_step_dim = input_.getDim();
+  nntrainer::TensorDim output_step_dim = output_.getDim();
+  nntrainer::TensorDim router_logits_step_dim = router_logits_.getDim();
+
+  input_step_dim.batch(1);
+  output_step_dim.batch(1);
+  router_logits_step_dim.batch(to - from);
+
+  input_step_dim.height(to - from);
+  output_step_dim.height(to - from);
+
+  for (unsigned int b = 0; b < input_.batch(); ++b) {
+    auto input = input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto router_input = router_input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto output = output_.getSharedDataTensor(
+      output_step_dim, b * output_step_dim.getFeatureLen(), true);
+    auto router_logits =
+      router_logits_.getSharedDataTensor(router_logits_step_dim, 0, true);
+
+    const unsigned batch_size = input.batch();
+    const unsigned seq_len = input.height();
+    const unsigned hidden_size = input.width();
+    const unsigned total_tokens = batch_size * seq_len;
+
+    input.reshape({total_tokens, 1, 1, hidden_size});
+    router_input.reshape({total_tokens, 1, 1, hidden_size});
+    output.reshape({total_tokens, 1, 1, hidden_size});
+    output.setZero();
+    expert_mask.setZero();
+
+    nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+    router_input.dot(gate_weights, router_logits);
+    auto topk_result = router_logits.topK(topk);
+    auto topk_values = std::get<0>(topk_result);
+    auto topk_indices = std::get<1>(topk_result);
+
+    normalize_router_weights(topk_values, total_tokens, topk,
+                             router_apply_softmax);
+
+    const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+    for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+      for (int k = 0; k < static_cast<int>(topk); ++k) {
+        expert_mask.setValue(indices_data[i * topk + k], 0, k, i, 1.0f);
+      }
+    }
+
+    std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+      num_experts);
+    for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+      for (int k = 0; k < static_cast<int>(topk); ++k) {
+        unsigned expert_idx = indices_data[i * topk + k];
+        float weight = topk_values.getValue<float>(i, 0, 0, k);
+        expert_assignments[expert_idx].emplace_back(i, weight);
+      }
+    }
+
+    // LRU prediction set (this token's top-k plus a few near-misses), indices
+    // only; routing weights above are unchanged so output is bit-identical.
+    std::vector<unsigned int> predicted =
+      collect_predicted(router_logits, total_tokens, topk, num_experts);
+
+    long long activate_ns = 0, compute_ns = 0;
+#ifdef DEBUG
+    int hit_count = 0, miss_count = 0;
+    auto t_loop0 = high_resolution_clock::now();
+#endif
+
+    // Serial outer loop: the Q4_0 expert GEMV parallelizes internally via
+    // ThreadManager, and nesting parallel_for deadlocks.
+    for (unsigned int expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (assignments.empty())
+        continue;
+
+      bool is_miss =
+        run_active_expert(context, input, output, assignments, expert_idx,
+                          hidden_size, activate_ns, compute_ns);
+#ifdef DEBUG
+      is_miss ? ++miss_count : ++hit_count;
+#else
+      (void)is_miss;
+#endif
+    }
+
+    // Keep predicted experts warm, then evict the coldest beyond cache_size.
+    touch_predicted(predicted);
+    evict_experts(context);
+
+#ifdef DEBUG
+    auto t_loop1 = high_resolution_clock::now();
+    auto dt = duration_cast<nanoseconds>(t_loop1 - t_loop0);
+    std::cout << context.getName() << " \t| " << dt.count() / 1'000'000 << " ms"
+              << "\t| hit=" << hit_count << " miss=" << miss_count
+              << "\t| activate=" << activate_ns / 1'000'000 << "ms"
+              << " compute=" << compute_ns / 1'000'000 << "ms"
+              << " resident=" << loaded_expert_deque.size() << std::endl;
+#else
+    (void)activate_ns;
+    (void)compute_ns;
+#endif
+
+    output.reshape({batch_size, 1, seq_len, hidden_size});
+  }
+}
+
+void SmallThinkerCachedSlimMoELayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, moe_props);
+  nntrainer::LayerImpl::setProperty(remain_props);
+}
+
+void SmallThinkerCachedSlimMoELayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support derivative calculation");
+}
+
+void SmallThinkerCachedSlimMoELayer::calcGradient(
+  nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support gradient calculation");
+}
+
+void SmallThinkerCachedSlimMoELayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  nntrainer::LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(moe_props, method, this);
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_cached_slim.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_cached_slim.h
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   smallthinker_moe_layer_cached_slim.h
+ * @date   26 June 2026
+ * @brief  SmallThinker MoE layer with on-demand expert loading and LRU cache.
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#ifndef __SMALLTHINKER_MOE_LAYER_CACHED_SLIM_H__
+#define __SMALLTHINKER_MOE_LAYER_CACHED_SLIM_H__
+#ifdef __cplusplus
+
+#include <list>
+#include <mutex>
+#include <smallthinker_moe_layer.h>
+#include <unordered_map>
+#include <vector>
+
+namespace causallm {
+
+/**
+ * @class   SmallThinkerCachedSlimMoELayer
+ * @brief   SmallThinker Mixture of Expert Layer with virtual expert weights
+ *          and an LRU cache to keep recently-used experts mapped across tokens.
+ */
+class SmallThinkerCachedSlimMoELayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief     Constructor of SmallThinker cached-slim Mixture of Expert Layer
+   */
+  SmallThinkerCachedSlimMoELayer();
+
+  /**
+   * @brief     Destructor of SmallThinker cached-slim Mixture of Expert Layer
+   */
+  ~SmallThinkerCachedSlimMoELayer() = default;
+
+  /**
+   * @brief  Move constructor.
+   * @param[in] SmallThinkerCachedSlimMoELayer &&
+   */
+  SmallThinkerCachedSlimMoELayer(
+    SmallThinkerCachedSlimMoELayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @param[in] rhs SmallThinkerCachedSlimMoELayer to be moved.
+   */
+  SmallThinkerCachedSlimMoELayer &
+  operator=(SmallThinkerCachedSlimMoELayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, const ml::train::ExportMethods
+   * &methods)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return SmallThinkerCachedSlimMoELayer::type;
+  };
+
+  /**
+   * @brief Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return false; }
+
+  static constexpr const char *type =
+    "smallthinker_moe_cached_slim"; /**< type of the layer */
+
+private:
+  unsigned int num_experts;      /**< number of experts */
+  unsigned int topk;             /**< number of experts per token */
+  bool router_apply_softmax;     /**< whether router uses softmax or sigmoid */
+  unsigned int cache_size;       /**< max resident experts in the LRU cache */
+  nntrainer::ActiFunc acti_func; /**< activation function for the expert */
+  std::tuple<props::NumExperts, props::NumExpertsPerToken,
+             nntrainer::props::Unit, props::MoEActivation,
+             props::MoERouterApplySoftmax, props::MoECacheSize>
+    moe_props;
+
+  // weight indices
+  std::vector<unsigned int> expert_gate_proj_indices;
+  std::vector<unsigned int> expert_up_proj_indices;
+  std::vector<unsigned int> expert_down_proj_indices;
+  unsigned int gate_idx;
+
+  // intermediate tensor indices
+  unsigned int router_logits_idx;
+  unsigned int expert_mask_idx;
+
+  // LRU cache of resident (mmap'd) experts. An expert stays mapped across
+  // tokens until evicted, so repeatedly-hit experts are not re-loaded. Guarded
+  // by cache_mutex so a background prefetch thread can mutate it too.
+  std::list<int> loaded_expert_deque; /**< LRU order */
+  std::unordered_map<int, std::list<int>::iterator> iteration_map;
+  std::vector<bool> need_load; /**< per-expert: must activate before use */
+  std::mutex cache_mutex;
+
+  inline void compute_expert_forward(
+    const nntrainer::Tensor &input, nntrainer::Tensor &output,
+    const std::vector<std::pair<unsigned, float>> &token_assignments,
+    const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+    const nntrainer::Tensor &down_proj, unsigned int hidden_size);
+
+  /**
+   * @brief Activate the expert on a cache miss (and record it in the LRU),
+   *        then run the expert forward. Does NOT deactivate; eviction is
+   *        deferred to evict_experts().
+   * @return true if this was a cache miss (expert was activated here).
+   */
+  bool
+  run_active_expert(nntrainer::RunLayerContext &context,
+                    const nntrainer::Tensor &input, nntrainer::Tensor &output,
+                    const std::vector<std::pair<unsigned, float>> &assignments,
+                    unsigned int expert_idx, unsigned int hidden_size,
+                    long long &activate_ns, long long &compute_ns);
+
+  /** @brief Bump predicted experts to the MRU end so they survive eviction. */
+  void touch_predicted(const std::vector<unsigned int> &predicted);
+
+  /** @brief Deactivate (munmap) LRU-front experts until size <= cache_size. */
+  void evict_experts(nntrainer::RunLayerContext &context);
+};
+} // namespace causallm
+
+#endif /* __cplusplus */
+#endif /* __SMALLTHINKER_MOE_LAYER_CACHED_SLIM_H__ */

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_slim.cpp
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_slim.cpp
@@ -1,0 +1,418 @@
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file   smallthinker_moe_layer_slim.cpp
+ * @date   12 May 2026
+ * @brief  SmallThinker MoE layer with on-demand expert loading (no cache).
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#include <cmath>
+#include <node_exporter.h>
+#include <smallthinker_moe_layer_slim.h>
+#include <stdexcept>
+#include <thread_manager.h>
+
+namespace causallm {
+
+namespace {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+void normalize_router_weights(nntrainer::Tensor &topk_values,
+                              unsigned int total_tokens, unsigned int topk,
+                              bool router_apply_softmax) {
+  if (router_apply_softmax) {
+    topk_values.apply(nntrainer::ActiFunc::softmax<float>, topk_values);
+    return;
+  }
+
+  float *values_data = topk_values.getData<float>();
+  for (unsigned int i = 0; i < total_tokens; ++i) {
+    float sum = 0.0f;
+    for (unsigned int k = 0; k < topk; ++k) {
+      float &value = values_data[i * topk + k];
+      value = 1.0f / (1.0f + std::exp(-value));
+      sum += value;
+    }
+    for (unsigned int k = 0; k < topk; ++k) {
+      values_data[i * topk + k] /= sum;
+    }
+  }
+}
+
+} // namespace
+
+SmallThinkerSlimMoELayer::SmallThinkerSlimMoELayer() :
+  LayerImpl(),
+  num_experts(0),
+  topk(0),
+  router_apply_softmax(true),
+  moe_props(props::NumExperts(), props::NumExpertsPerToken(),
+            nntrainer::props::Unit(), props::MoEActivation(),
+            props::MoERouterApplySoftmax()),
+  expert_gate_proj_indices({}),
+  expert_up_proj_indices({}),
+  expert_down_proj_indices({}),
+  gate_idx(std::numeric_limits<unsigned>::max()),
+  router_logits_idx(std::numeric_limits<unsigned>::max()),
+  expert_mask_idx(std::numeric_limits<unsigned>::max()) {}
+
+void SmallThinkerSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
+
+  NNTR_THROW_IF(context.getNumInputs() != 2, std::invalid_argument)
+    << "SmallThinker slim MoE layer requires expert input and router input";
+
+  auto &weight_regularizer =
+    std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
+  auto &weight_regularizer_constant =
+    std::get<nntrainer::props::WeightRegularizerConstant>(*layer_impl_props);
+  auto &weight_initializer =
+    std::get<nntrainer::props::WeightInitializer>(*layer_impl_props);
+  auto &weight_decay =
+    std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
+
+  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  const bool is_nchw = context.getFormat() == nntrainer::Tformat::NCHW;
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  context.setOutputDimensions(output_dims);
+
+  num_experts = std::get<props::NumExperts>(moe_props).get();
+  topk = std::get<props::NumExpertsPerToken>(moe_props).get();
+  router_apply_softmax =
+    std::get<props::MoERouterApplySoftmax>(moe_props).get();
+  const unsigned int intermediate_size =
+    std::get<nntrainer::props::Unit>(moe_props).get();
+  const unsigned int hidden_size = in_dim.width();
+
+  if (std::get<props::MoEActivation>(moe_props).empty()) {
+    throw std::runtime_error("Activation type is not set for MoE layer");
+  }
+  switch (context.getActivationDataType()) {
+  case ml::train::TensorDim::DataType::FP32:
+    acti_func.setActiFunc<float>(
+      std::get<props::MoEActivation>(moe_props).get());
+    break;
+  default:
+    throw std::runtime_error("Unsupported activation data type for MoE layer");
+  }
+
+  nntrainer::TensorDim gate_dim(
+    1, is_nchw ? 1 : num_experts, is_nchw ? hidden_size : 1,
+    is_nchw ? num_experts : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     nntrainer::TensorDim::DataType::FP32),
+    is_nchw ? 0b0011 : 0b0101);
+
+  gate_idx = context.requestWeight(
+    gate_dim, weight_initializer, weight_regularizer,
+    weight_regularizer_constant, weight_decay, "gate", true);
+
+  expert_gate_proj_indices.reserve(num_experts);
+  expert_up_proj_indices.reserve(num_experts);
+  expert_down_proj_indices.reserve(num_experts);
+
+  nntrainer::TensorDim expert_gate_dim(
+    1, is_nchw ? 1 : intermediate_size, is_nchw ? hidden_size : 1,
+    is_nchw ? intermediate_size : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  nntrainer::TensorDim expert_down_dim(
+    1, is_nchw ? 1 : hidden_size, is_nchw ? intermediate_size : 1,
+    is_nchw ? hidden_size : intermediate_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  for (unsigned int i = 0; i < num_experts; ++i) {
+    expert_up_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_up_" + std::to_string(i), false, true));
+
+    expert_gate_proj_indices.push_back(context.requestWeight(
+      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_gate_" + std::to_string(i), false, true));
+
+    expert_down_proj_indices.push_back(context.requestWeight(
+      expert_down_dim, weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_down_" + std::to_string(i), false, true));
+  }
+
+  const unsigned batch_size = in_dim.batch();
+  const unsigned seq_len = in_dim.height();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  router_logits_idx =
+    context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
+                          nntrainer::Initializer::NONE, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+
+  expert_mask_idx =
+    context.requestTensor({num_experts, 1, topk, total_tokens}, "expert_mask",
+                          nntrainer::Initializer::ZEROS, false,
+                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+}
+
+void SmallThinkerSlimMoELayer::forwarding(nntrainer::RunLayerContext &context,
+                                          bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input = context.getInput(1);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  const unsigned batch_size = input.batch();
+  const unsigned seq_len = input.height();
+  const unsigned hidden_size = input.width();
+  const unsigned total_tokens = batch_size * seq_len;
+
+  input.reshape({total_tokens, 1, 1, hidden_size});
+  router_input.reshape({total_tokens, 1, 1, hidden_size});
+  output.reshape({total_tokens, 1, 1, hidden_size});
+  output.setZero();
+
+  nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+  router_input.dot(gate_weights, router_logits);
+  auto topk_result = router_logits.topK(topk);
+  auto topk_values = std::get<0>(topk_result);
+  auto topk_indices = std::get<1>(topk_result);
+
+  normalize_router_weights(topk_values, total_tokens, topk,
+                           router_apply_softmax);
+
+  expert_mask.setZero();
+  const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+  auto &tm = nntrainer::ThreadManager::Global();
+  tm.parallel_for(0, total_tokens * topk, [&](size_t idx) {
+    const size_t i = idx / topk;
+    const size_t k = idx % topk;
+    expert_mask.setValue(indices_data[i * topk + k], 0, k, i, 1.0f);
+  });
+
+  std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+    num_experts);
+  for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+    for (int k = 0; k < static_cast<int>(topk); ++k) {
+      unsigned expert_idx = indices_data[i * topk + k];
+      float weight = topk_values.getValue<float>(i, 0, 0, k);
+      expert_assignments[expert_idx].emplace_back(i, weight);
+    }
+  }
+
+  for (unsigned int expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+    const auto &assignments = expert_assignments[expert_idx];
+    if (assignments.empty())
+      continue;
+
+    auto &gate_proj = context.getWeight(expert_gate_proj_indices[expert_idx]);
+    auto &up_proj = context.getWeight(expert_up_proj_indices[expert_idx]);
+    auto &down_proj = context.getWeight(expert_down_proj_indices[expert_idx]);
+
+    gate_proj.activate();
+    up_proj.activate();
+    down_proj.activate();
+
+    compute_expert_forward(input, output, assignments, gate_proj, up_proj,
+                           down_proj, hidden_size);
+
+    gate_proj.deactivate();
+    up_proj.deactivate();
+    down_proj.deactivate();
+  }
+
+  output.reshape({batch_size, 1, seq_len, hidden_size});
+  input.reshape({batch_size, 1, seq_len, hidden_size});
+  router_input.reshape({batch_size, 1, seq_len, hidden_size});
+}
+
+inline void SmallThinkerSlimMoELayer::compute_expert_forward(
+  const nntrainer::Tensor &input, nntrainer::Tensor &output,
+  const std::vector<std::pair<unsigned, float>> &token_assignments,
+  const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+  const nntrainer::Tensor &down_proj, unsigned int hidden_size) {
+
+  const unsigned intermediate_size = gate_proj.width();
+  const unsigned num_tokens = token_assignments.size();
+
+  if (num_tokens == 0)
+    return;
+
+  nntrainer::TensorDim token_input_dim({1, 1, 1, hidden_size},
+                                       input.getTensorType());
+  nntrainer::TensorDim intermediate_dim({1, 1, 1, intermediate_size},
+                                        input.getTensorType());
+  nntrainer::TensorDim token_output_dim({1, 1, 1, hidden_size},
+                                        input.getTensorType());
+
+  nntrainer::Tensor expert_output(output.batch(), output.channel(),
+                                  output.height(), output.width(),
+                                  output.getTensorType());
+  expert_output.setZero();
+
+  for (size_t i = 0; i < num_tokens; ++i) {
+    const unsigned token_idx = token_assignments[i].first;
+    const float weight = token_assignments[i].second;
+
+    size_t token_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_input =
+      input.getSharedDataTensor(token_input_dim, token_offset, true);
+
+    nntrainer::Tensor gate_out(intermediate_dim);
+    nntrainer::Tensor acti_out(intermediate_dim);
+    nntrainer::Tensor up_out(intermediate_dim);
+
+    token_input.dot(gate_proj, gate_out);
+    acti_func.run_fn(gate_out, acti_out);
+    token_input.dot(up_proj, up_out);
+    acti_out.multiply_i(up_out);
+
+    nntrainer::Tensor token_expert_output(token_output_dim);
+    acti_out.dot(down_proj, token_expert_output);
+
+    token_expert_output.multiply_i(weight);
+    size_t output_offset = token_idx * hidden_size;
+    nntrainer::Tensor token_output =
+      expert_output.getSharedDataTensor(token_output_dim, output_offset, true);
+
+    token_output.add_i(token_expert_output);
+  }
+
+  output.add_i(expert_output);
+}
+
+void SmallThinkerSlimMoELayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+
+  nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &router_input_ = context.getInput(1);
+  nntrainer::Tensor &output_ = context.getOutput(SINGLE_INOUT_IDX);
+
+  nntrainer::Tensor &router_logits_ = context.getTensor(router_logits_idx);
+  nntrainer::Tensor &expert_mask = context.getTensor(expert_mask_idx);
+
+  nntrainer::TensorDim input_step_dim = input_.getDim();
+  nntrainer::TensorDim output_step_dim = output_.getDim();
+  nntrainer::TensorDim router_logits_step_dim = router_logits_.getDim();
+
+  input_step_dim.batch(1);
+  output_step_dim.batch(1);
+  router_logits_step_dim.batch(to - from);
+
+  input_step_dim.height(to - from);
+  output_step_dim.height(to - from);
+
+  for (unsigned int b = 0; b < input_.batch(); ++b) {
+    auto input = input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto router_input = router_input_.getSharedDataTensor(
+      input_step_dim, b * input_step_dim.getFeatureLen(), true);
+    auto output = output_.getSharedDataTensor(
+      output_step_dim, b * output_step_dim.getFeatureLen(), true);
+    auto router_logits =
+      router_logits_.getSharedDataTensor(router_logits_step_dim, 0, true);
+
+    const unsigned batch_size = input.batch();
+    const unsigned seq_len = input.height();
+    const unsigned hidden_size = input.width();
+    const unsigned total_tokens = batch_size * seq_len;
+
+    input.reshape({total_tokens, 1, 1, hidden_size});
+    router_input.reshape({total_tokens, 1, 1, hidden_size});
+    output.reshape({total_tokens, 1, 1, hidden_size});
+    output.setZero();
+    expert_mask.setZero();
+
+    nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
+    router_input.dot(gate_weights, router_logits);
+    auto topk_result = router_logits.topK(topk);
+    auto topk_values = std::get<0>(topk_result);
+    auto topk_indices = std::get<1>(topk_result);
+
+    normalize_router_weights(topk_values, total_tokens, topk,
+                             router_apply_softmax);
+
+    const uint32_t *indices_data = topk_indices.getData<uint32_t>();
+    for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+      for (int k = 0; k < static_cast<int>(topk); ++k) {
+        expert_mask.setValue(indices_data[i * topk + k], 0, k, i, 1.0f);
+      }
+    }
+
+    std::vector<std::vector<std::pair<unsigned, float>>> expert_assignments(
+      num_experts);
+    for (int i = 0; i < static_cast<int>(total_tokens); ++i) {
+      for (int k = 0; k < static_cast<int>(topk); ++k) {
+        unsigned expert_idx = indices_data[i * topk + k];
+        float weight = topk_values.getValue<float>(i, 0, 0, k);
+        expert_assignments[expert_idx].emplace_back(i, weight);
+      }
+    }
+
+    // Serial outer loop: the Q4_0 expert GEMV parallelizes internally via
+    // ThreadManager, and nesting parallel_for deadlocks.
+    for (unsigned int expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (assignments.empty())
+        continue;
+
+      auto &gate_proj = context.getWeight(expert_gate_proj_indices[expert_idx]);
+      auto &up_proj = context.getWeight(expert_up_proj_indices[expert_idx]);
+      auto &down_proj = context.getWeight(expert_down_proj_indices[expert_idx]);
+
+      gate_proj.activate();
+      up_proj.activate();
+      down_proj.activate();
+
+      compute_expert_forward(input, output, assignments, gate_proj, up_proj,
+                             down_proj, hidden_size);
+
+      gate_proj.deactivate();
+      up_proj.deactivate();
+      down_proj.deactivate();
+    }
+
+    output.reshape({batch_size, 1, seq_len, hidden_size});
+  }
+}
+
+void SmallThinkerSlimMoELayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, moe_props);
+  nntrainer::LayerImpl::setProperty(remain_props);
+}
+
+void SmallThinkerSlimMoELayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support derivative calculation");
+}
+
+void SmallThinkerSlimMoELayer::calcGradient(
+  nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("MoE layer does not support gradient calculation");
+}
+
+void SmallThinkerSlimMoELayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  nntrainer::LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(moe_props, method, this);
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_slim.h
+++ b/Applications/CausalLM/models/smallthinker/smallthinker_moe_layer_slim.h
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   smallthinker_moe_layer_slim.h
+ * @date   12 May 2026
+ * @brief  SmallThinker MoE layer with on-demand expert loading (no cache).
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ */
+
+#ifndef __SMALLTHINKER_MOE_LAYER_SLIM_H__
+#define __SMALLTHINKER_MOE_LAYER_SLIM_H__
+#ifdef __cplusplus
+
+#include <smallthinker_moe_layer.h>
+#include <vector>
+
+namespace causallm {
+
+/**
+ * @class   SmallThinkerSlimMoELayer
+ * @brief   SmallThinker Mixture of Expert Layer with virtual expert weights.
+ *          Each expert is activated (mmap'd), computed, and immediately
+ *          deactivated (munmap'd) — no persistent cache across tokens.
+ */
+class SmallThinkerSlimMoELayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief     Constructor of SmallThinker slim Mixture of Expert Layer
+   */
+  SmallThinkerSlimMoELayer();
+
+  /**
+   * @brief     Destructor of SmallThinker slim Mixture of Expert Layer
+   */
+  ~SmallThinkerSlimMoELayer() = default;
+
+  /**
+   * @brief  Move constructor.
+   * @param[in] SmallThinkerSlimMoELayer &&
+   */
+  SmallThinkerSlimMoELayer(SmallThinkerSlimMoELayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @param[in] rhs SmallThinkerSlimMoELayer to be moved.
+   */
+  SmallThinkerSlimMoELayer &operator=(SmallThinkerSlimMoELayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, const ml::train::ExportMethods
+   * &methods)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return SmallThinkerSlimMoELayer::type;
+  };
+
+  /**
+   * @brief Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return false; }
+
+  static constexpr const char *type =
+    "smallthinker_moe_slim"; /**< type of the layer */
+
+private:
+  unsigned int num_experts;      /**< number of experts */
+  unsigned int topk;             /**< number of experts per token */
+  bool router_apply_softmax;     /**< whether router uses softmax or sigmoid */
+  nntrainer::ActiFunc acti_func; /**< activation function for the expert */
+  std::tuple<props::NumExperts, props::NumExpertsPerToken,
+             nntrainer::props::Unit, props::MoEActivation,
+             props::MoERouterApplySoftmax>
+    moe_props;
+
+  // weight indices
+  std::vector<unsigned int> expert_gate_proj_indices;
+  std::vector<unsigned int> expert_up_proj_indices;
+  std::vector<unsigned int> expert_down_proj_indices;
+  unsigned int gate_idx;
+
+  // intermediate tensor indices
+  unsigned int router_logits_idx;
+  unsigned int expert_mask_idx;
+
+  inline void compute_expert_forward(
+    const nntrainer::Tensor &input, nntrainer::Tensor &output,
+    const std::vector<std::pair<unsigned, float>> &token_assignments,
+    const nntrainer::Tensor &gate_proj, const nntrainer::Tensor &up_proj,
+    const nntrainer::Tensor &down_proj, unsigned int hidden_size);
+};
+} // namespace causallm
+
+#endif /* __cplusplus */
+#endif /* __SMALLTHINKER_MOE_LAYER_SLIM_H__ */

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -357,6 +357,14 @@ void registerAllModels() {
       return std::make_unique<causallm::SmallThinkerSlimCausalLM>(
         cfg, generation_cfg, nntr_cfg);
     });
+#if !defined(_WIN32)
+  factory.registerModel(
+    "SmallThinkerCachedSlimForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerCachedSlimCausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
+#endif
 }
 
 /**

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -85,6 +85,7 @@
 #include "qwen3_embedding.h"
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
+#include "smallthinker_causallm.h"
 
 using json = nlohmann::json;
 using DataType = ml::train::TensorDim::DataType;
@@ -343,6 +344,13 @@ void registerAllModels() {
                           return std::make_unique<causallm::EmbeddingGemma>(
                             cfg, generation_cfg, nntr_cfg);
                         });
+  factory.registerModel(
+    "SmallThinkerForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerCausalLM>(cfg,
+                                                              generation_cfg,
+                                                              nntr_cfg);
+    });
 }
 
 /**

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -351,6 +351,12 @@ void registerAllModels() {
                                                               generation_cfg,
                                                               nntr_cfg);
     });
+  factory.registerModel(
+    "SmallThinkerSlimForCausalLM",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::SmallThinkerSlimCausalLM>(
+        cfg, generation_cfg, nntr_cfg);
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary

- **base** (`SmallThinkerForCausalLM`): all expert weights resident in RAM; full-memory MoE with batched GEMM for prefill and per-token GEMV for decode
- **slim** (`SmallThinkerSlimForCausalLM`): pure on-demand loading — each expert is mmap'd, computed, then immediately munmap'd; minimal memory footprint at the cost of repeated load overhead
- **cachedslim** (`SmallThinkerCachedSlimForCausalLM`): on-demand loading with LRU expert cache (default 32 slots, tuneable via `NNTR_MOE_CACHE_SIZE`); keeps recently-used experts mapped across tokens, reducing cold loads using a top-k+5 prediction set

SmallThinker uses a non-standard MoE routing scheme shared across all three variants:
- Router input is the **pre-attention residual** (not the ffn-normed tensor)
- Expert forward: `relu(gate_proj(x)) * up_proj(x) → down_proj`
- Router weights are always **FP32** regardless of expert quantization (quantizing the router scrambles top-k selection)
- Router normalization is configurable: softmax or sigmoid+normalize (controlled by `moe_primary_router_apply_softmax`)

The three variants match the Qwen3 model family structure (`base` / `slim` / `cachedslim`). The slim variant was re-aligned: previously SmallThinker slim contained full LRU cache logic (functionally equivalent to cachedslim); this PR separates the two concerns cleanly.

## Test plan

- [ ] Build host: `meson compile -C build` — no errors
- [ ] Build Android: `./build_android.sh` — no errors
- [ ] Run inference with each architecture string and confirm identical output text across all three variants on a fixed prompt
- [ ] With `-DDEBUG`, confirm cachedslim prints `hit=/miss=/resident=` per layer and `resident` stays ≤ `cache_size`
- [ ] `NNTR_MOE_CACHE_SIZE=0` forces evict-every-token (miss ≈ active experts per token)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)