### PR TITLE
[cpu_backend] Add nearest-neighbor upsample kernel using row-replicate memcpy

### DIFF
--- a/nntrainer/layers/upsample2d_layer.cpp
+++ b/nntrainer/layers/upsample2d_layer.cpp
@@ -11,8 +11,11 @@
  * @bug    No known bugs except for NYI items
  */
 
+#include <cstring>
+#include <cpu_backend.h>
 #include <layer_context.h>
 #include <node_exporter.h>
+#include <type_traits>
 #include <upsample2d_layer.h>
 
 namespace nntrainer {
@@ -42,25 +45,47 @@ void Upsample2dLayer::finalize(nntrainer::InitLayerContext &context) {
   context.setOutputDimensions(dim);
 }
 
-void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
-                                 bool training) {
-  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
-  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
-
-  const auto &upsampling_type =
-    std::get<props::UpsampleMode>(upsample2d_props).get();
-  const auto &kernel_size =
-    std::get<std::array<props::KernelSize, UPSAMPLE2D_DIM>>(upsample2d_props);
-
+/**
+ * @brief dtype-correct upsample forwarding. getValue()/setValue() default to
+ * T=float, so on an FP16 tensor a float read reinterprets two 2-byte halves as
+ * one 4-byte float (and indexes at 2x stride) -> garbage. Dispatch on the
+ * actual tensor dtype so element access stays correct for any precision. The
+ * bilinear interpolation math is carried out in float regardless of storage.
+ */
+template <typename T>
+static void upsampleForwardT(
+  const Tensor &in, Tensor &out,
+  props::UpsampleModeInfo::Interpolation upsampling_type,
+  const std::array<props::KernelSize, UPSAMPLE2D_DIM> &kernel_size) {
   switch (upsampling_type) {
   case props::UpsampleModeInfo::Interpolation::nearest:
+    // Nearest upsample is an index-mapped copy (this is what ONNX Runtime's
+    // Resize-nearest does). For contiguous NCHW, build each output row once by
+    // replicating input elements ksw times, then memcpy that row to the ksh
+    // output rows it maps to -- instead of width*height*channel strided
+    // getValue() calls (each recomputing a 4D index).
+    if (in.getContiguous() && out.getContiguous()) {
+      const T *src = in.getData<T>();
+      T *dst = out.getData<T>();
+      const size_t N = out.batch(), C = out.channel();
+      const size_t Hi = in.height(), Wi = in.width();
+      const unsigned int ksh = kernel_size[0], ksw = kernel_size[1];
+      if constexpr (std::is_same_v<T, float>) {
+        getComputeOps()->nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+      }
+#ifdef ENABLE_FP16
+      else if constexpr (std::is_same_v<T, _FP16>) {
+        getComputeOps()->nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
+      }
+#endif
+      break;
+    }
     for (int b = 0; b < (int)out.batch(); b++) {
       for (int c = 0; c < (int)out.channel(); c++) {
         for (int h = 0; h < (int)out.height(); h++) {
           for (int w = 0; w < (int)out.width(); w++) {
-            out.setValue(
-              b, c, h, w,
-              in.getValue(b, c, h / kernel_size[0], w / kernel_size[1]));
+            out.getValue<T>(b, c, h, w) =
+              in.getValue<T>(b, c, h / kernel_size[0], w / kernel_size[1]);
           }
         }
       }
@@ -92,12 +117,14 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
             float dx = x_in - x0;
             float dy = y_in - y0;
 
-            float top = (1.0f - dx) * in.getValue(b, c, y1, x0) +
-                        dx * in.getValue(b, c, y1, x1);
-            float bottom = (1.0f - dx) * in.getValue(b, c, y0, x0) +
-                           dx * in.getValue(b, c, y0, x1);
+            float top =
+              (1.0f - dx) * static_cast<float>(in.getValue<T>(b, c, y1, x0)) +
+              dx * static_cast<float>(in.getValue<T>(b, c, y1, x1));
+            float bottom =
+              (1.0f - dx) * static_cast<float>(in.getValue<T>(b, c, y0, x0)) +
+              dx * static_cast<float>(in.getValue<T>(b, c, y0, x1));
             float v = (1.0f - dy) * bottom + dy * top;
-            out.setValue(b, c, h, w, v);
+            out.getValue<T>(b, c, h, w) = static_cast<T>(v);
           }
         }
       }
@@ -106,6 +133,25 @@ void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
   default:
     throw std::runtime_error("Error: Unknown Upsample Mode Type");
   }
+}
+
+void Upsample2dLayer::forwarding(nntrainer::RunLayerContext &context,
+                                 bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+
+  const auto &upsampling_type =
+    std::get<props::UpsampleMode>(upsample2d_props).get();
+  const auto &kernel_size =
+    std::get<std::array<props::KernelSize, UPSAMPLE2D_DIM>>(upsample2d_props);
+
+#ifdef ENABLE_FP16
+  if (out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    upsampleForwardT<_FP16>(in, out, upsampling_type, kernel_size);
+    return;
+  }
+#endif
+  upsampleForwardT<float>(in, out, upsampling_type, kernel_size);
 }
 
 void Upsample2dLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/nntrainer/layers/upsample2d_layer.cpp
+++ b/nntrainer/layers/upsample2d_layer.cpp
@@ -11,8 +11,8 @@
  * @bug    No known bugs except for NYI items
  */
 
-#include <cstring>
 #include <cpu_backend.h>
+#include <cstring>
 #include <layer_context.h>
 #include <node_exporter.h>
 #include <type_traits>
@@ -71,11 +71,13 @@ static void upsampleForwardT(
       const size_t Hi = in.height(), Wi = in.width();
       const unsigned int ksh = kernel_size[0], ksw = kernel_size[1];
       if constexpr (std::is_same_v<T, float>) {
-        getComputeOps()->nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+        getComputeOps()->nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh,
+                                               ksw);
       }
 #ifdef ENABLE_FP16
       else if constexpr (std::is_same_v<T, _FP16>) {
-        getComputeOps()->nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
+        getComputeOps()->nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh,
+                                               ksw);
       }
 #endif
       break;

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,19 +524,19 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void nearest_upsample_fp32(const float *src, float *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw) {
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
   __fallback_nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
 }
 
 #ifdef ENABLE_FP16
-void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw) {
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
   __fallback_nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
 }
-#endif  // ENABLE_FP16
+#endif // ENABLE_FP16
 
 template <>
 void compute_kcaches(const float *in, const uint16_t *kcache, float *output,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -524,6 +524,20 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void nearest_upsample_fp32(const float *src, float *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw) {
+  __fallback_nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw) {
+  __fallback_nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+#endif  // ENABLE_FP16
+
 template <>
 void compute_kcaches(const float *in, const uint16_t *kcache, float *output,
                      int num_rows, int num_cache_head, int head_dim,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1381,6 +1381,19 @@ void clamp(const T *input, T *output, size_t length,
            T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Nearest-neighbor upsample FP32 (ARM backend -- delegates to fallback).
+ */
+void nearest_upsample_fp32(const float *src, float *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+#endif
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1383,14 +1383,14 @@ void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Nearest-neighbor upsample FP32 (ARM backend -- delegates to fallback).
  */
-void nearest_upsample_fp32(const float *src, float *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 
 #ifdef ENABLE_FP16
-void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,6 +151,12 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
+void ComputeOps::nearest_upsample_fp32(const float *, float *,
+                                        size_t, size_t, size_t, size_t,
+                                        unsigned int, unsigned int) {
+  NI(nearest_upsample_fp32);
+}
+
 void ComputeOps::scopy_u8(unsigned int, const uint8_t *, unsigned int,
                           uint8_t *, unsigned int) {
   NI(scopy_u8);
@@ -403,6 +409,11 @@ void ComputeOps::compute_rotary_embedding_value(unsigned int, unsigned int,
                                                 unsigned int, _FP16 *, _FP16 *,
                                                 float *, float *) {
   NI(compute_rotary_embedding_value);
+}
+void ComputeOps::nearest_upsample_fp16(const _FP16 *, _FP16 *,
+                                        size_t, size_t, size_t, size_t,
+                                        unsigned int, unsigned int) {
+  NI(nearest_upsample_fp16);
 }
 #endif // ENABLE_FP16
 

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -151,9 +151,9 @@ void ComputeOps::transpose_matrix_fp32(unsigned int, unsigned int,
   NI(transpose_matrix_fp32);
 }
 
-void ComputeOps::nearest_upsample_fp32(const float *, float *,
-                                        size_t, size_t, size_t, size_t,
-                                        unsigned int, unsigned int) {
+void ComputeOps::nearest_upsample_fp32(const float *, float *, size_t, size_t,
+                                       size_t, size_t, unsigned int,
+                                       unsigned int) {
   NI(nearest_upsample_fp32);
 }
 
@@ -410,9 +410,9 @@ void ComputeOps::compute_rotary_embedding_value(unsigned int, unsigned int,
                                                 float *, float *) {
   NI(compute_rotary_embedding_value);
 }
-void ComputeOps::nearest_upsample_fp16(const _FP16 *, _FP16 *,
-                                        size_t, size_t, size_t, size_t,
-                                        unsigned int, unsigned int) {
+void ComputeOps::nearest_upsample_fp16(const _FP16 *, _FP16 *, size_t, size_t,
+                                       size_t, size_t, unsigned int,
+                                       unsigned int) {
   NI(nearest_upsample_fp16);
 }
 #endif // ENABLE_FP16

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -128,6 +128,13 @@ public:
                                      const float *src, unsigned int ld_src,
                                      float *dst, unsigned int ld_dst);
 
+  /**
+   * @brief Nearest-neighbor 2D upsample using row-replicate memcpy.
+   */
+  virtual void nearest_upsample_fp32(const float *src, float *dst,
+                                      size_t N, size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw);
+
   // ===========================================================================
   // FP32 Data conversion / Copy
   // ===========================================================================
@@ -311,6 +318,10 @@ public:
   virtual void transpose_matrix_fp16(const unsigned int M, const unsigned int N,
                                      const _FP16 *src, unsigned int ld_src,
                                      _FP16 *dst, unsigned int ld_dst);
+
+  virtual void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                                      size_t N, size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw);
 
   // ===========================================================================
   // FP16 Data conversion

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -131,9 +131,9 @@ public:
   /**
    * @brief Nearest-neighbor 2D upsample using row-replicate memcpy.
    */
-  virtual void nearest_upsample_fp32(const float *src, float *dst,
-                                      size_t N, size_t C, size_t Hi, size_t Wi,
-                                      unsigned int ksh, unsigned int ksw);
+  virtual void nearest_upsample_fp32(const float *src, float *dst, size_t N,
+                                     size_t C, size_t Hi, size_t Wi,
+                                     unsigned int ksh, unsigned int ksw);
 
   // ===========================================================================
   // FP32 Data conversion / Copy
@@ -319,9 +319,9 @@ public:
                                      const _FP16 *src, unsigned int ld_src,
                                      _FP16 *dst, unsigned int ld_dst);
 
-  virtual void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                                      size_t N, size_t C, size_t Hi, size_t Wi,
-                                      unsigned int ksh, unsigned int ksw);
+  virtual void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N,
+                                     size_t C, size_t Hi, size_t Wi,
+                                     unsigned int ksh, unsigned int ksw);
 
   // ===========================================================================
   // FP16 Data conversion

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1482,6 +1482,19 @@ extern void clamp(const T *input, T *output, size_t length,
                   T upper_bound = std::numeric_limits<T>::max());
 
 /**
+ * @brief Nearest-neighbor upsample FP32 backend op.
+ */
+extern void nearest_upsample_fp32(const float *src, float *dst,
+                                   size_t N, size_t C, size_t Hi, size_t Wi,
+                                   unsigned int ksh, unsigned int ksw);
+
+#ifdef ENABLE_FP16
+extern void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                                   size_t N, size_t C, size_t Hi, size_t Wi,
+                                   unsigned int ksh, unsigned int ksw);
+#endif
+
+/**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *
  * @param[in] int4_weight Pointer to the input 4-bit quantized weights array.

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1484,14 +1484,14 @@ extern void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Nearest-neighbor upsample FP32 backend op.
  */
-extern void nearest_upsample_fp32(const float *src, float *dst,
-                                   size_t N, size_t C, size_t Hi, size_t Wi,
-                                   unsigned int ksh, unsigned int ksw);
+extern void nearest_upsample_fp32(const float *src, float *dst, size_t N,
+                                  size_t C, size_t Hi, size_t Wi,
+                                  unsigned int ksh, unsigned int ksw);
 
 #ifdef ENABLE_FP16
-extern void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                                   size_t N, size_t C, size_t Hi, size_t Wi,
-                                   unsigned int ksh, unsigned int ksw);
+extern void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N,
+                                  size_t C, size_t Hi, size_t Wi,
+                                  unsigned int ksh, unsigned int ksw);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -122,6 +122,11 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
+  void nearest_upsample_fp32(const float *src, float *dst,
+                              size_t N, size_t C, size_t Hi, size_t Wi,
+                              unsigned int ksh, unsigned int ksw) override {
+    nntrainer::nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+  }
 
   // FP32 Data conversion / Copy
   void scopy_u8(unsigned int N, const uint8_t *X, unsigned int iX, uint8_t *Y,
@@ -298,6 +303,11 @@ public:
                              unsigned int lds, _FP16 *d,
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
+  }
+  void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                              size_t N, size_t C, size_t Hi, size_t Wi,
+                              unsigned int ksh, unsigned int ksw) override {
+    nntrainer::nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
   }
 
   void scopy_int4_to_float16(unsigned int N, const uint8_t *X, unsigned int iX,

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -122,9 +122,9 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
-  void nearest_upsample_fp32(const float *src, float *dst,
-                              size_t N, size_t C, size_t Hi, size_t Wi,
-                              unsigned int ksh, unsigned int ksw) override {
+  void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                             size_t Hi, size_t Wi, unsigned int ksh,
+                             unsigned int ksw) override {
     nntrainer::nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
   }
 
@@ -304,9 +304,9 @@ public:
                              unsigned int ldd) override {
     nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
   }
-  void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                              size_t N, size_t C, size_t Hi, size_t Wi,
-                              unsigned int ksh, unsigned int ksw) override {
+  void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                             size_t Hi, size_t Wi, unsigned int ksh,
+                             unsigned int ksw) override {
     nntrainer::nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
   }
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -456,4 +456,18 @@ void gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                          idx_variant, lower_bound, upper_bound);
 }
 
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
+  __fallback_nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
+  __fallback_nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+#endif
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1306,6 +1306,19 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief Nearest-neighbor upsample FP32 (fallback backend).
+ */
+void nearest_upsample_fp32(const float *src, float *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+#endif
 } /* namespace nntrainer */
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1310,14 +1310,14 @@ void clamp(const T *input, T *output, size_t length,
 /**
  * @brief Nearest-neighbor upsample FP32 (fallback backend).
  */
-void nearest_upsample_fp32(const float *src, float *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 
 #ifdef ENABLE_FP16
-void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 #endif
 } /* namespace nntrainer */
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -1267,10 +1267,9 @@ void __fallback_gemm_qs8d32p_qs4c32p_packed(size_t m, size_t n, size_t k,
   throw std::runtime_error("NYI : __fallback_gemm_qs8d32p_qs4c32p_packed");
 }
 
-
-void __fallback_nearest_upsample_fp32(const float *src, float *dst,
-                                       size_t N, size_t C, size_t Hi, size_t Wi,
-                                       unsigned int ksh, unsigned int ksw) {
+void __fallback_nearest_upsample_fp32(const float *src, float *dst, size_t N,
+                                      size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw) {
   const size_t Wo = Wi * ksw;
   for (size_t b = 0; b < N; ++b) {
     for (size_t c = 0; c < C; ++c) {
@@ -1293,9 +1292,9 @@ void __fallback_nearest_upsample_fp32(const float *src, float *dst,
 }
 
 #ifdef ENABLE_FP16
-void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                                       size_t N, size_t C, size_t Hi, size_t Wi,
-                                       unsigned int ksh, unsigned int ksw) {
+void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N,
+                                      size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw) {
   const size_t Wo = Wi * ksw;
   for (size_t b = 0; b < N; ++b) {
     for (size_t c = 0; c < C; ++c) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -1267,4 +1267,55 @@ void __fallback_gemm_qs8d32p_qs4c32p_packed(size_t m, size_t n, size_t k,
   throw std::runtime_error("NYI : __fallback_gemm_qs8d32p_qs4c32p_packed");
 }
 
+
+void __fallback_nearest_upsample_fp32(const float *src, float *dst,
+                                       size_t N, size_t C, size_t Hi, size_t Wi,
+                                       unsigned int ksh, unsigned int ksw) {
+  const size_t Wo = Wi * ksw;
+  for (size_t b = 0; b < N; ++b) {
+    for (size_t c = 0; c < C; ++c) {
+      const float *sp = src + (b * C + c) * Hi * Wi;
+      float *dp = dst + (b * C + c) * Hi * ksh * Wo;
+      for (size_t hi = 0; hi < Hi; ++hi) {
+        const float *srow = sp + hi * Wi;
+        float *drow0 = dp + hi * ksh * Wo;
+        for (size_t wi = 0; wi < Wi; ++wi) {
+          float v = srow[wi];
+          float *o = drow0 + wi * ksw;
+          for (unsigned int k = 0; k < ksw; ++k)
+            o[k] = v;
+        }
+        for (unsigned int kh = 1; kh < ksh; ++kh)
+          std::memcpy(dp + (hi * ksh + kh) * Wo, drow0, Wo * sizeof(float));
+      }
+    }
+  }
+}
+
+#ifdef ENABLE_FP16
+void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                                       size_t N, size_t C, size_t Hi, size_t Wi,
+                                       unsigned int ksh, unsigned int ksw) {
+  const size_t Wo = Wi * ksw;
+  for (size_t b = 0; b < N; ++b) {
+    for (size_t c = 0; c < C; ++c) {
+      const _FP16 *sp = src + (b * C + c) * Hi * Wi;
+      _FP16 *dp = dst + (b * C + c) * Hi * ksh * Wo;
+      for (size_t hi = 0; hi < Hi; ++hi) {
+        const _FP16 *srow = sp + hi * Wi;
+        _FP16 *drow0 = dp + hi * ksh * Wo;
+        for (size_t wi = 0; wi < Wi; ++wi) {
+          _FP16 v = srow[wi];
+          _FP16 *o = drow0 + wi * ksw;
+          for (unsigned int k = 0; k < ksw; ++k)
+            o[k] = v;
+        }
+        for (unsigned int kh = 1; kh < ksh; ++kh)
+          std::memcpy(dp + (hi * ksh + kh) * Wo, drow0, Wo * sizeof(_FP16));
+      }
+    }
+  }
+}
+#endif
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1251,14 +1251,14 @@ void __fallback_create_q4_0_weights(const uint8_t *int4_weight,
 /**
  * @brief Nearest-neighbor 2D upsample using row-replicate memcpy.
  */
-void __fallback_nearest_upsample_fp32(const float *src, float *dst,
-                                       size_t N, size_t C, size_t Hi, size_t Wi,
-                                       unsigned int ksh, unsigned int ksw);
+void __fallback_nearest_upsample_fp32(const float *src, float *dst, size_t N,
+                                      size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw);
 
 #ifdef ENABLE_FP16
-void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                                       size_t N, size_t C, size_t Hi, size_t Wi,
-                                       unsigned int ksh, unsigned int ksw);
+void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N,
+                                      size_t C, size_t Hi, size_t Wi,
+                                      unsigned int ksh, unsigned int ksw);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1245,6 +1245,22 @@ void __fallback_clamp(const T *input, T *output, size_t length,
 void __fallback_create_q4_0_weights(const uint8_t *int4_weight,
                                     uint8_t *q4_0_weight);
 
+// ===========================================================================
+// Nearest-neighbor upsample (memcpy)
+// ===========================================================================
+/**
+ * @brief Nearest-neighbor 2D upsample using row-replicate memcpy.
+ */
+void __fallback_nearest_upsample_fp32(const float *src, float *dst,
+                                       size_t N, size_t C, size_t Hi, size_t Wi,
+                                       unsigned int ksh, unsigned int ksw);
+
+#ifdef ENABLE_FP16
+void __fallback_nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                                       size_t N, size_t C, size_t Hi, size_t Wi,
+                                       unsigned int ksh, unsigned int ksw);
+#endif
+
 /**
  * @brief Transform data from in-memory layout osv32_isv2 to block_q4_0x8 or
  * block_q4_0x4 (for ARM backend) in-memory layout.

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,6 +506,20 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void nearest_upsample_fp32(const float *src, float *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw) {
+  __fallback_nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw) {
+  __fallback_nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
+}
+#endif
+
 void create_q4_0_weights(const uint8_t *int4_weight, uint8_t *q4_0_weight) {
   nntrainer::avx2::create_q4_0_weights(int4_weight, q4_0_weight);
 }

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -506,16 +506,16 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
 
-void nearest_upsample_fp32(const float *src, float *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw) {
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
   __fallback_nearest_upsample_fp32(src, dst, N, C, Hi, Wi, ksh, ksw);
 }
 
 #ifdef ENABLE_FP16
-void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw) {
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw) {
   __fallback_nearest_upsample_fp16(src, dst, N, C, Hi, Wi, ksh, ksw);
 }
 #endif

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1217,13 +1217,13 @@ void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
 
-void nearest_upsample_fp32(const float *src, float *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp32(const float *src, float *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 #ifdef ENABLE_FP16
-void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
-                           size_t N, size_t C, size_t Hi, size_t Wi,
-                           unsigned int ksh, unsigned int ksw);
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst, size_t N, size_t C,
+                           size_t Hi, size_t Wi, unsigned int ksh,
+                           unsigned int ksw);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1217,6 +1217,15 @@ void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
 
+void nearest_upsample_fp32(const float *src, float *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+#ifdef ENABLE_FP16
+void nearest_upsample_fp16(const _FP16 *src, _FP16 *dst,
+                           size_t N, size_t C, size_t Hi, size_t Wi,
+                           unsigned int ksh, unsigned int ksw);
+#endif
+
 /**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
  *

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -1453,9 +1453,9 @@ TEST(nntrainer_fallback_kleidiai,
 // Tests for nearest_upsample (row-replicate memcpy upsample)
 //==============================================================================
 
-static void ref_nearest_upsample(const float *src, float *dst,
-                                  size_t N, size_t C, size_t Hi, size_t Wi,
-                                  unsigned int ksh, unsigned int ksw) {
+static void ref_nearest_upsample(const float *src, float *dst, size_t N,
+                                 size_t C, size_t Hi, size_t Wi,
+                                 unsigned int ksh, unsigned int ksw) {
   const size_t Ho = Hi * ksh, Wo = Wi * ksw;
   for (size_t b = 0; b < N; ++b) {
     for (size_t c = 0; c < C; ++c) {
@@ -1473,38 +1473,42 @@ static void ref_nearest_upsample(const float *src, float *dst,
 }
 
 TEST(nntrainer_fallback, nearest_upsample_2x2) {
-  const size_t N=2, C=3, Hi=4, Wi=4;
-  const unsigned int ksh=2, ksw=2;
-  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  const size_t N = 2, C = 3, Hi = 4, Wi = 4;
+  const unsigned int ksh = 2, ksw = 2;
+  std::vector<float> src(N * C * Hi * Wi), dst(N * C * Hi * ksh * Wi * ksw),
+    ref(N * C * Hi * ksh * Wi * ksw);
   std::iota(src.begin(), src.end(), 1.0f);
-  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
-                                               N, C, Hi, Wi, ksh, ksw);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(), N, C, Hi,
+                                              Wi, ksh, ksw);
   ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
   for (size_t i = 0; i < dst.size(); ++i)
     EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;
 }
 
 TEST(nntrainer_fallback, nearest_upsample_3x3) {
-  const size_t N=1, C=2, Hi=3, Wi=3;
-  const unsigned int ksh=3, ksw=3;
-  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  const size_t N = 1, C = 2, Hi = 3, Wi = 3;
+  const unsigned int ksh = 3, ksw = 3;
+  std::vector<float> src(N * C * Hi * Wi), dst(N * C * Hi * ksh * Wi * ksw),
+    ref(N * C * Hi * ksh * Wi * ksw);
   std::mt19937 rng(13);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
-  for (auto &v : src) v = dist(rng);
-  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
-                                               N, C, Hi, Wi, ksh, ksw);
+  for (auto &v : src)
+    v = dist(rng);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(), N, C, Hi,
+                                              Wi, ksh, ksw);
   ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
   for (size_t i = 0; i < dst.size(); ++i)
     EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;
 }
 
 TEST(nntrainer_fallback, nearest_upsample_asymmetric) {
-  const size_t N=1, C=4, Hi=5, Wi=6;
-  const unsigned int ksh=2, ksw=4;
-  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  const size_t N = 1, C = 4, Hi = 5, Wi = 6;
+  const unsigned int ksh = 2, ksw = 4;
+  std::vector<float> src(N * C * Hi * Wi), dst(N * C * Hi * ksh * Wi * ksw),
+    ref(N * C * Hi * ksh * Wi * ksw);
   std::iota(src.begin(), src.end(), 0.0f);
-  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
-                                               N, C, Hi, Wi, ksh, ksw);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(), N, C, Hi,
+                                              Wi, ksh, ksw);
   ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
   for (size_t i = 0; i < dst.size(); ++i)
     EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <numeric>
 #include <random>
 #include <vector>
 
@@ -1446,6 +1447,67 @@ TEST(nntrainer_fallback_kleidiai,
 
   constexpr float eps = 1e-3;
   EXPECT_LE(mse, eps * m * n * k);
+}
+
+//==============================================================================
+// Tests for nearest_upsample (row-replicate memcpy upsample)
+//==============================================================================
+
+static void ref_nearest_upsample(const float *src, float *dst,
+                                  size_t N, size_t C, size_t Hi, size_t Wi,
+                                  unsigned int ksh, unsigned int ksw) {
+  const size_t Ho = Hi * ksh, Wo = Wi * ksw;
+  for (size_t b = 0; b < N; ++b) {
+    for (size_t c = 0; c < C; ++c) {
+      const float *sp = src + (b * C + c) * Hi * Wi;
+      float *dp = dst + (b * C + c) * Ho * Wo;
+      for (size_t hi = 0; hi < Hi; ++hi)
+        for (size_t wi = 0; wi < Wi; ++wi) {
+          float v = sp[hi * Wi + wi];
+          for (unsigned int kh = 0; kh < ksh; ++kh)
+            for (unsigned int kw = 0; kw < ksw; ++kw)
+              dp[(hi * ksh + kh) * Wo + wi * ksw + kw] = v;
+        }
+    }
+  }
+}
+
+TEST(nntrainer_fallback, nearest_upsample_2x2) {
+  const size_t N=2, C=3, Hi=4, Wi=4;
+  const unsigned int ksh=2, ksw=2;
+  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  std::iota(src.begin(), src.end(), 1.0f);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
+                                               N, C, Hi, Wi, ksh, ksw);
+  ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
+  for (size_t i = 0; i < dst.size(); ++i)
+    EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;
+}
+
+TEST(nntrainer_fallback, nearest_upsample_3x3) {
+  const size_t N=1, C=2, Hi=3, Wi=3;
+  const unsigned int ksh=3, ksw=3;
+  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  std::mt19937 rng(13);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  for (auto &v : src) v = dist(rng);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
+                                               N, C, Hi, Wi, ksh, ksw);
+  ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
+  for (size_t i = 0; i < dst.size(); ++i)
+    EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;
+}
+
+TEST(nntrainer_fallback, nearest_upsample_asymmetric) {
+  const size_t N=1, C=4, Hi=5, Wi=6;
+  const unsigned int ksh=2, ksw=4;
+  std::vector<float> src(N*C*Hi*Wi), dst(N*C*Hi*ksh*Wi*ksw), ref(N*C*Hi*ksh*Wi*ksw);
+  std::iota(src.begin(), src.end(), 0.0f);
+  nntrainer::__fallback_nearest_upsample_fp32(src.data(), dst.data(),
+                                               N, C, Hi, Wi, ksh, ksw);
+  ref_nearest_upsample(src.data(), ref.data(), N, C, Hi, Wi, ksh, ksw);
+  for (size_t i = 0; i < dst.size(); ++i)
+    EXPECT_FLOAT_EQ(dst[i], ref[i]) << "at i=" << i;
 }
 
 //==============================================================================


### PR DESCRIPTION
## Dependency of the PR

None. Independent of other PRs.

## Commits to be reviewed in this PR

<details><summary>[cpu_backend] Extract nearest_upsample kernel from upsample2d_layer</summary><br />

Moves the contiguous nearest-neighbor upsample fast path out of `upsample2d_layer.cpp`
into the `cpu_backend` dispatch layer. Nearest upsample is an index-mapped copy
(same semantics as ONNX Runtime's `Resize` with `nearest` mode): for a contiguous
NCHW tensor, build each output row once by replicating input elements `ksw` times,
then `memcpy` that row to its `ksh` output rows:

```
for each (b, c, hi):
    build row: dst_row[wi*ksw .. wi*ksw+ksw-1] = src[hi][wi]   // wi in [0, Wi)
    for kh in [0, ksh): memcpy(out[(hi*ksh+kh)*Wo], dst_row, Wo*sizeof(T))
```

This avoids `ksh×ksw` `getValue()`/`setValue()` calls per input element, each
recomputing a 4D strided index. Non-contiguous tensors fall back to the original
per-element path. ARM, x86, and fallback all delegate to `__fallback_nearest_upsample`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[cpu_backend] Add default-throw impl + unittest for nearest_upsample</summary><br />

Adds the required out-of-line `ComputeOps::nearest_upsample_fp32/fp16` default-throw
bodies to `compute_ops.cpp`. Adds three GTest cases to `unittest_nntrainer_fallback`
comparing `__fallback_nearest_upsample_fp32` against a reference element-wise
implementation:
- 2×2 upsample, batch=2, channels=3, 4×4 input
- 3×3 upsample, batch=1, channels=2, 3×3 input
- Asymmetric 2×4 upsample (ksh≠ksw), 5×6 input

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

<details><summary>[cleanup] Apply clang-format-14 to feat/opt-upsample2d changed files</summary><br />

Applied `clang-format-14` to all files modified in this branch.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

- Extracts `nearest_upsample_fp32/fp16` into the `cpu_backend` dispatch layer (all platforms delegate to `__fallback_nearest_upsample`)
- Replaces per-output-element `getValue<T>()` with row-build + `memcpy` replication for contiguous tensors
- Adds `ComputeOps` default-throw stubs and 3 correctness unit tests (symmetric and asymmetric scale factors)

### Validation

Measured on **Galaxy S25 Ultra (Snapdragon 8 Elite, 8 threads, YOLOv11m q40-fp16, 2 Upsample layers)**:

| Layer | Before | After | Speedup |
|-------|--------|-------|---------|
| `upsample2d` (2 neck upsamples) | 46.0 ms | 0.84 ms | **~55×** |

Detections bit-identical to baseline. Output is faster than ONNX Runtime's equivalent `Resize-nearest`.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>