### PR TITLE
[nntrainer] remove Android build warnings

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -93,7 +93,8 @@ static void col2im(const Tensor &col_matrix, const TensorDim &kdim,
    * of Tensor. Then we could remove to access the getData or getValue which has
    * dependecy of data type.
    */
-  auto apply_data = [&]<typename T>(T *val) {
+  auto apply_data = [&](auto *val) {
+    using T = std::decay_t<decltype(*val)>;
     unsigned col_w = 0;
     for (int hs = -(int)pt; hs <= h_stride_end; hs += hstride) {
       for (int ws = -(int)pl; ws <= w_stride_end; ws += wstride) {
@@ -230,7 +231,8 @@ static void im2col(const Tensor &in, const TensorDim &kdim,
               in.getTensorType()));
   // float *out_data = out.getData();
 
-  auto apply_data = [&]<typename T>(T *out_data) {
+  auto apply_data = [&](auto *out_data) {
+    using T = std::decay_t<decltype(*out_data)>;
     int h_stride_end = height - eff_k_height - pt;
     int w_stride_end = width - eff_k_width - pl;
 

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -191,7 +191,8 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
 
   unsigned int out_map_size = deriv.height() * deriv.width();
   unsigned int in_map_size = height * width;
-  auto apply_max = [&]<typename T>(T *result_data) {
+  auto apply_max = [&](auto *result_data) {
+    using T = std::decay_t<decltype(*result_data)>;
     const int *iter = pool_helper.getData<int>();
     const T *deriv_data = deriv.getData<T>();
     for (unsigned int b = 0; b < batch; ++b) {
@@ -210,7 +211,8 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
     }
   };
 
-  auto apply_average = [&]<typename T>(T *result_data) {
+  auto apply_average = [&](auto *result_data) {
+    using T = std::decay_t<decltype(*result_data)>;
     int height_stride_end = height - p_height + pt;
     int width_stride_end = width - p_width + pl;
     const int *iter = pool_helper.getData<int>();
@@ -242,7 +244,8 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
     }
   };
 
-  auto apply_global_max = [&]<typename T>(T *result_data) {
+  auto apply_global_max = [&](auto *result_data) {
+    using T = std::decay_t<decltype(*result_data)>;
     const T *deriv_data = deriv.getData<T>();
     for (unsigned int b = 0; b < batch; b++) {
       for (unsigned int c = 0; c < channel; c++) {
@@ -349,8 +352,9 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
 
   unsigned int max_idx_count = 0;
 
-  auto pool_fn_max = [&]<typename T>(const T *in_data, int channel_idx,
-                                     int start_h, int start_w) {
+  auto pool_fn_max = [&](const auto *in_data, int channel_idx, int start_h,
+                         int start_w) {
+    using T = std::decay_t<decltype(*in_data)>;
     int end_h = start_h + patch_height;
     int end_w = start_w + patch_width;
 
@@ -380,9 +384,9 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     return max_val;
   };
 
-  auto pool_fn_global_max = [&, this]<typename T>(const T *in_data,
-                                                  int channel_idx, int start_h,
-                                                  int start_w) {
+  auto pool_fn_global_max = [&, this](const auto *in_data, int channel_idx,
+                                      int start_h, int start_w) {
+    using T = std::decay_t<decltype(*in_data)>;
     int end_h = start_h + patch_height;
     int end_w = start_w + patch_width;
 
@@ -409,8 +413,9 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     return max_val;
   };
 
-  auto pool_fn_average = [&]<typename T>(const T *in_data, int channel_idx,
-                                         int start_h, int start_w) {
+  auto pool_fn_average = [&](const auto *in_data, int channel_idx, int start_h,
+                             int start_w) {
+    using T = std::decay_t<decltype(*in_data)>;
     int end_h = start_h + patch_height;
     int end_w = start_w + patch_width;
     T total = static_cast<T>(0.0f);


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[nntrainer] remove Android build warnings</summary><br />

Replace explicit lambda template parameter syntax [&]<typename T>() with
generic lambdas using auto parameters and std::decay_t type deduction.
This maintains C++17 compatibility while removing all C++20 extension warnings
in conv2d_layer.cpp and pooling2d_layer.cpp.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR resolves Android build warnings when using `package_android.sh`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>