### PR TITLE
[CI] update PR label conditions for review counts

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Unzip artifact"
         run: unzip pr_number.zip
 
-      - name: Remove & Make label if approved review >= 3
+      - name: Remove & Make label if approved review >= 2
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,39 +53,20 @@ jobs:
             let review = Number(fs.readFileSync('./review_num'));
             let is_contain = String(fs.readFileSync('./contain_bool')).trim();
 
-            if ((review >= 3) && (is_contain==String("true"))) {
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              name : "Need Review"
-            })
+            if ((review >= 2) && (is_contain==String("true"))) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                name : "Need Review"
+              })
             }
 
-            if ((review >= 3) && (is_contain==String("true"))) {
+            if (review >= 2) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
                 labels: ["PR/READY2MERGE"]
               })
-              }
-
-      - name: Make label if approved review < 3
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            let fs = require('fs');
-            let issue_number = Number(fs.readFileSync('./pr_number'));
-            let review = Number(fs.readFileSync('./review_num'));
-            let is_contain = String(fs.readFileSync('./contain_bool')).trim();
-
-            if ((review < 3) && (is_contain==String("false"))) {
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              labels: ["Need Review"]
-            })
             }


### PR DESCRIPTION
- Stop adding 'Need Review' label automatically; users must add it manually.
- Lower the required review count threshold for the 'PR/READY2MERGE' label from 3 to 2.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>