### PR TITLE
fix(ci): support UTF-8 encoded source files in doxygen checks

### DIFF
--- a/.github/workflows/static.check.scripts/doxygen-build.sh
+++ b/.github/workflows/static.check.scripts/doxygen-build.sh
@@ -68,7 +68,7 @@ for file in `cat $files`; do
   fi
 
   # Handle only a source code sequentially in case that there are lots of files in one commit.
-  if [[ `file $file | grep "ASCII text" | wc -l` -gt 0 ]]; then
+  if [[ `file $file | grep -E "(ASCII|Unicode) text" | wc -l` -gt 0 ]]; then
     case $file in
       # In case of source code
       *.c | *.cpp | *.cc | *.hh | *.h | *.hpp | *.py | *.sh | *.php | *.java)

--- a/.github/workflows/static.check.scripts/doxygen-tag.sh
+++ b/.github/workflows/static.check.scripts/doxygen-tag.sh
@@ -37,7 +37,7 @@ fi
 echo "::group::Doxygen tag check started"
 
 for file in `cat $files`; do
-  if [[ `file $file | grep "ASCII text" | wc -l` -gt 0 ]]; then
+  if [[ `file $file | grep -E "(ASCII|Unicode) text" | wc -l` -gt 0 ]]; then
       # In case of source code files: *.c|*.h|*.cpp|*.py|*.sh|*.php )
       case $file in
           # In case of C/C++ code


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>fix(ci): support UTF-8 encoded source files in doxygen checks</summary><br />

The doxygen-tag.sh and doxygen-build.sh scripts were filtering files using "ASCII text" only, which excluded UTF-8 encoded files. This caused doxygen checks to skip UTF-8 files containing non-ASCII characters (e.g., em-dashes in comments).

Updated the file type filter to accept both ASCII and Unicode text:
- doxygen-tag.sh: grep now uses regex to match "(ASCII|Unicode) text"
- doxygen-build.sh: same fix applied

This ensures doxygen checks apply consistently to all text source files regardless of their text encoding.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: haehun.yang <haehun.yang@samsung.com>

</details>

### Summary

- fix(ci): support UTF-8 encoded source files in doxygen checks

Signed-off-by: haehun.yang <haehun.yang@samsung.com>
