### PR TITLE
[Build] Fix clang invalid-feature-combination error from -march=native on AVX10.1 runners

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,9 @@ if cxx_compiler_id == 'clang'
   warning_flags += '-Wno-format-nonliteral'
   warning_flags += '-Wno-varargs'
   warning_flags += '-Wno-missing-braces'
+  # -march=native on newer AVX10.1-capable CPUs conflicts with the explicit
+  # -mavx2/-mfma below; clang treats that as a hard error under -Werror.
+  warning_flags += '-Wno-error=invalid-feature-combination'
 else
   warning_flags += '-Wno-maybe-uninitialized'
 endif


### PR DESCRIPTION
## Summary
- `meson_test` CI (ubuntu-22.04/24.04, clang) has been failing on `main`'s scheduled builds for weeks, unrelated to any specific PR.
- GitHub Actions runners now expose AVX10.1-capable CPUs. `meson.build` unconditionally adds `-march=native -mavx2 -mfma`; clang detects the conflicting feature combination and (under `-Werror`) hard-fails with `invalid feature combination: +avx10.1-256; will be promoted to avx10.1-512`.
- Add `-Wno-error=invalid-feature-combination` to the clang warning flags, gated by meson's `has_argument` check (same pattern as the other `-Wno-error=*` flags nearby), so older clang without this diagnostic is unaffected.

## Test plan
- [ ] CI `meson_test (ubuntu-22.04)` and `meson_test (ubuntu-24.04)` pass on this PR
- [ ] `main` scheduled build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)