### PR TITLE
[cpu_backend] Add stride-1 max pool (separable NEON) kernel

### DIFF
--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -465,7 +465,8 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     break;
   }
 
-  const unsigned int map_size = (unsigned int)in_height * (unsigned int)in_width;
+  const unsigned int map_size =
+    (unsigned int)in_height * (unsigned int)in_width;
   const unsigned int out_map = output.height() * output.width();
   const int height_stride_end = height - patch_height - pt;
   const int width_stride_end = width - patch_width - pl;
@@ -490,15 +491,15 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
         T *out_c = out_data + (size_t)c * out_map;
         if (neon_max) {
           if constexpr (std::is_same_v<T, float>) {
-            getComputeOps()->maxpool2d_s1_fp32(in_c, out_c, in_height, in_width,
-                                               Ho, Wo, (int)patch_height,
-                                               (int)patch_width, (int)pt, (int)pl);
+            getComputeOps()->maxpool2d_s1_fp32(
+              in_c, out_c, in_height, in_width, Ho, Wo, (int)patch_height,
+              (int)patch_width, (int)pt, (int)pl);
           }
 #ifdef ENABLE_FP16
           else if constexpr (std::is_same_v<T, _FP16>) {
-            getComputeOps()->maxpool2d_s1_fp16(in_c, out_c, in_height, in_width,
-                                               Ho, Wo, (int)patch_height,
-                                               (int)patch_width, (int)pt, (int)pl);
+            getComputeOps()->maxpool2d_s1_fp16(
+              in_c, out_c, in_height, in_width, Ho, Wo, (int)patch_height,
+              (int)patch_width, (int)pt, (int)pl);
           }
 #endif
           continue;

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -14,9 +14,10 @@
  */
 
 #include <cstring>
-#include <limits>
+#include <type_traits>
 
 #include <common_properties.h>
+#include <cpu_backend.h>
 #include <layer_context.h>
 #include <nntr_threads.h>
 #include <nntrainer_error.h>
@@ -24,6 +25,7 @@
 #include <node_exporter.h>
 #include <pooling2d_layer.h>
 #include <util_func.h>
+
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
@@ -323,7 +325,10 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
   auto &pooling_type = std::get<props::PoolingType>(pooling2d_props).get();
 
   unsigned int channel = in.channel();
-  auto [pt, pb, pl, pr] = padding;
+  auto pt = padding[0];
+  auto pb = padding[1];
+  auto pl = padding[2];
+  auto pr = padding[3];
 
   int in_height = in.height();
   int in_width = in.width();
@@ -460,44 +465,66 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     break;
   }
 
-  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    const float *in_data = in.getData<float>();
-    float *out_data = output.getData<float>();
+  const unsigned int map_size = (unsigned int)in_height * (unsigned int)in_width;
+  const unsigned int out_map = output.height() * output.width();
+  const int height_stride_end = height - patch_height - pt;
+  const int width_stride_end = width - patch_width - pl;
 
-    unsigned int map_size = in_height * in_width;
+  // For inference the channels are independent, so run them in parallel -- the
+  // surrounding forwarding() only parallelizes over batch, which is 1 here, so
+  // pooling was effectively single-threaded. Training keeps the original serial
+  // order so pool_helper (max indices) is written in the expected sequence.
+  // NEON-vectorized stride-1 max pooling fast path (inference only): the SPPF
+  // maxpools are 5x5 stride-1. For other configs / training fall back to the
+  // generic pool_fn.
+  const bool neon_max = !training &&
+                        pooling_type == props::PoolingTypeInfo::Enum::max &&
+                        stride[0].get() == 1 && stride[1].get() == 1;
+  const int Ho = (int)output.height(), Wo = (int)output.width();
 
-    int height_stride_end = height - patch_height - pt;
-    int width_stride_end = width - patch_width - pl;
-    for (unsigned int i = 0; i < channel; ++i) {
-      const float *in_data_channel_sliced = in_data + i * map_size;
-      for (int j = -(int)pt; j <= height_stride_end; j += stride[0]) {
-        for (int k = -(int)pl; k <= width_stride_end; k += stride[1]) {
-          float pool_value = pool_fn_fp32(in_data_channel_sliced, i, j, k);
-          *out_data = pool_value;
-          out_data++;
+  auto run = [&]<typename T>(const T *in_data, T *out_data,
+                             const typename PoolFunc<T>::Type &pool_fn) {
+    auto job = [&](unsigned int cs, unsigned int ce, unsigned int, void *) {
+      for (unsigned int c = cs; c < ce; ++c) {
+        const T *in_c = in_data + (size_t)c * map_size;
+        T *out_c = out_data + (size_t)c * out_map;
+        if (neon_max) {
+          if constexpr (std::is_same_v<T, float>) {
+            getComputeOps()->maxpool2d_s1_fp32(in_c, out_c, in_height, in_width,
+                                               Ho, Wo, (int)patch_height,
+                                               (int)patch_width, (int)pt, (int)pl);
+          }
+#ifdef ENABLE_FP16
+          else if constexpr (std::is_same_v<T, _FP16>) {
+            getComputeOps()->maxpool2d_s1_fp16(in_c, out_c, in_height, in_width,
+                                               Ho, Wo, (int)patch_height,
+                                               (int)patch_width, (int)pt, (int)pl);
+          }
+#endif
+          continue;
         }
+        unsigned int oi = 0;
+        for (int j = -(int)pt; j <= height_stride_end; j += stride[0])
+          for (int k = -(int)pl; k <= width_stride_end; k += stride[1])
+            out_c[oi++] = pool_fn(in_c, (int)c, j, k);
+      }
+    };
+    if (!training) {
+      auto workers = ParallelBatch(job, channel, nullptr);
+      if (workers.getNumWorkers() > 1) {
+        workers.run();
+        return;
       }
     }
+    job(0, channel, 0, nullptr);
+  };
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    run(in.getData<float>(), output.getData<float>(), pool_fn_fp32);
   }
 #ifdef ENABLE_FP16
   else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
-    const _FP16 *in_data = in.getData<_FP16>();
-    _FP16 *out_data = output.getData<_FP16>();
-
-    unsigned int map_size = in_height * in_width;
-
-    int height_stride_end = height - patch_height - pt;
-    int width_stride_end = width - patch_width - pl;
-    for (unsigned int i = 0; i < channel; ++i) {
-      const _FP16 *in_data_channel_sliced = in_data + i * map_size;
-      for (int j = -pt; j <= height_stride_end; j += stride[0]) {
-        for (int k = -pl; k <= width_stride_end; k += stride[1]) {
-          _FP16 pool_value = pool_fn_fp16(in_data_channel_sliced, i, j, k);
-          *out_data = pool_value;
-          out_data++;
-        }
-      }
-    }
+    run(in.getData<_FP16>(), output.getData<_FP16>(), pool_fn_fp16);
   }
 #endif
   else {

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,6 +524,116 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  std::vector<float> tmp((size_t)Hi * Wi);
+  const float ninf = std::numeric_limits<float>::lowest();
+
+  // Row pass
+  for (int ih = 0; ih < Hi; ++ih) {
+    const float *irow = in + (size_t)ih * Wi;
+    float *trow = tmp.data() + (size_t)ih * Wi;
+    for (int w = 0; w < Wi; ++w)
+      trow[w] = ninf;
+    for (int kw = 0; kw < pw; ++kw) {
+      const int shift = kw - pad_l;
+      const int w0 = (shift < 0) ? -shift : 0;
+      const int w1r = Wi - shift;
+      const int w1 = (Wo < w1r) ? Wo : w1r;
+      int w = w0;
+#ifdef __ARM_NEON
+      for (; w + 4 <= w1; w += 4)
+        vst1q_f32(trow + w,
+                  vmaxq_f32(vld1q_f32(trow + w),
+                            vld1q_f32(irow + w + shift)));
+#endif
+      for (; w < w1; ++w)
+        if (irow[w + shift] > trow[w])
+          trow[w] = irow[w + shift];
+    }
+  }
+
+  // Col pass
+  for (int oh = 0; oh < Ho; ++oh) {
+    float *orow = out + (size_t)oh * Wo;
+    for (int w = 0; w < Wo; ++w)
+      orow[w] = ninf;
+    for (int kh = 0; kh < ph; ++kh) {
+      const int ih = oh - pad_t + kh;
+      if (ih < 0 || ih >= Hi)
+        continue;
+      const float *trow = tmp.data() + (size_t)ih * Wi;
+      int w = 0;
+#ifdef __ARM_NEON
+      for (; w + 4 <= Wo; w += 4)
+        vst1q_f32(orow + w,
+                  vmaxq_f32(vld1q_f32(orow + w),
+                            vld1q_f32(trow + w)));
+#endif
+      for (; w < Wo; ++w)
+        if (trow[w] > orow[w])
+          orow[w] = trow[w];
+    }
+  }
+}
+
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  std::vector<_FP16> tmp((size_t)Hi * Wi);
+  const _FP16 ninf = std::numeric_limits<_FP16>::lowest();
+
+  // Row pass
+  for (int ih = 0; ih < Hi; ++ih) {
+    const _FP16 *irow = in + (size_t)ih * Wi;
+    _FP16 *trow = tmp.data() + (size_t)ih * Wi;
+    for (int w = 0; w < Wi; ++w)
+      trow[w] = ninf;
+    for (int kw = 0; kw < pw; ++kw) {
+      const int shift = kw - pad_l;
+      const int w0 = (shift < 0) ? -shift : 0;
+      const int w1r = Wi - shift;
+      const int w1 = (Wo < w1r) ? Wo : w1r;
+      int w = w0;
+#ifdef __ARM_NEON
+      for (; w + 8 <= w1; w += 8)
+        vst1q_f16((__fp16 *)trow + w,
+                  vmaxq_f16(vld1q_f16((const __fp16 *)trow + w),
+                            vld1q_f16((const __fp16 *)irow + w + shift)));
+#endif
+      for (; w < w1; ++w)
+        if (irow[w + shift] > trow[w])
+          trow[w] = irow[w + shift];
+    }
+  }
+
+  // Col pass
+  for (int oh = 0; oh < Ho; ++oh) {
+    _FP16 *orow = out + (size_t)oh * Wo;
+    for (int w = 0; w < Wo; ++w)
+      orow[w] = ninf;
+    for (int kh = 0; kh < ph; ++kh) {
+      const int ih = oh - pad_t + kh;
+      if (ih < 0 || ih >= Hi)
+        continue;
+      const _FP16 *trow = tmp.data() + (size_t)ih * Wi;
+      int w = 0;
+#ifdef __ARM_NEON
+      for (; w + 8 <= Wo; w += 8)
+        vst1q_f16((__fp16 *)orow + w,
+                  vmaxq_f16(vld1q_f16((const __fp16 *)orow + w),
+                            vld1q_f16((const __fp16 *)trow + w)));
+#endif
+      for (; w < Wo; ++w)
+        if (trow[w] > orow[w])
+          orow[w] = trow[w];
+    }
+  }
+}
+#endif  // ENABLE_FP16
+
 template <>
 void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
                      int num_rows, int num_cache_head, int head_dim,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,9 +524,8 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   std::vector<float> tmp((size_t)Hi * Wi);
   const float ninf = std::numeric_limits<float>::lowest();
 
@@ -545,8 +544,7 @@ void maxpool2d_s1_fp32(const float *in, float *out,
 #ifdef __ARM_NEON
       for (; w + 4 <= w1; w += 4)
         vst1q_f32(trow + w,
-                  vmaxq_f32(vld1q_f32(trow + w),
-                            vld1q_f32(irow + w + shift)));
+                  vmaxq_f32(vld1q_f32(trow + w), vld1q_f32(irow + w + shift)));
 #endif
       for (; w < w1; ++w)
         if (irow[w + shift] > trow[w])
@@ -568,8 +566,7 @@ void maxpool2d_s1_fp32(const float *in, float *out,
 #ifdef __ARM_NEON
       for (; w + 4 <= Wo; w += 4)
         vst1q_f32(orow + w,
-                  vmaxq_f32(vld1q_f32(orow + w),
-                            vld1q_f32(trow + w)));
+                  vmaxq_f32(vld1q_f32(orow + w), vld1q_f32(trow + w)));
 #endif
       for (; w < Wo; ++w)
         if (trow[w] > orow[w])
@@ -579,9 +576,8 @@ void maxpool2d_s1_fp32(const float *in, float *out,
 }
 
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   std::vector<_FP16> tmp((size_t)Hi * Wi);
   const _FP16 ninf = std::numeric_limits<_FP16>::lowest();
 
@@ -632,7 +628,7 @@ void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
     }
   }
 }
-#endif  // ENABLE_FP16
+#endif // ENABLE_FP16
 
 template <>
 void compute_kcaches(const float *in, const uint16_t *kcache, float *output,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1383,14 +1383,12 @@ void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Stride-1 max pool FP32 with NEON (ARM backend).
  */
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1381,6 +1381,19 @@ void clamp(const T *input, T *output, size_t length,
            T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Stride-1 max pool FP32 with NEON (ARM backend).
+ */
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+#endif
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,6 +151,11 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
+void ComputeOps::maxpool2d_s1_fp32(const float *, float *,
+                                    int, int, int, int, int, int, int, int) {
+  NI(maxpool2d_s1_fp32);
+}
+
 void ComputeOps::scopy_u8(unsigned int, const uint8_t *, unsigned int,
                           uint8_t *, unsigned int) {
   NI(scopy_u8);
@@ -403,6 +408,10 @@ void ComputeOps::compute_rotary_embedding_value(unsigned int, unsigned int,
                                                 unsigned int, _FP16 *, _FP16 *,
                                                 float *, float *) {
   NI(compute_rotary_embedding_value);
+}
+void ComputeOps::maxpool2d_s1_fp16(const _FP16 *, _FP16 *,
+                                    int, int, int, int, int, int, int, int) {
+  NI(maxpool2d_s1_fp16);
 }
 #endif // ENABLE_FP16
 

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,8 +151,8 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
-void ComputeOps::maxpool2d_s1_fp32(const float *, float *,
-                                    int, int, int, int, int, int, int, int) {
+void ComputeOps::maxpool2d_s1_fp32(const float *, float *, int, int, int, int,
+                                   int, int, int, int) {
   NI(maxpool2d_s1_fp32);
 }
 
@@ -409,8 +409,8 @@ void ComputeOps::compute_rotary_embedding_value(unsigned int, unsigned int,
                                                 float *, float *) {
   NI(compute_rotary_embedding_value);
 }
-void ComputeOps::maxpool2d_s1_fp16(const _FP16 *, _FP16 *,
-                                    int, int, int, int, int, int, int, int) {
+void ComputeOps::maxpool2d_s1_fp16(const _FP16 *, _FP16 *, int, int, int, int,
+                                   int, int, int, int) {
   NI(maxpool2d_s1_fp16);
 }
 #endif // ENABLE_FP16

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -135,9 +135,9 @@ public:
    * @brief Stride-1 max pool FP32.
    *        Single-channel kernel: in/out point to [Hi*Wi] / [Ho*Wo] planes.
    */
-  virtual void maxpool2d_s1_fp32(const float *in, float *out,
-                                  int Hi, int Wi, int Ho, int Wo,
-                                  int ph, int pw, int pad_t, int pad_l);
+  virtual void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi,
+                                 int Ho, int Wo, int ph, int pw, int pad_t,
+                                 int pad_l);
 
   // ===========================================================================
   // FP32 Data conversion / Copy
@@ -323,9 +323,9 @@ public:
                                      const _FP16 *src, unsigned int ld_src,
                                      _FP16 *dst, unsigned int ld_dst);
 
-  virtual void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                                  int Hi, int Wi, int Ho, int Wo,
-                                  int ph, int pw, int pad_t, int pad_l);
+  virtual void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi,
+                                 int Ho, int Wo, int ph, int pw, int pad_t,
+                                 int pad_l);
 
   // ===========================================================================
   // FP16 Data conversion

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -129,6 +129,17 @@ public:
                                      float *dst, unsigned int ld_dst);
 
   // ===========================================================================
+  // FP32 Pooling ops
+  // ===========================================================================
+  /**
+   * @brief Stride-1 max pool FP32.
+   *        Single-channel kernel: in/out point to [Hi*Wi] / [Ho*Wo] planes.
+   */
+  virtual void maxpool2d_s1_fp32(const float *in, float *out,
+                                  int Hi, int Wi, int Ho, int Wo,
+                                  int ph, int pw, int pad_t, int pad_l);
+
+  // ===========================================================================
   // FP32 Data conversion / Copy
   // ===========================================================================
   virtual void scopy_u8(const unsigned int N, const uint8_t *X,
@@ -311,6 +322,10 @@ public:
   virtual void transpose_matrix_fp16(const unsigned int M, const unsigned int N,
                                      const _FP16 *src, unsigned int ld_src,
                                      _FP16 *dst, unsigned int ld_dst);
+
+  virtual void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                                  int Hi, int Wi, int Ho, int Wo,
+                                  int ph, int pw, int pad_t, int pad_l);
 
   // ===========================================================================
   // FP16 Data conversion

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1482,6 +1482,19 @@ extern void clamp(const T *input, T *output, size_t length,
                   T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Stride-1 max pool FP32 backend op.
+ */
+extern void maxpool2d_s1_fp32(const float *in, float *out,
+                               int Hi, int Wi, int Ho, int Wo,
+                               int ph, int pw, int pad_t, int pad_l);
+
+#ifdef ENABLE_FP16
+extern void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                               int Hi, int Wi, int Ho, int Wo,
+                               int ph, int pw, int pad_t, int pad_l);
+#endif
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1484,14 +1484,14 @@ extern void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Stride-1 max pool FP32 backend op.
  */
-extern void maxpool2d_s1_fp32(const float *in, float *out,
-                               int Hi, int Wi, int Ho, int Wo,
-                               int ph, int pw, int pad_t, int pad_l);
+extern void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi,
+                              int Ho, int Wo, int ph, int pw, int pad_t,
+                              int pad_l);
 
 #ifdef ENABLE_FP16
-extern void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                               int Hi, int Wi, int Ho, int Wo,
-                               int ph, int pw, int pad_t, int pad_l);
+extern void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi,
+                              int Ho, int Wo, int ph, int pw, int pad_t,
+                              int pad_l);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -122,6 +122,11 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
+  void maxpool2d_s1_fp32(const float *in, float *out,
+                          int Hi, int Wi, int Ho, int Wo,
+                          int ph, int pw, int pad_t, int pad_l) override {
+    nntrainer::maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  }
 
   // FP32 Data conversion / Copy
   void scopy_u8(unsigned int N, const uint8_t *X, unsigned int iX, uint8_t *Y,
@@ -298,6 +303,11 @@ public:
                              unsigned int lds, _FP16 *d,
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
+  }
+  void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                          int Hi, int Wi, int Ho, int Wo,
+                          int ph, int pw, int pad_t, int pad_l) override {
+    nntrainer::maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   }
 
   void scopy_int4_to_float16(unsigned int N, const uint8_t *X, unsigned int iX,

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -122,9 +122,9 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
-  void maxpool2d_s1_fp32(const float *in, float *out,
-                          int Hi, int Wi, int Ho, int Wo,
-                          int ph, int pw, int pad_t, int pad_l) override {
+  void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                         int Wo, int ph, int pw, int pad_t,
+                         int pad_l) override {
     nntrainer::maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   }
 
@@ -304,9 +304,9 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
-  void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                          int Hi, int Wi, int Ho, int Wo,
-                          int ph, int pw, int pad_t, int pad_l) override {
+  void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                         int Wo, int ph, int pw, int pad_t,
+                         int pad_l) override {
     nntrainer::maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   }
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -456,4 +456,18 @@ void gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                          idx_variant, lower_bound, upper_bound);
 }
 
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  __fallback_maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+}
+
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  __fallback_maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+}
+#endif
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -456,16 +456,14 @@ void gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                          idx_variant, lower_bound, upper_bound);
 }
 
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   __fallback_maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
 }
 
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   __fallback_maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
 }
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1310,14 +1310,12 @@ void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Stride-1 max pool FP32 (fallback backend).
  */
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 #endif
 } /* namespace nntrainer */
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1306,6 +1306,19 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief Stride-1 max pool FP32 (fallback backend).
+ */
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+#endif
 } /* namespace nntrainer */
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -1267,4 +1267,87 @@ void __fallback_gemm_qs8d32p_qs4c32p_packed(size_t m, size_t n, size_t k,
   throw std::runtime_error("NYI : __fallback_gemm_qs8d32p_qs4c32p_packed");
 }
 
+
+void __fallback_maxpool2d_s1_fp32(const float *in, float *out,
+                                   int Hi, int Wi, int Ho, int Wo,
+                                   int ph, int pw, int pad_t, int pad_l) {
+  const float ninf = std::numeric_limits<float>::lowest();
+  std::vector<float> tmp((size_t)Hi * Wi);
+
+  // Row pass: tmp[ih][w] = max over pw-wide horizontal window of in
+  for (int ih = 0; ih < Hi; ++ih) {
+    const float *irow = in + (size_t)ih * Wi;
+    float *trow = tmp.data() + (size_t)ih * Wi;
+    for (int w = 0; w < Wi; ++w)
+      trow[w] = ninf;
+    for (int kw = 0; kw < pw; ++kw) {
+      const int shift = kw - pad_l;
+      const int w0 = (shift < 0) ? -shift : 0;
+      const int w1r = Wi - shift;
+      const int w1 = (Wo < w1r) ? Wo : w1r;
+      for (int w = w0; w < w1; ++w)
+        if (irow[w + shift] > trow[w])
+          trow[w] = irow[w + shift];
+    }
+  }
+
+  // Col pass: out[oh][w] = max over ph-tall vertical window of tmp
+  for (int oh = 0; oh < Ho; ++oh) {
+    float *orow = out + (size_t)oh * Wo;
+    for (int w = 0; w < Wo; ++w)
+      orow[w] = ninf;
+    for (int kh = 0; kh < ph; ++kh) {
+      const int ih = oh - pad_t + kh;
+      if (ih < 0 || ih >= Hi)
+        continue;
+      const float *trow = tmp.data() + (size_t)ih * Wi;
+      for (int w = 0; w < Wo; ++w)
+        if (trow[w] > orow[w])
+          orow[w] = trow[w];
+    }
+  }
+}
+
+#ifdef ENABLE_FP16
+void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                                   int Hi, int Wi, int Ho, int Wo,
+                                   int ph, int pw, int pad_t, int pad_l) {
+  const _FP16 ninf = std::numeric_limits<_FP16>::lowest();
+  std::vector<_FP16> tmp((size_t)Hi * Wi);
+
+  // Row pass
+  for (int ih = 0; ih < Hi; ++ih) {
+    const _FP16 *irow = in + (size_t)ih * Wi;
+    _FP16 *trow = tmp.data() + (size_t)ih * Wi;
+    for (int w = 0; w < Wi; ++w)
+      trow[w] = ninf;
+    for (int kw = 0; kw < pw; ++kw) {
+      const int shift = kw - pad_l;
+      const int w0 = (shift < 0) ? -shift : 0;
+      const int w1r = Wi - shift;
+      const int w1 = (Wo < w1r) ? Wo : w1r;
+      for (int w = w0; w < w1; ++w)
+        if (irow[w + shift] > trow[w])
+          trow[w] = irow[w + shift];
+    }
+  }
+
+  // Col pass
+  for (int oh = 0; oh < Ho; ++oh) {
+    _FP16 *orow = out + (size_t)oh * Wo;
+    for (int w = 0; w < Wo; ++w)
+      orow[w] = ninf;
+    for (int kh = 0; kh < ph; ++kh) {
+      const int ih = oh - pad_t + kh;
+      if (ih < 0 || ih >= Hi)
+        continue;
+      const _FP16 *trow = tmp.data() + (size_t)ih * Wi;
+      for (int w = 0; w < Wo; ++w)
+        if (trow[w] > orow[w])
+          orow[w] = trow[w];
+    }
+  }
+}
+#endif
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -1267,10 +1267,9 @@ void __fallback_gemm_qs8d32p_qs4c32p_packed(size_t m, size_t n, size_t k,
   throw std::runtime_error("NYI : __fallback_gemm_qs8d32p_qs4c32p_packed");
 }
 
-
-void __fallback_maxpool2d_s1_fp32(const float *in, float *out,
-                                   int Hi, int Wi, int Ho, int Wo,
-                                   int ph, int pw, int pad_t, int pad_l) {
+void __fallback_maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi,
+                                  int Ho, int Wo, int ph, int pw, int pad_t,
+                                  int pad_l) {
   const float ninf = std::numeric_limits<float>::lowest();
   std::vector<float> tmp((size_t)Hi * Wi);
 
@@ -1309,9 +1308,9 @@ void __fallback_maxpool2d_s1_fp32(const float *in, float *out,
 }
 
 #ifdef ENABLE_FP16
-void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                                   int Hi, int Wi, int Ho, int Wo,
-                                   int ph, int pw, int pad_t, int pad_l) {
+void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi,
+                                  int Ho, int Wo, int ph, int pw, int pad_t,
+                                  int pad_l) {
   const _FP16 ninf = std::numeric_limits<_FP16>::lowest();
   std::vector<_FP16> tmp((size_t)Hi * Wi);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1252,14 +1252,14 @@ void __fallback_create_q4_0_weights(const uint8_t *int4_weight,
  * @brief Scalar stride-1 max pool for one [Hi,Wi] plane -> [Ho,Wo].
  *        Two-pass separable algorithm (row then col).
  */
-void __fallback_maxpool2d_s1_fp32(const float *in, float *out,
-                                   int Hi, int Wi, int Ho, int Wo,
-                                   int ph, int pw, int pad_t, int pad_l);
+void __fallback_maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi,
+                                  int Ho, int Wo, int ph, int pw, int pad_t,
+                                  int pad_l);
 
 #ifdef ENABLE_FP16
-void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                                   int Hi, int Wi, int Ho, int Wo,
-                                   int ph, int pw, int pad_t, int pad_l);
+void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi,
+                                  int Ho, int Wo, int ph, int pw, int pad_t,
+                                  int pad_l);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1245,6 +1245,23 @@ void __fallback_clamp(const T *input, T *output, size_t length,
 void __fallback_create_q4_0_weights(const uint8_t *int4_weight,
                                     uint8_t *q4_0_weight);
 
+// ===========================================================================
+// Stride-1 max pooling
+// ===========================================================================
+/**
+ * @brief Scalar stride-1 max pool for one [Hi,Wi] plane -> [Ho,Wo].
+ *        Two-pass separable algorithm (row then col).
+ */
+void __fallback_maxpool2d_s1_fp32(const float *in, float *out,
+                                   int Hi, int Wi, int Ho, int Wo,
+                                   int ph, int pw, int pad_t, int pad_l);
+
+#ifdef ENABLE_FP16
+void __fallback_maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                                   int Hi, int Wi, int Ho, int Wo,
+                                   int ph, int pw, int pad_t, int pad_l);
+#endif
+
 /**
  * @brief Transform data from in-memory layout osv32_isv2 to block_q4_0x8 or
  * block_q4_0x4 (for ARM backend) in-memory layout.

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,16 +506,14 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   __fallback_maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
 }
 
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l) {
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l) {
   __fallback_maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
 }
 #endif

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,6 +506,20 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  __fallback_maxpool2d_s1_fp32(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+}
+
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l) {
+  __fallback_maxpool2d_s1_fp16(in, out, Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+}
+#endif
+
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {
   nntrainer::avx2::create_q4_0_weights(int4_weight, q4_0_weight);
 }

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1220,13 +1220,11 @@ void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Stride-1 max pool FP32 (x86 backend -- delegates to fallback).
  */
-void maxpool2d_s1_fp32(const float *in, float *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp32(const float *in, float *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 #ifdef ENABLE_FP16
-void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
-                       int Hi, int Wi, int Ho, int Wo,
-                       int ph, int pw, int pad_t, int pad_l);
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out, int Hi, int Wi, int Ho,
+                       int Wo, int ph, int pw, int pad_t, int pad_l);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1218,6 +1218,18 @@ void clamp(const T *input, T *output, size_t length,
            T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Stride-1 max pool FP32 (x86 backend -- delegates to fallback).
+ */
+void maxpool2d_s1_fp32(const float *in, float *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+#ifdef ENABLE_FP16
+void maxpool2d_s1_fp16(const _FP16 *in, _FP16 *out,
+                       int Hi, int Wi, int Ho, int Wo,
+                       int ph, int pw, int pad_t, int pad_l);
+#endif
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -1453,19 +1453,21 @@ TEST(nntrainer_fallback_kleidiai,
 // Tests for maxpool2d_s1 (stride-1 max pool)
 //==============================================================================
 
-static void ref_maxpool2d_s1(const float *in, float *out,
-                              int Hi, int Wi, int Ho, int Wo,
-                              int ph, int pw, int pad_t, int pad_l) {
+static void ref_maxpool2d_s1(const float *in, float *out, int Hi, int Wi,
+                             int Ho, int Wo, int ph, int pw, int pad_t,
+                             int pad_l) {
   const float ninf = std::numeric_limits<float>::lowest();
   for (int oh = 0; oh < Ho; ++oh) {
     for (int ow = 0; ow < Wo; ++ow) {
       float v = ninf;
       for (int kh = 0; kh < ph; ++kh) {
         int ih = oh - pad_t + kh;
-        if (ih < 0 || ih >= Hi) continue;
+        if (ih < 0 || ih >= Hi)
+          continue;
         for (int kw = 0; kw < pw; ++kw) {
           int iw = ow - pad_l + kw;
-          if (iw < 0 || iw >= Wi) continue;
+          if (iw < 0 || iw >= Wi)
+            continue;
           v = std::max(v, in[ih * Wi + iw]);
         }
       }
@@ -1481,9 +1483,10 @@ TEST(nntrainer_fallback, maxpool2d_s1_no_pad) {
   std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
   std::mt19937 rng(42);
   std::uniform_real_distribution<float> dist(-5.0f, 5.0f);
-  for (auto &v : in) v = dist(rng);
-  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
-                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (auto &v : in)
+    v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(), Hi, Wi, Ho, Wo,
+                                          ph, pw, pad_t, pad_l);
   ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   for (int i = 0; i < Ho * Wo; ++i)
     EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;
@@ -1495,9 +1498,10 @@ TEST(nntrainer_fallback, maxpool2d_s1_same_pad) {
   std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
   std::mt19937 rng(99);
   std::uniform_real_distribution<float> dist(-10.0f, 10.0f);
-  for (auto &v : in) v = dist(rng);
-  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
-                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (auto &v : in)
+    v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(), Hi, Wi, Ho, Wo,
+                                          ph, pw, pad_t, pad_l);
   ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   for (int i = 0; i < Ho * Wo; ++i)
     EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;
@@ -1509,9 +1513,10 @@ TEST(nntrainer_fallback, maxpool2d_s1_5x5_kernel) {
   std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
   std::mt19937 rng(7);
   std::uniform_real_distribution<float> dist(-3.0f, 3.0f);
-  for (auto &v : in) v = dist(rng);
-  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
-                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (auto &v : in)
+    v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(), Hi, Wi, Ho, Wo,
+                                          ph, pw, pad_t, pad_l);
   ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
   for (int i = 0; i < Ho * Wo; ++i)
     EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <numeric>
 #include <random>
 #include <vector>
 
@@ -1446,6 +1447,74 @@ TEST(nntrainer_fallback_kleidiai,
 
   constexpr float eps = 1e-3;
   EXPECT_LE(mse, eps * m * n * k);
+}
+
+//==============================================================================
+// Tests for maxpool2d_s1 (stride-1 max pool)
+//==============================================================================
+
+static void ref_maxpool2d_s1(const float *in, float *out,
+                              int Hi, int Wi, int Ho, int Wo,
+                              int ph, int pw, int pad_t, int pad_l) {
+  const float ninf = std::numeric_limits<float>::lowest();
+  for (int oh = 0; oh < Ho; ++oh) {
+    for (int ow = 0; ow < Wo; ++ow) {
+      float v = ninf;
+      for (int kh = 0; kh < ph; ++kh) {
+        int ih = oh - pad_t + kh;
+        if (ih < 0 || ih >= Hi) continue;
+        for (int kw = 0; kw < pw; ++kw) {
+          int iw = ow - pad_l + kw;
+          if (iw < 0 || iw >= Wi) continue;
+          v = std::max(v, in[ih * Wi + iw]);
+        }
+      }
+      out[oh * Wo + ow] = v;
+    }
+  }
+}
+
+TEST(nntrainer_fallback, maxpool2d_s1_no_pad) {
+  const int Hi = 7, Wi = 7, ph = 3, pw = 3;
+  const int pad_t = 0, pad_l = 0;
+  const int Ho = Hi - ph + 1, Wo = Wi - pw + 1;
+  std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-5.0f, 5.0f);
+  for (auto &v : in) v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
+                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (int i = 0; i < Ho * Wo; ++i)
+    EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;
+}
+
+TEST(nntrainer_fallback, maxpool2d_s1_same_pad) {
+  const int Hi = 8, Wi = 8, ph = 3, pw = 3;
+  const int pad_t = 1, pad_l = 1, Ho = Hi, Wo = Wi;
+  std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
+  std::mt19937 rng(99);
+  std::uniform_real_distribution<float> dist(-10.0f, 10.0f);
+  for (auto &v : in) v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
+                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (int i = 0; i < Ho * Wo; ++i)
+    EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;
+}
+
+TEST(nntrainer_fallback, maxpool2d_s1_5x5_kernel) {
+  const int Hi = 13, Wi = 13, ph = 5, pw = 5;
+  const int pad_t = 2, pad_l = 2, Ho = Hi, Wo = Wi;
+  std::vector<float> in(Hi * Wi), out(Ho * Wo), ref(Ho * Wo);
+  std::mt19937 rng(7);
+  std::uniform_real_distribution<float> dist(-3.0f, 3.0f);
+  for (auto &v : in) v = dist(rng);
+  nntrainer::__fallback_maxpool2d_s1_fp32(in.data(), out.data(),
+                                           Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  ref_maxpool2d_s1(in.data(), ref.data(), Hi, Wi, Ho, Wo, ph, pw, pad_t, pad_l);
+  for (int i = 0; i < Ho * Wo; ++i)
+    EXPECT_FLOAT_EQ(out[i], ref[i]) << "at i=" << i;
 }
 
 //==============================================================================


### PR DESCRIPTION
## Dependency of the PR

None. Independent of other PRs.

## Commits to be reviewed in this PR

<details><summary>[cpu_backend] Extract maxpool2d_s1 NEON kernel from pooling2d_layer</summary><br />

Moves the stride-1 max pool implementation out of `pooling2d_layer.cpp` into the
`cpu_backend` dispatch layer, following the same pattern as `depthwise_conv2d`.

**Algorithm:** Replaces the naive O(ph×pw×n) 2D scan with a separable two-pass approach:
- **Row pass** – `tmp[ih][w] = 1D sliding max` over a pw-wide horizontal window
- **Col pass** – `out[oh][w] = 1D sliding max` over a ph-tall vertical window of `tmp`

Each pass uses NEON `vmaxq_f32` (fp32, 4-wide) / `vmaxq_f16` (fp16, 8-wide) over the
full spatial dimension, guarded by `#ifdef __ARM_NEON`. x86 and non-NEON ARM fall back
to scalar via `__fallback_maxpool2d_s1`. The temporary buffer (one `[Hi×Wi]` plane) fits
in L1/L2 for typical SPPF feature maps.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[cpu_backend] Add default-throw impl + unittest for maxpool2d_s1</summary><br />

Adds the required out-of-line `ComputeOps::maxpool2d_s1_fp32/fp16` default-throw bodies
to `compute_ops.cpp` (same pattern as every other virtual op). Adds three GTest cases to
`unittest_nntrainer_fallback` that compare `__fallback_maxpool2d_s1_fp32` against a
naive reference loop across:
- 3×3 kernel, no padding (7×7 input → 5×5 output)
- 3×3 kernel, same-padding (8×8 → 8×8)
- 5×5 kernel, same-padding (13×13 → 13×13)

All element-wise comparisons use `EXPECT_FLOAT_EQ`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[cleanup] Apply clang-format-14 to feat/opt-pooling2d changed files</summary><br />

Applied `clang-format-14` to all files modified in this branch.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

- Extracts `maxpool2d_s1_fp32/fp16` into the `cpu_backend` dispatch layer (ARM NEON / x86 scalar / fallback)
- Replaces O(ph×pw×n) naive 2D max scan with separable O((ph+pw)×n) two-pass NEON algorithm
  - fp32: `vmaxq_f32` (4-wide), fp16: `vmaxq_f16` (8-wide), scalar fallback for x86/non-NEON
- Adds `ComputeOps` default-throw stubs and 3 correctness unit tests

### Validation

Measured on **Galaxy S25 Ultra (Snapdragon 8 Elite, 8 threads, YOLOv11m q40-fp16)**:

| Layer | Before | After | Speedup |
|-------|--------|-------|---------|
| `pooling2d` (SPPF 5×5 max pool) | 14.2 ms | 1.6 ms | **9.1×** |

Detections bit-identical to baseline. 2.5× fewer NEON ops for 5×5 kernel (10 positions vs 25).

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>