### PR TITLE
[nntrainer] Fix is_prefill to recognize multi-token prefill steps

### DIFF
--- a/Applications/CausalLM/layers/logit_softcapping.cpp
+++ b/Applications/CausalLM/layers/logit_softcapping.cpp
@@ -60,7 +60,7 @@ void LogitSoftCappingLayer::forwarding(nntrainer::RunLayerContext &context,
 void LogitSoftCappingLayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/Applications/CausalLM/layers/per_layer_slice.cpp
+++ b/Applications/CausalLM/layers/per_layer_slice.cpp
@@ -40,7 +40,7 @@ void PerLayerSliceLayer::forwarding(nntrainer::RunLayerContext &context,
 void PerLayerSliceLayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -62,7 +62,7 @@ void ReshapedRMSNormLayer::incremental_forwarding(
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -55,7 +55,7 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/Applications/CausalLM/layers/rms_reverse_norm.cpp
+++ b/Applications/CausalLM/layers/rms_reverse_norm.cpp
@@ -86,13 +86,16 @@ void RMSReverseNormLayer::incremental_forwarding(
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  bool is_prefill = !from;
+  unsigned int step_size = to - from;
+  bool is_prefill = !from || step_size > 1;
+  if (skip_prefill && is_prefill)
+    return;
+
   if (from) {
     // Normalize to 0-based while preserving step size for multi-token prefill
     to = to - from;
     from = 0;
-  } else if (skip_prefill && is_prefill)
-    return;
+  }
 
   in_step_dim.batch(1);
   in_step_dim.height(to - from);

--- a/Applications/CausalLM/layers/scalar_multiply.cpp
+++ b/Applications/CausalLM/layers/scalar_multiply.cpp
@@ -64,7 +64,7 @@ void ScalarMultiplyLayer::forwarding(nntrainer::RunLayerContext &context,
 void ScalarMultiplyLayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -47,7 +47,7 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   nntrainer::Tensor &in2 = context.getInput(INPUT_IDX_2);
   nntrainer::Tensor &out = context.getOutput(OUT_IDX);
 
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -80,7 +80,7 @@ void ActivationLayer::incremental_forwarding(RunLayerContext &context,
                                              unsigned int from, unsigned int to,
                                              bool training) {
   (void)training;
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -46,7 +46,7 @@ void AdditionLayer::forwarding(RunLayerContext &context, bool training) {
 void AdditionLayer::incremental_forwarding(RunLayerContext &context,
                                            unsigned int from, unsigned int to,
                                            bool training) {
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -247,7 +247,7 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   Tensor loraA, loraB, hidden_tmp_lora, hidden_out_lora;
 
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 

--- a/nntrainer/layers/multiply_layer.cpp
+++ b/nntrainer/layers/multiply_layer.cpp
@@ -35,7 +35,7 @@ void MultiplyLayer::forwarding_operation(const Tensor &input0,
 void MultiplyLayer::incremental_forwarding(RunLayerContext &context,
                                            unsigned int from, unsigned int to,
                                            bool training) {
-  bool is_prefill = !from;
+  bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary>[nntrainer] Fix is_prefill to recognize multi-token prefill steps</summary><br />

skip_prefill-capable layers computed is_prefill as simply !from, which
only recognized the very first prefill call (from == 0) as prefill.
During multi-turn inference, a later turn's prefill re-enters these
layers with from > 0 and a multi-token step (to - from > 1) -- e.g. the
KV-shared/sliding-window layers in gemma4 -- so is_prefill
evaluated false and the layer computed normally instead of skipping.

mha_core.cpp already treated any step > 1 as prefill regardless of
from; the affected layers now match that convention:

  bool is_prefill = !from || (to - from) > 1;

Without this, a skip_prefill layer downstream of one that already
skipped (e.g. mha_core) would compute over that layer's stale output
tensor, producing well-defined but incorrect hidden states that
propagate into later layers' KV cache writes.

Affected: fc_layer, addition_layer, activation_layer, multiply_layer
(nntrainer/layers), and rms_norm, reshaped_rms_norm, rms_reverse_norm,
swiglu, per_layer_slice, scalar_multiply, logit_softcapping
(Applications/CausalLM/layers). Also reorders rms_reverse_norm's check
to compute is_prefill before normalizing from/to, so the skip decision
sees the original step size.

lm_head / tie_word_embedding's lmhead path intentionally left
unchanged -- they always compute only the last row of the given range,
and the SKIP_PREFILL multi-token segment's output is discarded by the
caller (causal_lm.cpp), so not skipping there wastes compute but does
not affect correctness.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jayden0701 <jrock.oh@samsung.com>

</details>

### Summary

- Fix `is_prefill` detection in 10 layers (`fc_layer`, `addition_layer`, `activation_layer`, `multiply_layer`, `rms_norm`, `reshaped_rms_norm`, `rms_reverse_norm`, `swiglu`, `per_layer_slice`, `scalar_multiply`, `logit_softcapping`) so multi-token, non-zero-offset prefill (`from > 0 && to - from > 1`) is correctly treated as prefill, matching `mha_core.cpp`'s existing convention.

Signed-off-by: jayden0701 <jrock.oh@samsung.com>