### PR TITLE
[CausalLM] Support multi-token prefill in RMSReverseNorm

### DIFF
--- a/Applications/CausalLM/layers/rms_reverse_norm.cpp
+++ b/Applications/CausalLM/layers/rms_reverse_norm.cpp
@@ -86,13 +86,11 @@ void RMSReverseNormLayer::incremental_forwarding(
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  unsigned int _from = from;
   bool is_prefill = !from;
   if (from) {
-    NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-      << "incremental step size is not 1";
+    // Normalize to 0-based while preserving step size for multi-token prefill
+    to = to - from;
     from = 0;
-    to = 1;
   } else if (skip_prefill && is_prefill)
     return;
 


### PR DESCRIPTION

### Summary
`RMSReverseNormLayer::incremental_forwarding` previously assumed a
single-token decode step: it asserted `(to - from) == 1` and hardcoded
`to = 1`. This made multi-turn inference impossible when the prefill
phase (non-zero `from`) spanned more than one token.

### Changes
- Removed the `to - from != 1` assertion.
- Replaced the hardcoded `to = 1` with `to = to - from`, normalizing the
  range to 0-based while preserving the original step size.

### Rationale
This enables multi-turn / multi-token prefill, where the step size can
be greater than 1. The rest of the computation (weight multiply, RMS
norm, out_scale) already operates on the full `to - from` slice, so it
works correctly without further changes.

### Testing
Verified that single-token decode behavior is unchanged and that
multi-token prefill no longer throws.
