### PR TITLE
[nntrainer] optimize qai8dxp_qsi4cxp GEMM with cache-aware tiling

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi4cxp.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi4cxp.cpp
@@ -32,6 +32,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
+
 #include <kleidiai_interface.h>
 #include <thread_manager.h>
 
@@ -254,19 +256,11 @@ void __kai_gemm_qai8dxp_qsi4cxp_rhs_unpacked(
   size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
   void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, float *dst_act_mtx_f32,
   size_t idx_variant, bool is_nxk, float lower_bound, float upper_bound) {
-  const size_t mr = ukernel_variants[idx_variant].ukernel.get_mr();
-  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
-  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
-  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
-
   // Get the size in bytes for the packed matrices
-  const size_t lhs_packed_size =
-    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr);
   const size_t rhs_packed_size =
     __kai_get_rhs_packed_size_qsi4cxp_qs4cxs1s0(n, k, idx_variant, is_nxk);
 
   // Allocate the matrices
-  uint8_t *lhs_packed_mtx_qa8dx = new uint8_t[lhs_packed_size];
   uint8_t *rhs_packed_mtx_qs4cx = new uint8_t[rhs_packed_size];
 
   // RHS packing
@@ -278,7 +272,6 @@ void __kai_gemm_qai8dxp_qsi4cxp_rhs_unpacked(
   __kai_gemm_qai8dxp_qsi4cxp(m, n, k, lhs_native_mtx_f32, rhs_packed_mtx_qs4cx,
                              dst_act_mtx_f32, idx_variant);
 
-  delete[] lhs_packed_mtx_qa8dx;
   delete[] rhs_packed_mtx_qs4cx;
 }
 
@@ -288,7 +281,6 @@ void __kai_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                 float *dst_act_mtx_f32, size_t idx_variant,
                                 float lower_bound, float upper_bound) {
   const size_t mr = ukernel_variants[idx_variant].ukernel.get_mr();
-  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
   const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
   const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
 
@@ -305,82 +297,39 @@ void __kai_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
 
   auto &tm = nntrainer::ThreadManager::Global();
 
-  /// @todo find better heuristic
-  if (m_step > n_step) {
-    // parallelize over m
-    tm.parallel_for(0, m_loop, [&](size_t i) {
-      size_t m_start = i * m_step;
-      size_t m_to_process = std::min(m_step, m - m_start);
+  const size_t dst_stride = n * sizeof(float);
 
-      size_t lhs_offset = m_start * k;
-      float *lhs_ptr = (float *)lhs_native_mtx_f32 + lhs_offset;
+  // LHS quantize + pack, parallel over rows
+  tm.parallel_for(0, m_loop, [&](size_t i) {
+    size_t m_start = i * m_step;
+    size_t m_to_process = std::min(m_step, m - m_start);
 
-      const size_t lhs_packed_offset =
-        ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
-      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+    size_t lhs_offset = m_start * k;
+    float *lhs_ptr = (float *)lhs_native_mtx_f32 + lhs_offset;
 
-      // LHS packing
-      kai_run_lhs_quant_pack_qai8dxp_f32(m_to_process, k,   // Dimensions
-                                         mr, kr, sr, 0,     // Packing arguments
-                                         lhs_ptr,           // LHS
-                                         k * sizeof(float), // LHS stride
-                                         lhs_packed_ptr);   // LHS packed
+    const size_t lhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+    uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
 
-      const size_t rhs_packed_offset =
-        ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(0, k);
-      const void *rhs_packed_ptr =
-        (const void *)((const char *)rhs_packed_mtx_qs4cx + rhs_packed_offset);
+    // LHS packing
+    kai_run_lhs_quant_pack_qai8dxp_f32(m_to_process, k,   // Dimensions
+                                       mr, kr, sr, 0,     // Packing arguments
+                                       lhs_ptr,           // LHS
+                                       k * sizeof(float), // LHS stride
+                                       lhs_packed_ptr);   // LHS packed
+  });
 
-      const size_t dst_stride = n * sizeof(float);
-      const size_t dst_offset =
-        ukernel_variants[idx_variant].ukernel.get_dst_offset(m_start, 0,
-                                                             dst_stride);
-      float *dst_ptr = (float *)((uint8_t *)dst_act_mtx_f32 + dst_offset);
-
-      ukernel_variants[idx_variant].ukernel.run_matmul(
-        m_to_process, n, k,      // Dimensions
-        lhs_packed_ptr,          // LHS packed
-        rhs_packed_ptr,          // RHS packed
-        dst_ptr,                 // DST
-        dst_stride,              // DST stride (row)
-        sizeof(float),           // DST stride (col)
-        lower_bound, upper_bound // Min and max for the clamp operation
-      );
-    });
-  } else {
-    // parallelize over m
-    tm.parallel_for(0, m_loop, [&](size_t i) {
-      size_t m_start = i * m_step;
-      size_t m_to_process = std::min(m_step, m - m_start);
-
-      size_t lhs_offset = m_start * k;
-      float *lhs_ptr = (float *)lhs_native_mtx_f32 + lhs_offset;
-
-      const size_t lhs_packed_offset =
-        ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
-      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
-
-      // LHS packing
-      kai_run_lhs_quant_pack_qai8dxp_f32(m_to_process, k,   // Dimensions
-                                         mr, kr, sr, 0,     // Packing arguments
-                                         lhs_ptr,           // LHS
-                                         k * sizeof(float), // LHS stride
-                                         lhs_packed_ptr);   // LHS packed
-    });
-
-    // parallelize over n
+  if (m <= m_step) {
+    // GEMV-like shape: LHS stays cached, parallelize over n only
     tm.parallel_for(0, n_loop, [&](size_t i) {
       size_t n_start = i * n_step;
       size_t n_to_process = std::min(n_step, n - n_start);
-
-      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx;
 
       const size_t rhs_packed_offset =
         ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_start, k);
       const void *rhs_packed_ptr =
         (const void *)((const char *)rhs_packed_mtx_qs4cx + rhs_packed_offset);
 
-      const size_t dst_stride = n * sizeof(float);
       const size_t dst_offset =
         ukernel_variants[idx_variant].ukernel.get_dst_offset(0, n_start,
                                                              dst_stride);
@@ -388,7 +337,7 @@ void __kai_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
 
       ukernel_variants[idx_variant].ukernel.run_matmul(
         m, n_to_process, k,      // Dimensions
-        lhs_packed_ptr,          // LHS packed
+        lhs_packed_mtx_qa8dx,    // LHS packed
         rhs_packed_ptr,          // RHS packed
         dst_ptr,                 // DST
         dst_stride,              // DST stride (row)
@@ -396,7 +345,92 @@ void __kai_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
         lower_bound, upper_bound // Min and max for the clamp operation
       );
     });
+
+    delete[] lhs_packed_mtx_qa8dx;
+    return;
   }
+
+  // Cache-aware 2D tiling
+  // - The kernel re-reads the whole RHS panel every m_step rows, so the panel
+  //   must stay L2-resident.
+  auto ceil_div = [](size_t a, size_t b) { return (a + b - 1) / b; };
+
+  const size_t n_block_bytes =
+    ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_step, k);
+  const size_t m_block_bytes =
+    ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_step, k);
+
+  // Assume that per-core L2 size is 1MB
+  constexpr size_t l2_cache_bytes = 1024 * 1024;
+
+  // n: fewest tiles whose RHS panel fits ~2/3 of L2, split evenly
+  constexpr size_t rhs_l2_budget = l2_cache_bytes * 2 / 3;
+  size_t n_tiles = std::clamp<size_t>(
+    ceil_div(n_loop * n_block_bytes, rhs_l2_budget), 1, n_loop);
+  size_t n_blocks = ceil_div(n_loop, n_tiles);
+  n_tiles = ceil_div(n_loop, n_blocks);
+
+  // m: enough tiles for work stealing to balance uneven cores
+  constexpr size_t tasks_per_thread = 16;
+  const size_t num_threads = tm.getComputeThreadCount();
+  const size_t target_tasks = tasks_per_thread * num_threads;
+  size_t m_tiles =
+    std::clamp<size_t>(ceil_div(target_tasks, n_tiles), 1, m_loop);
+  size_t m_blocks = ceil_div(m_loop, m_tiles);
+
+  // reduce m block so the LHS panel also fits in L2
+  const size_t rhs_panel_bytes = n_blocks * n_block_bytes;
+  if (rhs_panel_bytes < l2_cache_bytes) {
+    m_blocks = std::min(
+      m_blocks,
+      std::max<size_t>((l2_cache_bytes - rhs_panel_bytes) / m_block_bytes, 1));
+  }
+  m_tiles = ceil_div(m_loop, m_blocks);
+
+  // increase n block to reach the task target for small m
+  if (m_tiles * n_tiles < target_tasks && n_tiles < n_loop) {
+    n_tiles = std::min(ceil_div(target_tasks, m_tiles), n_loop);
+    n_blocks = ceil_div(n_loop, n_tiles);
+    n_tiles = ceil_div(n_loop, n_blocks);
+  }
+
+  const size_t m_chunk = m_blocks * m_step;
+  const size_t n_chunk = n_blocks * n_step;
+
+  // row-major: consecutive tasks share the LHS panel
+  tm.parallel_for(0, m_tiles * n_tiles, [&](size_t t) {
+    const size_t ti = t / n_tiles;
+    const size_t tj = t % n_tiles;
+
+    const size_t m_start = ti * m_chunk;
+    const size_t m_to_process = std::min(m_chunk, m - m_start);
+    const size_t n_start = tj * n_chunk;
+    const size_t n_to_process = std::min(n_chunk, n - n_start);
+
+    const size_t lhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+    const uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+
+    const size_t rhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_start, k);
+    const void *rhs_packed_ptr =
+      (const void *)((const char *)rhs_packed_mtx_qs4cx + rhs_packed_offset);
+
+    const size_t dst_offset =
+      ukernel_variants[idx_variant].ukernel.get_dst_offset(m_start, n_start,
+                                                           dst_stride);
+    float *dst_ptr = (float *)((uint8_t *)dst_act_mtx_f32 + dst_offset);
+
+    ukernel_variants[idx_variant].ukernel.run_matmul(
+      m_to_process, n_to_process, k, // Dimensions
+      lhs_packed_ptr,                // LHS packed
+      rhs_packed_ptr,                // RHS packed
+      dst_ptr,                       // DST
+      dst_stride,                    // DST stride (row)
+      sizeof(float),                 // DST stride (col)
+      lower_bound, upper_bound       // Min and max for the clamp operation
+    );
+  });
 
   delete[] lhs_packed_mtx_qa8dx;
 }


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[nntrainer] optimize qai8dxp_qsi4cxp GEMM with cache-aware tiling</summary><br />

Replace the m_step/n_step one-dimensional split heuristic in
__kai_gemm_qai8dxp_qsi4cxp with cache-aware 2D tiling, assuming a
fixed 1 MiB per-core L2:

- n_chunk: the micro-kernels iterate row-blocks outer / columns
  inner, so the RHS panel is re-read every m_step rows. Size it to
  an even split of n whose panel fits in 2/3 of L2.
- m_chunk: sized for ~16 tasks per thread so work stealing can
  balance heterogeneous cores, and capped so the LHS panel reused
  by consecutive tiles stays L2-resident beside the RHS panel,
  trading oversized panels for more tasks.
- Tiles are walked row-major; small m splits n finer to keep all
  cores fed, and m <= m_step keeps the previous GEMV n-split path.

Measured on 8 threads, M=1024 N=2560 K=4096, variant 8 (i8mm
8x8x32), interleaved A/B with 60s cooldowns: 10.99ms -> 10.21ms
median (-7.2%, 6/6 wins) with 3x lower run-to-run variance.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

## Summary

This PR improves heuristics for qai8dxp_qsi4cxp GEMM especially for the fastest kernel 8(matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm).

The following results are measured on Galaxy S26+.

### kernel performance
Since kernel level benchmark on main branch is not valid, I used the #4060 which resolved this issue.
* 1024x2560x4096 (ukernel 3~8)
 

| Kernel | optimized (ns) | PR 4060 (ns) |
|--------|-----------|-------------|
| ukernel[3] matmul_clamp_f32_qai8dxp4x4_qsi4cxp8x4_8x8x32_neon_dotprod | 17692640 | 17855062 |
| ukernel[4] matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x4_16x4x32_neon_dotprod | 18724320 | 19493789 |
| ukernel[5] matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_4x4x32_neon_i8mm | 14166047 | 15385062 |
| ukernel[6] matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_8x4x32_neon_i8mm | 11728945 | 13745500 |
| ukernel[7] matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_4x8x32_neon_i8mm | 12334203 | 12401266 |
| ukernel[8] matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm | 10184508 | 11624187 |



### model performance
* qwen3-0.6b, 1024 input, 512 output

|  | optimized (TPS) | main (TPS) |
|--------|-----------|-------------|
| Prefill | 581.158 | 570.474 |
| Decode | 53.8267 | 49.0234 |

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
