### PR TITLE
[kleidiai] Optimize rhs packing for QS4CX

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.c
@@ -1,0 +1,193 @@
+/**
+ * @file   kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.c
+ * @date   02 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Custom NEON-optimized variant of kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0
+ *         specialized for (nr, kr, sr) = (8, 16, 2).
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+#error This file must be compiled for AArch64.
+#else // Architectural features check.
+
+#include "kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h"
+
+#include <arm_neon.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "kai/kai_common.h"
+
+static const size_t kai_num_bytes_sum_rhs = sizeof(int32_t);
+static const size_t kai_num_bytes_multiplier_rhs = sizeof(float);
+static const size_t kai_num_bytes_bias = sizeof(float);
+
+inline static size_t kai_k_roundedup(size_t k) {
+  // Round up k to be a multiple of 32.
+  size_t kai_k_multiple_of = 32;
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+// With (nr, kr, sr) = (8, 16, 2), the packing of one row block (8 source rows)
+// decomposes into independent 32-wide chunks along K. For chunk t, source row
+// bytes s[16t .. 16t+15] (holding k = 32t .. 32t+31, two nibbles per byte,
+// low nibble first) map to two 8-byte destination groups:
+//
+//   lo_nib[j] = (s[j]   & 0x0F) | (s[8+j] << 4)    j = 0..7
+//   hi_nib[j] = (s[8+j] & 0xF0) | (s[j]   >> 4)    j = 0..7
+//   zip(lo_nib, hi_nib) = out[0..15]
+//
+//   out[0..7]  -> dst + 128*t      + 8*nr_idx   (super block 2t)
+//   out[8..15] -> dst + 128*t + 64 + 8*nr_idx   (super block 2t+1)
+//
+// followed by XOR 0x88 (rhs_zero_point == 8). The per-row reduction sum is
+// the plain sum of all source nibbles minus 2 * zero_point per packed byte.
+void kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+  size_t num_groups, size_t n, size_t k, size_t nr, size_t kr, size_t sr,
+  const uint8_t *rhs, const float *bias, const float *scale, void *rhs_packed,
+  size_t extra_bytes,
+  const struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params *params) {
+  KAI_ASSERT(num_groups == 1);
+  KAI_ASSERT(extra_bytes == 0);
+  KAI_ASSERT((kr % sr) == 0);
+  KAI_ASSERT(rhs != NULL);
+  KAI_ASSERT(scale != NULL);
+  KAI_ASSERT(rhs_packed != NULL);
+  KAI_ASSERT(params != NULL);
+  KAI_ASSERT(params->lhs_zero_point == 1);
+  KAI_ASSERT(params->rhs_zero_point == 0 || params->rhs_zero_point == 8);
+
+  // Fast path only for (nr, kr, sr) = (8, 16, 2) with rhs_zero_point == 8 and
+  // even k. The uint16x8 nibble-sum accumulators are safe up to 1024 chunks
+  // (k_internal <= 32768); larger k is delegated as well.
+  if (nr != 8 || kr != 16 || sr != 2 || params->rhs_zero_point != 8 ||
+      (k % 2) != 0 || kai_k_roundedup(k) > 32768) {
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(num_groups, n, k, nr, kr, sr, rhs,
+                                           bias, scale, rhs_packed, extra_bytes,
+                                           params);
+    return;
+  }
+
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t rhs_packed_stride =
+    8 * ((k_internal / 2) + kai_num_bytes_multiplier_rhs +
+         kai_num_bytes_sum_rhs + kai_num_bytes_bias);
+  const size_t dst_num_rows = kai_roundup(n, 8) / 8;
+  const size_t rhs_stride = k / 2;
+  const size_t num_chunks = k_internal / 32;
+  const size_t num_full_chunks = k / 32;
+  const size_t tail_valid_bytes = (k - num_full_chunks * 32) / 2;
+
+  const uint8x16_t vmask_lo = vdupq_n_u8(0x0F);
+  const uint8x16_t vxor = vdupq_n_u8(0x88);
+
+  for (size_t dst_row_idx = 0; dst_row_idx < dst_num_rows; ++dst_row_idx) {
+    uint8_t *dst_row = (uint8_t *)rhs_packed + dst_row_idx * rhs_packed_stride;
+
+    int32_t *sums = (int32_t *)(dst_row + 8 * (k_internal / 2));
+    float *scales_out = (float *)((uint8_t *)sums + 8 * kai_num_bytes_sum_rhs);
+    float *bias_out =
+      (float *)((uint8_t *)scales_out + 8 * kai_num_bytes_multiplier_rhs);
+
+    // Clamp the row indices to avoid out-of-bound reads
+    const uint8_t *src_row[8];
+    for (size_t i = 0; i < 8; ++i) {
+      src_row[i] = rhs + KAI_MIN(dst_row_idx * 8 + i, n - 1) * rhs_stride;
+    }
+
+    uint16x8_t acc[8];
+    for (size_t i = 0; i < 8; ++i) {
+      acc[i] = vdupq_n_u16(0);
+    }
+
+    for (size_t t = 0; t < num_full_chunks; ++t) {
+      uint8_t *dst_t = dst_row + 128 * t;
+
+      for (size_t p = 0; p < 4; ++p) {
+        const uint8x16_t v0 = vld1q_u8(src_row[2 * p] + 16 * t);
+        const uint8x16_t v1 = vld1q_u8(src_row[2 * p + 1] + 16 * t);
+
+        const uint8x8_t v0l = vget_low_u8(v0);
+        const uint8x8_t v0h = vget_high_u8(v0);
+        const uint8x8_t v1l = vget_low_u8(v1);
+        const uint8x8_t v1h = vget_high_u8(v1);
+
+        const uint8x8x2_t z0 =
+          vzip_u8(vsli_n_u8(v0l, v0h, 4), vsri_n_u8(v0h, v0l, 4));
+        const uint8x8x2_t z1 =
+          vzip_u8(vsli_n_u8(v1l, v1h, 4), vsri_n_u8(v1h, v1l, 4));
+
+        // Adjacent rows share contiguous 8-byte slots -> one 16-byte store
+        vst1q_u8(dst_t + 16 * p,
+                 veorq_u8(vcombine_u8(z0.val[0], z1.val[0]), vxor));
+        vst1q_u8(dst_t + 64 + 16 * p,
+                 veorq_u8(vcombine_u8(z0.val[1], z1.val[1]), vxor));
+
+        acc[2 * p] = vpadalq_u8(
+          acc[2 * p], vaddq_u8(vandq_u8(v0, vmask_lo), vshrq_n_u8(v0, 4)));
+        acc[2 * p + 1] = vpadalq_u8(
+          acc[2 * p + 1], vaddq_u8(vandq_u8(v1, vmask_lo), vshrq_n_u8(v1, 4)));
+      }
+    }
+
+    if (num_full_chunks < num_chunks) {
+      // Tail chunk: pad the source with 0x88 so padded positions pack to
+      // (8 | 8 << 4) ^ 0x88 == 0 and contribute zero to the sums, matching
+      // the reference implementation.
+      const size_t t = num_full_chunks;
+      uint8_t *dst_t = dst_row + 128 * t;
+
+      for (size_t i = 0; i < 8; ++i) {
+        uint8_t buf[16];
+        memset(buf, 0x88, sizeof(buf));
+        memcpy(buf, src_row[i] + 16 * t, tail_valid_bytes);
+
+        const uint8x16_t v = vld1q_u8(buf);
+        const uint8x8_t vl = vget_low_u8(v);
+        const uint8x8_t vh = vget_high_u8(v);
+        const uint8x8x2_t z =
+          vzip_u8(vsli_n_u8(vl, vh, 4), vsri_n_u8(vh, vl, 4));
+
+        vst1_u8(dst_t + 8 * i, veor_u8(z.val[0], vget_low_u8(vxor)));
+        vst1_u8(dst_t + 64 + 8 * i, veor_u8(z.val[1], vget_low_u8(vxor)));
+
+        acc[i] =
+          vpadalq_u8(acc[i], vaddq_u8(vandq_u8(v, vmask_lo), vshrq_n_u8(v, 4)));
+      }
+    }
+
+    // Reduction sums: subtract 2 * rhs_zero_point per packed byte, then
+    // adjust by 16 as in the reference implementation.
+    for (size_t i = 0; i < 8; ++i) {
+      sums[i] = ((int32_t)vaddlvq_u16(acc[i]) - 8 * (int32_t)k_internal) * 16;
+    }
+
+    // Adjust the scales
+    for (size_t i = 0; i < 8; ++i) {
+      // Clamp the row index to avoid out-of-bound reads
+      const size_t src_row_idx = KAI_MIN(dst_row_idx * 8 + i, n - 1);
+      scales_out[i] = scale[src_row_idx] * 0.0625F;
+    }
+
+    // Set the bias
+    if (bias == NULL) {
+      memset(bias_out, 0, 8 * kai_num_bytes_bias);
+    } else {
+      for (size_t i = 0; i < 8; ++i) {
+        // Clamp the row index to avoid out-of-bound reads
+        const size_t src_row_idx = KAI_MIN(dst_row_idx * 8 + i, n - 1);
+        bias_out[i] = bias[src_row_idx];
+      }
+    }
+  }
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h
@@ -1,0 +1,74 @@
+/**
+ * @file   kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h
+ * @date   02 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Custom NEON-optimized variant of kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0
+ *         specialized for (nr, kr, sr) = (8, 16, 2).
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Run the micro-kernel to pack the RHS matrix (NEON-optimized).
+///
+/// Drop-in replacement for kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0. The fast
+/// path covers (nr, kr, sr) = (8, 16, 2) with rhs_zero_point == 8; any other
+/// configuration is delegated to the reference implementation. The packed
+/// output is byte-identical to the reference implementation.
+///
+/// The size/offset/stride helper functions of the reference implementation
+/// (kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0, ...) remain valid
+/// for this variant.
+///
+/// @param[in]  num_groups  The number of groups. It must be 1.
+/// @param[in]  n           The number of rows.
+/// @param[in]  k           The common dimension between the LHS and RHS matrix
+/// (K). It must be an even value.
+/// @param[in]  nr          The number of N rows to interleave on the same
+/// output output row.
+/// @param[in]  kr          The number of K values loaded in the single inner
+/// most loop of the matmul micro-kernel.
+/// @param[in]  sr          The number of kr splits. It can be 1 (no splits) up
+/// to kr.
+///                         However, kr must be multiple of sr.
+/// @param[in]  rhs         The RHS matrix containing the 4-bit values.
+///                         Size in bytes is expected to be greater than or
+///                         equal to n * k * (sizeof(uint8_t) / 2).
+/// @param[in]  bias        The biases.
+/// @param[in]  scale       The scale for each output channel.
+/// @param[out] rhs_packed  The packed RHS matrix.
+/// @param[in]  extra_bytes Extra bytes to append to the end of each row of the
+/// packed RHS matrix.
+/// @param[in]  params      Parameters for the micro-kernel.
+void kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+  size_t num_groups,  //
+  size_t n,           //
+  size_t k,           //
+  size_t nr,          //
+  size_t kr,          //
+  size_t sr,          //
+  const uint8_t *rhs, //
+  const float *bias,  //
+  const float *scale, //
+  void *rhs_packed,   //
+  size_t extra_bytes, //
+  const struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params *params);
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
@@ -7,6 +7,7 @@ pack_sources = [
     'kai_lhs_quant_pack_qai8dxp_f32.c',
     'kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.c',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.c',
+    'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.c',
 ]
 
 pack_headers = [
@@ -16,6 +17,7 @@ pack_headers = [
     'kai_lhs_quant_pack_qai8dxp_f32.h',
     'kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.h',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h',
+    'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h',
 ]
 
 foreach s : pack_sources

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi4cxp.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi4cxp.cpp
@@ -54,7 +54,7 @@
 // Include packinng kernels
 #include "kai/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
 #include "kai/pack/kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.h"
-#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h"
 
 #define INT4_MIN (-8)
 #define INT4_MAX (7)
@@ -226,8 +226,9 @@ void __kai_rhs_pack_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
     struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params nxk_params;
     nxk_params.lhs_zero_point = 1;
     nxk_params.rhs_zero_point = 8;
-    // RHS packing
-    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(
+
+    // use custom optimized rhs pack
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
       1, n, k, nr, kr, sr,                     // Packing arguments
       (const uint8_t *)(rhs_native_mtx_qs4cx), // RHS
       NULL,                                    // Bias

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -648,6 +648,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.h
 %{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4c32pscalef16_qsu4c32s16s0.h
 %{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h
+%{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h
 %{_includedir}/nntrainer/kai_common.h
 %{_includedir}/nntrainer/kleidiai_interface.h
 %if 0%{?enable_fp16}

--- a/test/unittest/unittest_nntrainer_kleidiai.cpp
+++ b/test/unittest/unittest_nntrainer_kleidiai.cpp
@@ -17,6 +17,8 @@
 #include <vector>
 
 #include "int4_utils.h"
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h"
 #include "kleidiai_interface.h"
 #include "nntrainer_test_util.h"
 #include <cpu_backend.h>
@@ -347,6 +349,116 @@ TEST(nntrainer_kleidiai, gemm_benchmark_comparison_1x2560x4096) {
 TEST(nntrainer_kleidiai, gemm_benchmark_comparison_1024x2560x4096) {
   run_gemm_benchmark_comparison(1024, 2560, 4096);
 }
+
+/**
+ * @brief rhs_pack_nxk_qsi4cxp_qs4cxs1s0 NEON optimization test
+ *
+ * Checks that kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon produces a
+ * byte-identical packed buffer to the reference implementation for
+ * (nr, kr, sr) = (8, 16, 2), and measures the latency of both.
+ */
+class rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon
+  : public ::testing::TestWithParam<std::tuple<size_t, size_t>> {};
+
+TEST_P(rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon, correctness_and_perf) {
+  auto [N, K] = GetParam();
+
+  constexpr size_t nr = 8;
+  constexpr size_t kr = 16;
+  constexpr size_t sr = 2;
+  constexpr size_t warmup_iters = 5;
+  constexpr size_t test_iters = 20;
+
+  // Random 4-bit source data (two nibbles per byte), scales and bias
+  const size_t rhs_stride = (K + 1) / 2;
+  std::vector<uint8_t> rhs_native(N * rhs_stride);
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  for (auto &b : rhs_native) {
+    b = static_cast<uint8_t>(dist(gen));
+  }
+  std::vector<float> scales = generate_random_vector<float>(N, 0.001F, 1.0F);
+
+  const size_t packed_size =
+    kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(N, K, nr, kr, sr);
+  std::vector<uint8_t> packed_ref(packed_size, 0xA5);
+  std::vector<uint8_t> packed_opt(packed_size, 0x5A);
+
+  struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params params;
+  params.lhs_zero_point = 1;
+  params.rhs_zero_point = 8;
+
+  // Correctness
+  kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(1, N, K, nr, kr, sr, rhs_native.data(),
+                                         NULL, scales.data(), packed_ref.data(),
+                                         0, &params);
+  kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+    1, N, K, nr, kr, sr, rhs_native.data(), NULL, scales.data(),
+    packed_opt.data(), 0, &params);
+
+  for (size_t i = 0; i < packed_size; i++) {
+    ASSERT_EQ(packed_ref[i], packed_opt[i])
+      << "first mismatch at byte " << i << " / " << packed_size;
+  }
+
+  // Performance
+  for (size_t i = 0; i < warmup_iters; ++i) {
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(
+      1, N, K, nr, kr, sr, rhs_native.data(), NULL, scales.data(),
+      packed_ref.data(), 0, &params);
+  }
+  nanoseconds time_ref = nanoseconds(0);
+  for (size_t i = 0; i < test_iters; ++i) {
+    auto t1 = steady_clock::now();
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(
+      1, N, K, nr, kr, sr, rhs_native.data(), NULL, scales.data(),
+      packed_ref.data(), 0, &params);
+    auto t2 = steady_clock::now();
+    time_ref += duration_cast<nanoseconds>(t2 - t1);
+  }
+
+  for (size_t i = 0; i < warmup_iters; ++i) {
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+      1, N, K, nr, kr, sr, rhs_native.data(), NULL, scales.data(),
+      packed_opt.data(), 0, &params);
+  }
+  nanoseconds time_opt = nanoseconds(0);
+  for (size_t i = 0; i < test_iters; ++i) {
+    auto t1 = steady_clock::now();
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+      1, N, K, nr, kr, sr, rhs_native.data(), NULL, scales.data(),
+      packed_opt.data(), 0, &params);
+    auto t2 = steady_clock::now();
+    time_opt += duration_cast<nanoseconds>(t2 - t1);
+  }
+
+  const auto avg_ref = time_ref.count() / test_iters;
+  const auto avg_opt = time_opt.count() / test_iters;
+  std::cout << "\n-----------------------------------------" << std::endl;
+  std::cout << "[RESULT] rhs_pack_nxk_qsi4cxp (n, k) = (" << N << ", " << K
+            << "), average over " << test_iters << " iterations:" << std::endl;
+  std::cout << "  reference: " << avg_ref << " ns (" << avg_ref / 1'000
+            << " us)" << std::endl;
+  std::cout << "  neon:      " << avg_opt << " ns (" << avg_opt / 1'000
+            << " us)" << std::endl;
+  std::cout << "  speedup:   " << static_cast<double>(avg_ref) / avg_opt << "x"
+            << std::endl;
+  std::cout << "-----------------------------------------" << std::endl;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  nntrainer_kleidiai, rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon,
+  ::testing::Values(std::make_tuple(1024, 1024), std::make_tuple(1024, 2048),
+                    std::make_tuple(1024, 3072), std::make_tuple(2048, 1024),
+                    std::make_tuple(3072, 1024),
+                    // edge cases: n % nr != 0, k % 32 != 0
+                    std::make_tuple(1000, 1000), std::make_tuple(9, 62)),
+  [](const ::testing::TestParamInfo<
+     rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon::ParamType> &info) {
+    size_t N = std::get<0>(info.param);
+    size_t K = std::get<1>(info.param);
+    return std::to_string(N) + "_" + std::to_string(K);
+  });
 
 int main(int argc, char **argv) {
   int result = -1;


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[kleidiai] Optimize rhs packing for QS4CX</summary><br />

[kleidiai] Optimize rhs packing for QS4CX

This commit introduces a custom optimized rhs packing for QS4CX.

Self evaluation:
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

## Summary
This PR increases performance for QS4CX rhs packing.

### Comparison on S26+

| | (n,k) = (1024,3072) weight | qwen3-0.6b |
|:--:|:--:|:--:|
| Before this PR | 5792300 ns | 1153059297 ns |
| From this PR | 64705 ns | 78486640 ns |
| gain | **89.5186x** | **14.69x** |


Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
