### PR TITLE
[ggml] Introduce Q8_0 weight gemv/gemm

### DIFF
--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -116,6 +116,18 @@ void __ggml_repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
   nntr_repack_q4_0_to_q4_0_8_bl(dst, 8, src, data_size, M, N);
 }
 
+void __ggml_repack_q8_0_to_q8_0_4x4(void *dst, void *src, size_t data_size,
+                                    const unsigned int M,
+                                    const unsigned int N) {
+  nntr_repack_q8_0_to_q8_0_4_bl(dst, 4, src, data_size, M, N);
+}
+
+void __ggml_repack_q8_0_to_q8_0_4x8(void *dst, void *src, size_t data_size,
+                                    const unsigned int M,
+                                    const unsigned int N) {
+  nntr_repack_q8_0_to_q8_0_4_bl(dst, 8, src, data_size, M, N);
+}
+
 void __ggml_repack_q4_K_to_q4_K_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N) {
   nntr_repack_q4_K_to_q4_K_8_bl(dst, 8, src, data_size, M, N);

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -183,6 +183,45 @@ void __ggml_q4_0_4x8_q8_0_GEMM(const unsigned int M,
                                std::vector<unsigned int> ldbs,
                                std::vector<T *> C,
                                std::vector<unsigned int> ldcs);
+
+/**
+ * @brief A(M, K) * W.T(N, K) = (M, N)
+ *
+ * @param M as descripted above
+ * @param N as descripted above
+ * @param K as descripted above
+ * @param A Activation
+ * @param lda leading dimension of A
+ * @param B offline quantized and packed q8_0x4 Weight
+ * @param ldb leading dimension of B
+ * @param C dst matrix
+ * @param ldc leading dimension of C
+ */
+void __ggml_q8_0_4x4_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc);
+
+/**
+ * @brief A(M, K) * W.T(N, K) = (M, N)
+ *
+ * @param M as descripted above
+ * @param N as descripted above
+ * @param K as descripted above
+ * @param A Activation
+ * @param lda leading dimension of A
+ * @param B offline quantized and packed q8_0x4 Weight
+ * @param ldb leading dimension of B
+ * @param C dst matrix
+ * @param ldc leading dimension of C
+ */
+void __ggml_q8_0_4x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc);
+
 /**
  * @brief A(M, K) * W.T(N, K) = (M, N)
  *
@@ -329,6 +368,30 @@ void __ggml_repack_q4_0_to_q4_0_4(void *dst, void *src, size_t data_size,
  */
 void __ggml_repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N);
+
+/**
+ * @brief repack q80 to q80x4 with interleave block 4
+ *
+ * @param dst output repacked q80x4
+ * @param src input q80
+ * @param data_size total weight size
+ * @param M number of rows
+ * @param N number of columns
+ */
+void __ggml_repack_q8_0_to_q8_0_4x4(void *dst, void *src, size_t data_size,
+                                    const unsigned int M, const unsigned int N);
+/**
+ * @brief repack q80 to q80x4 with interleave block 8
+ *
+ * @param dst output repacked q80x4
+ * @param src input q80
+ * @param data_size total weight size
+ * @param M number of rows
+ * @param N number of columns
+ */
+void __ggml_repack_q8_0_to_q8_0_4x8(void *dst, void *src, size_t data_size,
+                                    const unsigned int M, const unsigned int N);
+
 /**
  * @brief repack q4K to q4Kx8
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_omp.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_omp.cpp
@@ -377,6 +377,228 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M,
                            "multi-weights is not implemented yet");
 }
 
+void __ggml_q8_0_4x4_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc) {
+  auto &tm = ThreadManager::Global();
+
+  // @todo optimize parameters
+  if (M == 1) { // GEMV
+    unsigned int B_step = sizeof(block_q8_0) * (K / QK8_0);
+    unsigned int blocks_per_row = (K + QK8_0 - 1) / QK8_0;
+    unsigned int qa_size = sizeof(block_q8_0) * blocks_per_row;
+    std::vector<char> QA = std::vector<char>(qa_size);
+
+    // online quantization for fp32 activation with no packing
+    nntr_quantize_row_q8_0(A, QA.data(), K);
+
+    unsigned int chunk_size = 16;
+    unsigned int loop = (N + chunk_size - 1) / chunk_size;
+
+    // compute multithreaded GEMV
+    tm.parallel_for(0, loop, [=](size_t idx) {
+      unsigned int N_step_start = chunk_size * idx;
+      unsigned int N_step_end = std::min(chunk_size * (idx + 1), (size_t)N);
+
+      nntr_gemv_q8_0_4x4_q8_0(K, (float *)((C) + N_step_start), N,
+                              (void *)((char *)B + N_step_start * B_step),
+                              QA.data(), M, N_step_end - N_step_start);
+    });
+  } else { // GEMM
+    unsigned int blocks_per_4_rows = (K + QK8_0 - 1) / QK8_0;
+    unsigned int qa_4_rows_size = sizeof(block_q8_0x4) * blocks_per_4_rows;
+    const size_t qa_row_size =
+      (sizeof(block_q8_0) * K) / QK8_0; // ignore remainder
+    unsigned int M4 = M / 4;
+
+    unsigned int qa_size =
+      qa_4_rows_size * M4 + static_cast<unsigned int>(qa_row_size) * (M % 4);
+    std::vector<char> QA = std::vector<char>(qa_size);
+    char *qa_data = QA.data();
+
+    // online quantization for M4 * 4 rows; parallelize over 8-group chunks
+    // when there is enough work to amortize waking the pool
+    unsigned int quant_chunk = 8;
+    if (M4 >= 2 * quant_chunk) {
+      tm.parallel_for(0, (M4 + quant_chunk - 1) / quant_chunk, [=](size_t t) {
+        unsigned int q_end = std::min(quant_chunk * (t + 1), (size_t)M4);
+        for (unsigned int i = quant_chunk * t; i < q_end; i++) {
+          nntr_quantize_mat_q8_0_4x4(A + 4 * i * K,
+                                     qa_data + i * qa_4_rows_size, K);
+        }
+      });
+    } else {
+      for (unsigned int i = 0; i < M4; i++) {
+        nntr_quantize_mat_q8_0_4x4(A + 4 * i * K, qa_data + i * qa_4_rows_size,
+                                   K);
+      }
+    }
+
+    // online quantization for remainder
+    for (unsigned int i = M4 * 4; i < M; i++) {
+      nntr_quantize_row_q8_0(
+        (float *)A + i * K,
+        (QA.data() + (M4 * qa_4_rows_size) + (i - M4 * 4) * qa_row_size), K);
+    }
+
+    size_t row_chunk_size = 16;
+    size_t row_loop = (M4 * 4 + row_chunk_size - 1) / row_chunk_size;
+    size_t A_step = sizeof(block_q8_0) * (K / QK8_0);
+
+    size_t col_chunk_size = 16;
+    size_t col_loop = (N + col_chunk_size - 1) / col_chunk_size;
+    size_t B_step = sizeof(block_q8_0) * (K / QK8_0);
+
+    tm.parallel_for(0, col_loop * row_loop, [=](size_t i) {
+      unsigned int r = i / col_loop;
+      unsigned int c = i % col_loop;
+
+      unsigned int r_start = r * row_chunk_size;
+      unsigned int r_end = std::min((unsigned int)(row_chunk_size * (r + 1)),
+                                    (unsigned int)(M4 * 4));
+
+      unsigned int c_start = c * col_chunk_size;
+      unsigned int c_end =
+        std::min((unsigned int)(col_chunk_size * (c + 1)), N);
+
+      nntr_gemm_q8_0_4x4_q8_0(K, (float *)(C + r_start * N + c_start), ldc,
+                              (void *)((char *)B + c_start * B_step),
+                              (void *)(QA.data() + r_start * A_step),
+                              r_end - r_start, c_end - c_start);
+    });
+
+    // Compute leftover 1 ~ 3 rows with multithreaded GEMV
+    for (unsigned int pb = M4 * 4; pb < M; pb++) {
+      unsigned int chunk_size = 16;
+      unsigned int loop = (N + chunk_size - 1) / chunk_size;
+
+      tm.parallel_for(0, loop, [=](size_t idx) {
+        unsigned int M_step_start = chunk_size * idx;
+        unsigned int M_step_end = std::min(chunk_size * (idx + 1), (size_t)N);
+
+        nntr_gemv_q8_0_4x4_q8_0(
+          K, (float *)((C + ((pb - M4 * 4) * N) + (M4 * 4 * N)) + M_step_start),
+          N, (void *)((char *)B + M_step_start * B_step),
+          QA.data() + (M4 * qa_4_rows_size) + (pb - M4 * 4) * qa_row_size, 1,
+          M_step_end - M_step_start);
+      });
+    }
+  }
+}
+
+void __ggml_q8_0_4x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc) {
+  auto &tm = ThreadManager::Global();
+
+  // @todo optimize parameters
+  if (M == 1) { // GEMV
+    unsigned int B_step = sizeof(block_q8_0) * (K / QK8_0);
+    unsigned int blocks_per_row = (K + QK8_0 - 1) / QK8_0;
+    unsigned int qa_size = sizeof(block_q8_0) * blocks_per_row;
+    std::vector<char> QA = std::vector<char>(qa_size);
+
+    // online quantization for fp32 activation with no packing
+    nntr_quantize_row_q8_0(A, QA.data(), K);
+
+    unsigned int chunk_size = 16;
+    unsigned int loop = (N + chunk_size - 1) / chunk_size;
+
+    // compute multithreaded GEMV
+    tm.parallel_for(0, loop, [=](size_t idx) {
+      unsigned int N_step_start = chunk_size * idx;
+      unsigned int N_step_end = std::min(chunk_size * (idx + 1), (size_t)N);
+
+      nntr_gemv_q8_0_4x8_q8_0(K, (float *)((C) + N_step_start), N,
+                              (void *)((char *)B + N_step_start * B_step),
+                              QA.data(), M, N_step_end - N_step_start);
+    });
+  } else { // GEMM
+    unsigned int blocks_per_4_rows = (K + QK8_0 - 1) / QK8_0;
+    unsigned int qa_4_rows_size = sizeof(block_q8_0x4) * blocks_per_4_rows;
+    const size_t qa_row_size =
+      (sizeof(block_q8_0) * K) / QK8_0; // ignore remainder
+    unsigned int M4 = M / 4;
+
+    unsigned int qa_size =
+      qa_4_rows_size * M4 + static_cast<unsigned int>(qa_row_size) * (M % 4);
+    std::vector<char> QA = std::vector<char>(qa_size);
+    char *qa_data = QA.data();
+
+    // online quantization for M4 * 4 rows; parallelize over 8-group chunks
+    // when there is enough work to amortize waking the pool
+    unsigned int quant_chunk = 8;
+    if (M4 >= 2 * quant_chunk) {
+      tm.parallel_for(0, (M4 + quant_chunk - 1) / quant_chunk, [=](size_t t) {
+        unsigned int q_end = std::min(quant_chunk * (t + 1), (size_t)M4);
+        for (unsigned int i = quant_chunk * t; i < q_end; i++) {
+          nntr_quantize_mat_q8_0_4x8(A + 4 * i * K,
+                                     qa_data + i * qa_4_rows_size, K);
+        }
+      });
+    } else {
+      for (unsigned int i = 0; i < M4; i++) {
+        nntr_quantize_mat_q8_0_4x8(A + 4 * i * K, qa_data + i * qa_4_rows_size,
+                                   K);
+      }
+    }
+
+    // online quantization for remainder
+    for (unsigned int i = M4 * 4; i < M; i++) {
+      nntr_quantize_row_q8_0(
+        (float *)A + i * K,
+        (QA.data() + (M4 * qa_4_rows_size) + (i - M4 * 4) * qa_row_size), K);
+    }
+
+    size_t row_chunk_size = 16;
+    size_t row_loop = (M4 * 4 + row_chunk_size - 1) / row_chunk_size;
+    size_t A_step = sizeof(block_q8_0) * (K / QK8_0);
+
+    size_t col_chunk_size = 16;
+    size_t col_loop = (N + col_chunk_size - 1) / col_chunk_size;
+    size_t B_step = sizeof(block_q8_0) * (K / QK8_0);
+
+    tm.parallel_for(0, col_loop * row_loop, [=](size_t i) {
+      unsigned int r = i / col_loop;
+      unsigned int c = i % col_loop;
+
+      unsigned int r_start = r * row_chunk_size;
+      unsigned int r_end = std::min((unsigned int)(row_chunk_size * (r + 1)),
+                                    (unsigned int)(M4 * 4));
+
+      unsigned int c_start = c * col_chunk_size;
+      unsigned int c_end =
+        std::min((unsigned int)(col_chunk_size * (c + 1)), N);
+
+      nntr_gemm_q8_0_4x8_q8_0(K, (float *)(C + r_start * N + c_start), ldc,
+                              (void *)((char *)B + c_start * B_step),
+                              (void *)(QA.data() + r_start * A_step),
+                              r_end - r_start, c_end - c_start);
+    });
+
+    // Compute leftover 1 ~ 3 rows with multithreaded GEMV
+    for (unsigned int pb = M4 * 4; pb < M; pb++) {
+      unsigned int chunk_size = 16;
+      unsigned int loop = (N + chunk_size - 1) / chunk_size;
+
+      tm.parallel_for(0, loop, [=](size_t idx) {
+        unsigned int M_step_start = chunk_size * idx;
+        unsigned int M_step_end = std::min(chunk_size * (idx + 1), (size_t)N);
+
+        nntr_gemv_q8_0_4x8_q8_0(
+          K, (float *)((C + ((pb - M4 * 4) * N) + (M4 * 4 * N)) + M_step_start),
+          N, (void *)((char *)B + M_step_start * B_step),
+          QA.data() + (M4 * qa_4_rows_size) + (pb - M4 * 4) * qa_row_size, 1,
+          M_step_end - M_step_start);
+      });
+    }
+  }
+}
+
 void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int K, const float *A,
                                const unsigned int lda, const void *B,

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl.h
@@ -61,6 +61,25 @@ void nntr_gemv_q4_K_8x8_q8_K(int n, float *__restrict s, size_t bs,
                              const void *__restrict vx,
                              const void *__restrict vy, int nr, int nc);
 
+void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc);
+
+void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc);
+
+void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc);
+
+void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc);
+
+void nntr_quantize_mat_q8_0_4x4(const float *__restrict x, void *__restrict vy,
+                                int64_t k);
+
 void nntr_quantize_mat_q8_0_4x8(const float *__restrict x, void *__restrict vy,
                                 int64_t k);
 
@@ -72,6 +91,10 @@ int nntr_repack_q4_0_to_q4_0_4_bl(void *__restrict dst, int interleave_block,
                                   size_t nrow, size_t k);
 
 int nntr_repack_q4_0_to_q4_0_8_bl(void *__restrict dst, int interleave_block,
+                                  const void *__restrict data, size_t data_size,
+                                  size_t nrow, size_t k);
+
+int nntr_repack_q8_0_to_q8_0_4_bl(void *__restrict dst, int interleave_block,
                                   const void *__restrict data, size_t data_size,
                                   size_t nrow, size_t k);
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_avx.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_avx.cpp
@@ -939,6 +939,198 @@ void nntr_gemm_q4_0_8x8_q8_0(int n, float *__restrict s, size_t bs,
   }
 }
 
+//============================================================================
+// GEMM/GEMV - Q8_0 4x4
+//============================================================================
+
+void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 4;
+
+  assert(nr == 1);
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+}
+
+//============================================================================
+// GEMM/GEMV - Q8_0 4x8
+//============================================================================
+
+void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 8;
+
+  assert(nr == 1);
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+}
+
 void nntr_gemm_q4_K_8x8_q8_K(int n, float *__restrict s, size_t bs,
                              const void *__restrict vx,
                              const void *__restrict vy, int nr, int nc) {
@@ -3068,6 +3260,45 @@ void nntr_quantize_mat_q8_K_4x8(const float *__restrict x, void *__restrict vy,
   }
 }
 
+void nntr_quantize_mat_q8_0_4x4(const float *__restrict x, void *__restrict vy,
+                                int64_t k) {
+  assert(QK8_0 == 32);
+  assert(k % QK8_0 == 0);
+  const int nb = k / QK8_0;
+
+  block_q8_0x4 *__restrict y = (block_q8_0x4 *)vy;
+
+  // scalar
+  const int blck_size_interleave = 4;
+  float srcv[4][QK8_0];
+  float id[4];
+
+  for (int i = 0; i < nb; i++) {
+    for (int row_iter = 0; row_iter < 4; row_iter++) {
+      float amax = 0.0f; // absolute max
+
+      for (int j = 0; j < QK8_0; j++) {
+        srcv[row_iter][j] = x[row_iter * k + i * QK8_0 + j];
+        amax = MAX(amax, fabsf(srcv[row_iter][j]));
+      }
+
+      const float d = amax / ((1 << 7) - 1);
+      id[row_iter] = d ? 1.0f / d : 0.0f;
+
+      y[i].d[row_iter] = nntr_compute_fp32_to_fp16(d);
+    }
+
+    for (int j = 0; j < QK8_0 * 4; j++) {
+      int src_offset = (j / (4 * blck_size_interleave)) * blck_size_interleave;
+      int src_id = (j % (4 * blck_size_interleave)) / blck_size_interleave;
+      src_offset += (j % blck_size_interleave);
+
+      float x0 = srcv[src_id][src_offset] * id[src_id];
+      y[i].qs[j] = roundf(x0);
+    }
+  }
+}
+
 void nntr_quantize_mat_q8_0_4x8(const float *__restrict x, void *__restrict vy,
                                 int64_t k) {
   assert(Q8_0 == 32);
@@ -3221,6 +3452,25 @@ static block_q4_0x8 nntr_make_block_q4_0x8(block_q4_0 *in,
   return out;
 }
 
+static block_q8_0x4 nntr_make_block_q8_0x4(block_q8_0 *in,
+                                           unsigned int blck_size_interleave) {
+  block_q8_0x4 out;
+
+  for (int i = 0; i < 4; i++) {
+    out.d[i] = in[i].d;
+  }
+
+  const int end = QK8_0 * 4 / blck_size_interleave;
+  for (int i = 0; i < end; ++i) {
+    int src_id = i % 4;
+    int src_offset = (i / 4) * blck_size_interleave;
+    int dst_offset = i * blck_size_interleave;
+    memcpy(&out.qs[dst_offset], &in[src_id].qs[src_offset],
+           blck_size_interleave);
+  }
+  return out;
+}
+
 static block_q4_Kx8 make_block_q4_Kx8(block_q4_K *in,
                                       unsigned int blck_size_interleave) {
   block_q4_Kx8 out;
@@ -3352,6 +3602,35 @@ int nntr_repack_q4_0_to_q4_0_8_bl(void *__restrict dst, int interleave_block,
         dst_tmp[i] = src[x + i * nblocks];
       }
       *dst_++ = nntr_make_block_q4_0x8(dst_tmp, interleave_block);
+    }
+    src += nrows_interleaved * nblocks;
+  }
+  return 0;
+}
+
+int nntr_repack_q8_0_to_q8_0_4_bl(void *__restrict dst, int interleave_block,
+                                  const void *__restrict data, size_t data_size,
+                                  size_t nrow, size_t k) {
+  assert(interleave_block == 4 || interleave_block == 8);
+  constexpr int nrows_interleaved = 4;
+
+  block_q8_0x4 *dst_ = (block_q8_0x4 *)dst;
+  const block_q8_0 *src = (const block_q8_0 *)data;
+  block_q8_0 dst_tmp[4];
+  int nblocks = k / QK8_0;
+
+  assert(data_size == nrow * nblocks * sizeof(block_q8_0));
+
+  if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
+    return -1;
+  }
+
+  for (int b = 0; b < nrow; b += nrows_interleaved) {
+    for (int64_t x = 0; x < nblocks; x++) {
+      for (int i = 0; i < nrows_interleaved; i++) {
+        dst_tmp[i] = src[x + i * nblocks];
+      }
+      *dst_++ = nntr_make_block_q8_0x4(dst_tmp, interleave_block);
     }
     src += nrows_interleaved * nblocks;
   }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
@@ -105,6 +105,25 @@ static block_q4_0x8 nntr_make_block_q4_0x8(block_q4_0 *in,
   return out;
 }
 
+static block_q8_0x4 nntr_make_block_q8_0x4(block_q8_0 *in,
+                                           unsigned int blck_size_interleave) {
+  block_q8_0x4 out;
+
+  for (int i = 0; i < 4; i++) {
+    out.d[i] = in[i].d;
+  }
+
+  const int end = QK8_0 * 4 / blck_size_interleave;
+  for (int i = 0; i < end; ++i) {
+    int src_id = i % 4;
+    int src_offset = (i / 4) * blck_size_interleave;
+    int dst_offset = i * blck_size_interleave;
+    memcpy(&out.qs[dst_offset], &in[src_id].qs[src_offset],
+           blck_size_interleave);
+  }
+  return out;
+}
+
 static block_q4_Kx8 make_block_q4_Kx8(block_q4_K *in,
                                       unsigned int blck_size_interleave) {
   block_q4_Kx8 out;
@@ -318,6 +337,198 @@ void nntr_gemv_q4_0_8x8_q8_0(int n, float *__restrict s, size_t bs,
 }
 
 //============================================================================
+// GEMM/GEMV - Q8_0 4x4
+//============================================================================
+
+void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 4;
+
+  assert(nr == 1);
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+}
+
+//============================================================================
+// GEMM/GEMV - Q8_0 4x8
+//============================================================================
+
+void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  const int nb = n / qk;
+  const int ncols_interleaved = 4;
+  const int blocklen = 8;
+
+  assert(nr == 1);
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+}
+
+//============================================================================
 // GEMM/GEMV - Q4_K 8x8 (NYI in fallback)
 //============================================================================
 
@@ -338,6 +549,45 @@ void nntr_gemv_q4_K_8x8_q8_K(int n, float *__restrict s, size_t bs,
 //============================================================================
 // Quantization helper functions (matrix packing)
 //============================================================================
+
+void nntr_quantize_mat_q8_0_4x4(const float *__restrict x, void *__restrict vy,
+                                int64_t k) {
+  assert(QK8_0 == 32);
+  assert(k % QK8_0 == 0);
+  const int nb = k / QK8_0;
+
+  block_q8_0x4 *__restrict y = (block_q8_0x4 *)vy;
+
+  // scalar
+  const int blck_size_interleave = 4;
+  float srcv[4][QK8_0];
+  float id[4];
+
+  for (int i = 0; i < nb; i++) {
+    for (int row_iter = 0; row_iter < 4; row_iter++) {
+      float amax = 0.0f; // absolute max
+
+      for (int j = 0; j < QK8_0; j++) {
+        srcv[row_iter][j] = x[row_iter * k + i * QK8_0 + j];
+        amax = MAX(amax, fabsf(srcv[row_iter][j]));
+      }
+
+      const float d = amax / ((1 << 7) - 1);
+      id[row_iter] = d ? 1.0f / d : 0.0f;
+
+      y[i].d[row_iter] = nntr_compute_fp32_to_fp16(d);
+    }
+
+    for (int j = 0; j < QK8_0 * 4; j++) {
+      int src_offset = (j / (4 * blck_size_interleave)) * blck_size_interleave;
+      int src_id = (j % (4 * blck_size_interleave)) / blck_size_interleave;
+      src_offset += (j % blck_size_interleave);
+
+      float x0 = srcv[src_id][src_offset] * id[src_id];
+      y[i].qs[j] = roundf(x0);
+    }
+  }
+}
 
 void nntr_quantize_mat_q8_0_4x8(const float *__restrict x, void *__restrict vy,
                                 int64_t k) {
@@ -467,6 +717,35 @@ int nntr_repack_q4_0_to_q4_0_8_bl(void *__restrict dst, int interleave_block,
         dst_tmp[i] = src[x + i * nblocks];
       }
       *dst_++ = nntr_make_block_q4_0x8(dst_tmp, interleave_block);
+    }
+    src += nrows_interleaved * nblocks;
+  }
+  return 0;
+}
+
+int nntr_repack_q8_0_to_q8_0_4_bl(void *__restrict dst, int interleave_block,
+                                  const void *__restrict data, size_t data_size,
+                                  size_t nrow, size_t k) {
+  assert(interleave_block == 4 || interleave_block == 8);
+  constexpr int nrows_interleaved = 4;
+
+  block_q8_0x4 *dst_ = (block_q8_0x4 *)dst;
+  const block_q8_0 *src = (const block_q8_0 *)data;
+  block_q8_0 dst_tmp[4];
+  int nblocks = k / QK8_0;
+
+  assert(data_size == nrow * nblocks * sizeof(block_q8_0));
+
+  if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
+    return -1;
+  }
+
+  for (int b = 0; b < nrow; b += nrows_interleaved) {
+    for (int64_t x = 0; x < nblocks; x++) {
+      for (int i = 0; i < nrows_interleaved; i++) {
+        dst_tmp[i] = src[x + i * nblocks];
+      }
+      *dst_++ = nntr_make_block_q8_0x4(dst_tmp, interleave_block);
     }
     src += nrows_interleaved * nblocks;
   }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_neon.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_neon.cpp
@@ -1186,6 +1186,394 @@ void nntr_gemm_q4_0_8x8_q8_0(int n, float *__restrict s, size_t bs,
   }
 }
 
+void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_FEATURE_DOTPROD)
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+      float32x4_t sumf[4];
+      for (int m = 0; m < 4; m++) {
+        sumf[m] = vdupq_n_f32(0);
+      }
+
+      for (int l = 0; l < nb; l++) {
+        float32x4_t a_d = vcvt_f32_f16(vld1_f16((const float16_t *)a_ptr[l].d));
+        float32x4_t b_d = vcvt_f32_f16(vld1_f16((const float16_t *)b_ptr[l].d));
+
+        int32x4_t sumi_0 = vdupq_n_s32(0);
+        int32x4_t sumi_1 = vdupq_n_s32(0);
+        int32x4_t sumi_2 = vdupq_n_s32(0);
+        int32x4_t sumi_3 = vdupq_n_s32(0);
+
+        for (int k_group = 0; k_group < 8; k_group += 4) {
+          int8x16x4_t a = vld1q_s8_x4(a_ptr[l].qs + 16 * k_group);
+          int8x16x4_t b = vld1q_s8_x4(b_ptr[l].qs + 16 * k_group);
+
+          for (int k = 0; k < 4; k++) {
+            sumi_0 = vdotq_laneq_s32(sumi_0, b.val[k], a.val[k], 0);
+            sumi_1 = vdotq_laneq_s32(sumi_1, b.val[k], a.val[k], 1);
+            sumi_2 = vdotq_laneq_s32(sumi_2, b.val[k], a.val[k], 2);
+            sumi_3 = vdotq_laneq_s32(sumi_3, b.val[k], a.val[k], 3);
+          }
+        }
+
+        sumf[0] = vmlaq_f32(sumf[0], vmulq_laneq_f32(b_d, a_d, 0),
+                            vcvtq_f32_s32(sumi_0));
+        sumf[1] = vmlaq_f32(sumf[1], vmulq_laneq_f32(b_d, a_d, 1),
+                            vcvtq_f32_s32(sumi_1));
+        sumf[2] = vmlaq_f32(sumf[2], vmulq_laneq_f32(b_d, a_d, 2),
+                            vcvtq_f32_s32(sumi_2));
+        sumf[3] = vmlaq_f32(sumf[3], vmulq_laneq_f32(b_d, a_d, 3),
+                            vcvtq_f32_s32(sumi_3));
+      }
+
+      for (int m = 0; m < 4; m++) {
+        vst1q_f32(s + (y * 4 + m) * bs + x * 4, sumf[m]);
+      }
+    }
+  }
+#else
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+#endif
+}
+
+void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_FEATURE_DOTPROD)
+  const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+    for (int b = 0; b < nb; b++) {
+      int8x16x4_t b_low = vld1q_s8_x4((const int8_t *)b_ptr->qs);
+      int8x16x4_t b_high = vld1q_s8_x4((const int8_t *)b_ptr->qs + 64);
+      float16x4_t bd = vld1_f16((const __fp16 *)b_ptr->d);
+
+      int8x16x2_t a = vld1q_s8_x2(a_ptr->qs);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&a_ptr->d);
+
+      int32x4_t ret = vdupq_n_s32(0);
+
+      ret = vdotq_laneq_s32(ret, b_low.val[0], a.val[0], 0);
+      ret = vdotq_laneq_s32(ret, b_low.val[1], a.val[0], 1);
+      ret = vdotq_laneq_s32(ret, b_low.val[2], a.val[0], 2);
+      ret = vdotq_laneq_s32(ret, b_low.val[3], a.val[0], 3);
+
+      ret = vdotq_laneq_s32(ret, b_high.val[0], a.val[1], 0);
+      ret = vdotq_laneq_s32(ret, b_high.val[1], a.val[1], 1);
+      ret = vdotq_laneq_s32(ret, b_high.val[2], a.val[1], 2);
+      ret = vdotq_laneq_s32(ret, b_high.val[3], a.val[1], 3);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      a_ptr++;
+      b_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+#else
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+#endif
+}
+
+void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const block_q8_0x4 *b_ptr_base = (const block_q8_0x4 *)vx;
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_FEATURE_DOTPROD)
+  for (int y = 0; y < nr; y += 4) {
+    const block_q8_0x4 *a_ptr_base = (const block_q8_0x4 *)vy + (y / 4) * nb;
+
+    for (int x = 0; x < nc; x += ncols_interleaved) {
+      const block_q8_0x4 *b_ptr = b_ptr_base + (x / 4) * nb;
+      const block_q8_0x4 *a_ptr = a_ptr_base;
+
+      float32x4_t acc_f32[4];
+      for (int i = 0; i < 4; i++) {
+        acc_f32[i] = vdupq_n_f32(0);
+      }
+
+      for (int b = 0; b < nb; b++) {
+        int32x4_t acc[4];
+        for (int i = 0; i < 4; i++) {
+          acc[i] = vdupq_n_s32(0);
+        }
+
+        // Process 4 chunks of 8 positions each
+        for (int chunk = 0; chunk < 4; chunk++) {
+          int8x16_t a01 = vld1q_s8(a_ptr->qs + chunk * 32);
+          int8x16_t a23 = vld1q_s8(a_ptr->qs + chunk * 32 + 16);
+          int8x16_t b01 = vld1q_s8(b_ptr->qs + chunk * 32);
+          int8x16_t b23 = vld1q_s8(b_ptr->qs + chunk * 32 + 16);
+
+          acc[0] = vmmlaq_s32(acc[0], a01, b01);
+          acc[1] = vmmlaq_s32(acc[1], a01, b23);
+          acc[2] = vmmlaq_s32(acc[2], a23, b01);
+          acc[3] = vmmlaq_s32(acc[3], a23, b23);
+        }
+
+        // Reorder outputs from 2×2 tiles to row-major
+        // acc[0] = [r0c0, r0c1, r1c0, r1c1]
+        // acc[1] = [r0c2, r0c3, r1c2, r1c3]
+        // acc[2] = [r2c0, r2c1, r3c0, r3c1]
+        // acc[3] = [r2c2, r2c3, r3c2, r3c3]
+        int32x4_t row0 =
+          vcombine_s32(vget_low_s32(acc[0]), vget_low_s32(acc[1]));
+        int32x4_t row1 =
+          vcombine_s32(vget_high_s32(acc[0]), vget_high_s32(acc[1]));
+        int32x4_t row2 =
+          vcombine_s32(vget_low_s32(acc[2]), vget_low_s32(acc[3]));
+        int32x4_t row3 =
+          vcombine_s32(vget_high_s32(acc[2]), vget_high_s32(acc[3]));
+
+        // Scales
+        float32x4_t a_d = vcvt_f32_f16(vld1_f16((const __fp16 *)a_ptr->d));
+        float32x4_t b_d = vcvt_f32_f16(vld1_f16((const __fp16 *)b_ptr->d));
+
+        acc_f32[0] = vfmaq_f32(acc_f32[0], vcvtq_f32_s32(row0),
+                               vmulq_laneq_f32(b_d, a_d, 0));
+        acc_f32[1] = vfmaq_f32(acc_f32[1], vcvtq_f32_s32(row1),
+                               vmulq_laneq_f32(b_d, a_d, 1));
+        acc_f32[2] = vfmaq_f32(acc_f32[2], vcvtq_f32_s32(row2),
+                               vmulq_laneq_f32(b_d, a_d, 2));
+        acc_f32[3] = vfmaq_f32(acc_f32[3], vcvtq_f32_s32(row3),
+                               vmulq_laneq_f32(b_d, a_d, 3));
+
+        a_ptr++;
+        b_ptr++;
+      }
+
+      for (int row = 0; row < 4; row++) {
+        vst1q_f32(s + (y + row) * bs + x, acc_f32[row]);
+      }
+    }
+  }
+#else
+  float sumf[4][4];
+  int sumi;
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumf[m][j] = 0.0;
+        }
+      }
+      for (int l = 0; l < nb; l++) {
+        for (int k = 0; k < (qk / blocklen); k++) {
+          for (int m = 0; m < 4; m++) {
+            for (int j = 0; j < ncols_interleaved; j++) {
+              sumi = 0;
+              for (int i = 0; i < blocklen; ++i) {
+                const int v0 =
+                  b_ptr[l]
+                    .qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+                sumi += v0 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+              }
+              sumf[m][j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                            nntr_compute_fp16_to_fp32(a_ptr[l].d[m]);
+            }
+          }
+        }
+      }
+      for (int m = 0; m < 4; m++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+        }
+      }
+    }
+  }
+#endif
+}
+
+void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_FEATURE_DOTPROD)
+  const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+
+    for (int b = 0; b < nb; b++) {
+      int8x16x4_t b_low = vld1q_s8_x4((const int8_t *)b_ptr->qs);
+      int8x16x4_t b_high = vld1q_s8_x4((const int8_t *)b_ptr->qs + 64);
+      float16x4_t bd = vld1_f16((const __fp16 *)b_ptr->d);
+
+      int8x8x4_t a_chunks = vld1_s8_x4(a_ptr->qs);
+      int8x16_t a0 = vcombine_s8(a_chunks.val[0], a_chunks.val[0]);
+      int8x16_t a1 = vcombine_s8(a_chunks.val[1], a_chunks.val[1]);
+      int8x16_t a2 = vcombine_s8(a_chunks.val[2], a_chunks.val[2]);
+      int8x16_t a3 = vcombine_s8(a_chunks.val[3], a_chunks.val[3]);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&a_ptr->d);
+
+      int32x4_t ret0 = vdupq_n_s32(0);
+      int32x4_t ret1 = vdupq_n_s32(0);
+
+      // 0..7
+      ret0 = vdotq_s32(ret0, b_low.val[0], a0);
+      ret1 = vdotq_s32(ret1, b_low.val[1], a0);
+      // 8..15
+      ret0 = vdotq_s32(ret0, b_low.val[2], a1);
+      ret1 = vdotq_s32(ret1, b_low.val[3], a1);
+      // 16..23
+      ret0 = vdotq_s32(ret0, b_high.val[0], a2);
+      ret1 = vdotq_s32(ret1, b_high.val[1], a2);
+      // 24..31
+      ret0 = vdotq_s32(ret0, b_high.val[2], a3);
+      ret1 = vdotq_s32(ret1, b_high.val[3], a3);
+
+      int32x4_t ret = vpaddq_s32(ret0, ret1);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      a_ptr++;
+      b_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+#else
+  float sumf[4];
+  int sumi;
+
+  const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+  for (int x = 0; x < nc / ncols_interleaved; x++) {
+    const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+    for (int j = 0; j < ncols_interleaved; j++) {
+      sumf[j] = 0.0;
+    }
+    for (int l = 0; l < nb; l++) {
+      for (int k = 0; k < (qk / blocklen); k++) {
+        for (int j = 0; j < ncols_interleaved; j++) {
+          sumi = 0;
+          for (int i = 0; i < blocklen; ++i) {
+            const int v0 =
+              b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i];
+            sumi += v0 * a_ptr[l].qs[k * blocklen + i];
+          }
+          sumf[j] += sumi * nntr_compute_fp16_to_fp32(b_ptr[l].d[j]) *
+                     nntr_compute_fp16_to_fp32(a_ptr[l].d);
+        }
+      }
+    }
+    for (int j = 0; j < ncols_interleaved; j++) {
+      s[x * ncols_interleaved + j] = sumf[j];
+    }
+  }
+#endif
+}
+
 void nntr_gemm_q4_K_8x8_q8_K(int n, float *__restrict s, size_t bs,
                              const void *__restrict vx,
                              const void *__restrict vy, int nr, int nc) {
@@ -1419,6 +1807,74 @@ void nntr_quantize_mat_q8_K_4x8(const float *__restrict x, void *__restrict vy,
   }
 }
 
+void nntr_quantize_mat_q8_0_4x4(const float *__restrict x, void *__restrict vy,
+                                int64_t k) {
+  assert(QK8_0 == 32);
+  assert(k % QK8_0 == 0);
+  const int nb = k / QK8_0;
+
+  block_q8_0x4 *__restrict y = (block_q8_0x4 *)vy;
+
+  float32x4_t srcv[4][8];
+  float id[4];
+
+  for (int i = 0; i < nb; i++) {
+    float32x4_t asrcv[8];
+    float32x4_t amaxv[8];
+
+    for (int row_iter = 0; row_iter < 4; row_iter++) {
+      for (int j = 0; j < 8; j++)
+        srcv[row_iter][j] = vld1q_f32(x + row_iter * k + i * 32 + 4 * j);
+      for (int j = 0; j < 8; j++)
+        asrcv[j] = vabsq_f32(srcv[row_iter][j]);
+
+      for (int j = 0; j < 4; j++)
+        amaxv[2 * j] = vmaxq_f32(asrcv[2 * j], asrcv[2 * j + 1]);
+      for (int j = 0; j < 2; j++)
+        amaxv[4 * j] = vmaxq_f32(amaxv[4 * j], amaxv[4 * j + 2]);
+      for (int j = 0; j < 1; j++)
+        amaxv[8 * j] = vmaxq_f32(amaxv[8 * j], amaxv[8 * j + 4]);
+
+      const float amax = vmaxvq_f32(amaxv[0]);
+
+      const float d = amax / ((1 << 7) - 1);
+      id[row_iter] = d ? 1.0f / d : 0.0f;
+
+      y[i].d[row_iter] = nntr_compute_fp32_to_fp16(d);
+    }
+
+    for (int j = 0; j < 8; j++) {
+      float32x4_t v = vmulq_n_f32(srcv[0][j], id[0]);
+      int32x4_t vi = vcvtnq_s32_f32(v);
+      y[i].qs[16 * j + 0] = vgetq_lane_s32(vi, 0);
+      y[i].qs[16 * j + 1] = vgetq_lane_s32(vi, 1);
+      y[i].qs[16 * j + 2] = vgetq_lane_s32(vi, 2);
+      y[i].qs[16 * j + 3] = vgetq_lane_s32(vi, 3);
+
+      v = vmulq_n_f32(srcv[1][j], id[1]);
+      vi = vcvtnq_s32_f32(v);
+      y[i].qs[16 * j + 4] = vgetq_lane_s32(vi, 0);
+      y[i].qs[16 * j + 5] = vgetq_lane_s32(vi, 1);
+      y[i].qs[16 * j + 6] = vgetq_lane_s32(vi, 2);
+      y[i].qs[16 * j + 7] = vgetq_lane_s32(vi, 3);
+
+      v = vmulq_n_f32(srcv[2][j], id[2]);
+      vi = vcvtnq_s32_f32(v);
+      y[i].qs[16 * j + 8] = vgetq_lane_s32(vi, 0);
+      y[i].qs[16 * j + 9] = vgetq_lane_s32(vi, 1);
+      y[i].qs[16 * j + 10] = vgetq_lane_s32(vi, 2);
+      y[i].qs[16 * j + 11] = vgetq_lane_s32(vi, 3);
+
+      v = vmulq_n_f32(srcv[3][j], id[3]);
+      vi = vcvtnq_s32_f32(v);
+      y[i].qs[16 * j + 12] = vgetq_lane_s32(vi, 0);
+      y[i].qs[16 * j + 13] = vgetq_lane_s32(vi, 1);
+      y[i].qs[16 * j + 14] = vgetq_lane_s32(vi, 2);
+      y[i].qs[16 * j + 15] = vgetq_lane_s32(vi, 3);
+    }
+  }
+}
+
 void nntr_quantize_mat_q8_0_4x8(const float *__restrict x, void *__restrict vy,
                                 int64_t k) {
   assert(Q8_0 == 32);
@@ -1536,6 +1992,25 @@ static block_q4_0x8 nntr_make_block_q4_0x8(block_q4_0 *in,
     memcpy(&out.qs[dst_offset], &elems, sizeof(uint64_t));
   }
 
+  return out;
+}
+
+static block_q8_0x4 nntr_make_block_q8_0x4(block_q8_0 *in,
+                                           unsigned int blck_size_interleave) {
+  block_q8_0x4 out;
+
+  for (int i = 0; i < 4; i++) {
+    out.d[i] = in[i].d;
+  }
+
+  const int end = QK8_0 * 4 / blck_size_interleave;
+  for (int i = 0; i < end; ++i) {
+    int src_id = i % 4;
+    int src_offset = (i / 4) * blck_size_interleave;
+    int dst_offset = i * blck_size_interleave;
+    memcpy(&out.qs[dst_offset], &in[src_id].qs[src_offset],
+           blck_size_interleave);
+  }
   return out;
 }
 
@@ -1670,6 +2145,35 @@ int nntr_repack_q4_0_to_q4_0_8_bl(void *__restrict dst, int interleave_block,
         dst_tmp[i] = src[x + i * nblocks];
       }
       *dst_++ = nntr_make_block_q4_0x8(dst_tmp, interleave_block);
+    }
+    src += nrows_interleaved * nblocks;
+  }
+  return 0;
+}
+
+int nntr_repack_q8_0_to_q8_0_4_bl(void *__restrict dst, int interleave_block,
+                                  const void *__restrict data, size_t data_size,
+                                  size_t nrow, size_t k) {
+  assert(interleave_block == 4 || interleave_block == 8);
+  constexpr int nrows_interleaved = 4;
+
+  block_q8_0x4 *dst_ = (block_q8_0x4 *)dst;
+  const block_q8_0 *src = (const block_q8_0 *)data;
+  block_q8_0 dst_tmp[4];
+  int nblocks = k / QK8_0;
+
+  assert(data_size == nrow * nblocks * sizeof(block_q8_0));
+
+  if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
+    return -1;
+  }
+
+  for (int b = 0; b < nrow; b += nrows_interleaved) {
+    for (int64_t x = 0; x < nblocks; x++) {
+      for (int i = 0; i < nrows_interleaved; i++) {
+        dst_tmp[i] = src[x + i * nblocks];
+      }
+      *dst_++ = nntr_make_block_q8_0x4(dst_tmp, interleave_block);
     }
     src += nrows_interleaved * nblocks;
   }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_sve.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_sve.cpp
@@ -946,6 +946,254 @@ void nntr_gemm_q4_0_8x8_q8_0(int n, float *__restrict s, size_t bs,
   }
 }
 
+void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *a_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+      float32x4_t sumf[4];
+      for (int m = 0; m < 4; m++) {
+        sumf[m] = vdupq_n_f32(0);
+      }
+
+      for (int l = 0; l < nb; l++) {
+        float32x4_t a_d = vcvt_f32_f16(vld1_f16((const float16_t *)a_ptr[l].d));
+        float32x4_t b_d = vcvt_f32_f16(vld1_f16((const float16_t *)b_ptr[l].d));
+
+        int32x4_t sumi_0 = vdupq_n_s32(0);
+        int32x4_t sumi_1 = vdupq_n_s32(0);
+        int32x4_t sumi_2 = vdupq_n_s32(0);
+        int32x4_t sumi_3 = vdupq_n_s32(0);
+
+        for (int k_group = 0; k_group < 8; k_group += 4) {
+          int8x16x4_t a = vld1q_s8_x4(a_ptr[l].qs + 16 * k_group);
+          int8x16x4_t b = vld1q_s8_x4(b_ptr[l].qs + 16 * k_group);
+
+          for (int k = 0; k < 4; k++) {
+            sumi_0 = vdotq_laneq_s32(sumi_0, b.val[k], a.val[k], 0);
+            sumi_1 = vdotq_laneq_s32(sumi_1, b.val[k], a.val[k], 1);
+            sumi_2 = vdotq_laneq_s32(sumi_2, b.val[k], a.val[k], 2);
+            sumi_3 = vdotq_laneq_s32(sumi_3, b.val[k], a.val[k], 3);
+          }
+        }
+
+        sumf[0] = vmlaq_f32(sumf[0], vmulq_laneq_f32(b_d, a_d, 0),
+                            vcvtq_f32_s32(sumi_0));
+        sumf[1] = vmlaq_f32(sumf[1], vmulq_laneq_f32(b_d, a_d, 1),
+                            vcvtq_f32_s32(sumi_1));
+        sumf[2] = vmlaq_f32(sumf[2], vmulq_laneq_f32(b_d, a_d, 2),
+                            vcvtq_f32_s32(sumi_2));
+        sumf[3] = vmlaq_f32(sumf[3], vmulq_laneq_f32(b_d, a_d, 3),
+                            vcvtq_f32_s32(sumi_3));
+      }
+
+      for (int m = 0; m < 4; m++) {
+        vst1q_f32(s + (y * 4 + m) * bs + x * 4, sumf[m]);
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 4;
+
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+    for (int b = 0; b < nb; b++) {
+      int8x16x4_t b_low = vld1q_s8_x4((const int8_t *)b_ptr->qs);
+      int8x16x4_t b_high = vld1q_s8_x4((const int8_t *)b_ptr->qs + 64);
+      float16x4_t bd = vld1_f16((const __fp16 *)b_ptr->d);
+
+      int8x16x2_t a = vld1q_s8_x2(a_ptr->qs);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&a_ptr->d);
+
+      int32x4_t ret = vdupq_n_s32(0);
+
+      ret = vdotq_laneq_s32(ret, b_low.val[0], a.val[0], 0);
+      ret = vdotq_laneq_s32(ret, b_low.val[1], a.val[0], 1);
+      ret = vdotq_laneq_s32(ret, b_low.val[2], a.val[0], 2);
+      ret = vdotq_laneq_s32(ret, b_low.val[3], a.val[0], 3);
+
+      ret = vdotq_laneq_s32(ret, b_high.val[0], a.val[1], 0);
+      ret = vdotq_laneq_s32(ret, b_high.val[1], a.val[1], 1);
+      ret = vdotq_laneq_s32(ret, b_high.val[2], a.val[1], 2);
+      ret = vdotq_laneq_s32(ret, b_high.val[3], a.val[1], 3);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      a_ptr++;
+      b_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+}
+
+void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const block_q8_0x4 *b_ptr_base = (const block_q8_0x4 *)vx;
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nr % 4 == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  for (int y = 0; y < nr; y += 4) {
+    const block_q8_0x4 *a_ptr_base = (const block_q8_0x4 *)vy + (y / 4) * nb;
+
+    for (int x = 0; x < nc; x += ncols_interleaved) {
+      const block_q8_0x4 *b_ptr = b_ptr_base + (x / 4) * nb;
+      const block_q8_0x4 *a_ptr = a_ptr_base;
+
+      float32x4_t acc_f32[4];
+      for (int i = 0; i < 4; i++) {
+        acc_f32[i] = vdupq_n_f32(0);
+      }
+
+      for (int b = 0; b < nb; b++) {
+        int32x4_t acc[4];
+        for (int i = 0; i < 4; i++) {
+          acc[i] = vdupq_n_s32(0);
+        }
+
+        // Process 4 chunks of 8 positions each
+        for (int chunk = 0; chunk < 4; chunk++) {
+          int8x16_t a01 = vld1q_s8(a_ptr->qs + chunk * 32);
+          int8x16_t a23 = vld1q_s8(a_ptr->qs + chunk * 32 + 16);
+          int8x16_t b01 = vld1q_s8(b_ptr->qs + chunk * 32);
+          int8x16_t b23 = vld1q_s8(b_ptr->qs + chunk * 32 + 16);
+
+          acc[0] = vmmlaq_s32(acc[0], a01, b01);
+          acc[1] = vmmlaq_s32(acc[1], a01, b23);
+          acc[2] = vmmlaq_s32(acc[2], a23, b01);
+          acc[3] = vmmlaq_s32(acc[3], a23, b23);
+        }
+
+        // Reorder outputs from 2×2 tiles to row-major
+        // acc[0] = [r0c0, r0c1, r1c0, r1c1]
+        // acc[1] = [r0c2, r0c3, r1c2, r1c3]
+        // acc[2] = [r2c0, r2c1, r3c0, r3c1]
+        // acc[3] = [r2c2, r2c3, r3c2, r3c3]
+        int32x4_t row0 =
+          vcombine_s32(vget_low_s32(acc[0]), vget_low_s32(acc[1]));
+        int32x4_t row1 =
+          vcombine_s32(vget_high_s32(acc[0]), vget_high_s32(acc[1]));
+        int32x4_t row2 =
+          vcombine_s32(vget_low_s32(acc[2]), vget_low_s32(acc[3]));
+        int32x4_t row3 =
+          vcombine_s32(vget_high_s32(acc[2]), vget_high_s32(acc[3]));
+
+        // Scales
+        float32x4_t a_d = vcvt_f32_f16(vld1_f16((const __fp16 *)a_ptr->d));
+        float32x4_t b_d = vcvt_f32_f16(vld1_f16((const __fp16 *)b_ptr->d));
+
+        acc_f32[0] = vfmaq_f32(acc_f32[0], vcvtq_f32_s32(row0),
+                               vmulq_laneq_f32(b_d, a_d, 0));
+        acc_f32[1] = vfmaq_f32(acc_f32[1], vcvtq_f32_s32(row1),
+                               vmulq_laneq_f32(b_d, a_d, 1));
+        acc_f32[2] = vfmaq_f32(acc_f32[2], vcvtq_f32_s32(row2),
+                               vmulq_laneq_f32(b_d, a_d, 2));
+        acc_f32[3] = vfmaq_f32(acc_f32[3], vcvtq_f32_s32(row3),
+                               vmulq_laneq_f32(b_d, a_d, 3));
+
+        a_ptr++;
+        b_ptr++;
+      }
+
+      for (int row = 0; row < 4; row++) {
+        vst1q_f32(s + (y + row) * bs + x, acc_f32[row]);
+      }
+    }
+  }
+}
+
+void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
+                             const void *__restrict vx,
+                             const void *__restrict vy, int nr, int nc) {
+
+  const int qk = QK8_0;
+  [[maybe_unused]] const int nb = n / qk;
+  [[maybe_unused]] const int ncols_interleaved = 4;
+  [[maybe_unused]] const int blocklen = 8;
+
+  assert(n % qk == 0);
+  assert(nc % ncols_interleaved == 0);
+
+  const block_q8_0x4 *b_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *a_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+
+    for (int b = 0; b < nb; b++) {
+      int8x16x4_t b_low = vld1q_s8_x4((const int8_t *)b_ptr->qs);
+      int8x16x4_t b_high = vld1q_s8_x4((const int8_t *)b_ptr->qs + 64);
+      float16x4_t bd = vld1_f16((const __fp16 *)b_ptr->d);
+
+      int8x8x4_t a_chunks = vld1_s8_x4(a_ptr->qs);
+      int8x16_t a0 = vcombine_s8(a_chunks.val[0], a_chunks.val[0]);
+      int8x16_t a1 = vcombine_s8(a_chunks.val[1], a_chunks.val[1]);
+      int8x16_t a2 = vcombine_s8(a_chunks.val[2], a_chunks.val[2]);
+      int8x16_t a3 = vcombine_s8(a_chunks.val[3], a_chunks.val[3]);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&a_ptr->d);
+
+      int32x4_t ret0 = vdupq_n_s32(0);
+      int32x4_t ret1 = vdupq_n_s32(0);
+
+      // 0..7
+      ret0 = vdotq_s32(ret0, b_low.val[0], a0);
+      ret1 = vdotq_s32(ret1, b_low.val[1], a0);
+      // 8..15
+      ret0 = vdotq_s32(ret0, b_low.val[2], a1);
+      ret1 = vdotq_s32(ret1, b_low.val[3], a1);
+      // 16..23
+      ret0 = vdotq_s32(ret0, b_high.val[0], a2);
+      ret1 = vdotq_s32(ret1, b_high.val[1], a2);
+      // 24..31
+      ret0 = vdotq_s32(ret0, b_high.val[2], a3);
+      ret1 = vdotq_s32(ret1, b_high.val[3], a3);
+
+      int32x4_t ret = vpaddq_s32(ret0, ret1);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      a_ptr++;
+      b_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+}
+
 void nntr_gemm_q4_K_8x8_q8_K(int n, float *__restrict s, size_t bs,
                              const void *__restrict vx,
                              const void *__restrict vy, int nr, int nc) {
@@ -1338,6 +1586,25 @@ static block_q4_0x8 nntr_make_block_q4_0x8(block_q4_0 *in,
   return out;
 }
 
+static block_q8_0x4 nntr_make_block_q8_0x4(block_q8_0 *in,
+                                           unsigned int blck_size_interleave) {
+  block_q8_0x4 out;
+
+  for (int i = 0; i < 4; i++) {
+    out.d[i] = in[i].d;
+  }
+
+  const int end = QK8_0 * 4 / blck_size_interleave;
+  for (int i = 0; i < end; ++i) {
+    int src_id = i % 4;
+    int src_offset = (i / 4) * blck_size_interleave;
+    int dst_offset = i * blck_size_interleave;
+    memcpy(&out.qs[dst_offset], &in[src_id].qs[src_offset],
+           blck_size_interleave);
+  }
+  return out;
+}
+
 static block_q4_Kx8 make_block_q4_Kx8(block_q4_K *in,
                                       unsigned int blck_size_interleave) {
   block_q4_Kx8 out;
@@ -1469,6 +1736,35 @@ int nntr_repack_q4_0_to_q4_0_8_bl(void *__restrict dst, int interleave_block,
         dst_tmp[i] = src[x + i * nblocks];
       }
       *dst_++ = nntr_make_block_q4_0x8(dst_tmp, interleave_block);
+    }
+    src += nrows_interleaved * nblocks;
+  }
+  return 0;
+}
+
+int nntr_repack_q8_0_to_q8_0_4_bl(void *__restrict dst, int interleave_block,
+                                  const void *__restrict data, size_t data_size,
+                                  size_t nrow, size_t k) {
+  assert(interleave_block == 4 || interleave_block == 8);
+  constexpr int nrows_interleaved = 4;
+
+  block_q8_0x4 *dst_ = (block_q8_0x4 *)dst;
+  const block_q8_0 *src = (const block_q8_0 *)data;
+  block_q8_0 dst_tmp[4];
+  int nblocks = k / QK8_0;
+
+  assert(data_size == nrow * nblocks * sizeof(block_q8_0));
+
+  if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
+    return -1;
+  }
+
+  for (int b = 0; b < nrow; b += nrows_interleaved) {
+    for (int64_t x = 0; x < nblocks; x++) {
+      for (int i = 0; i < nrows_interleaved; i++) {
+        dst_tmp[i] = src[x + i * nblocks];
+      }
+      *dst_++ = nntr_make_block_q8_0x4(dst_tmp, interleave_block);
     }
     src += nrows_interleaved * nblocks;
   }

--- a/test/unittest/unittest_nntrainer_ggml_arm.cpp
+++ b/test/unittest/unittest_nntrainer_ggml_arm.cpp
@@ -25,6 +25,7 @@
 
 #include <ggml_interface.h>
 #include <nntr_ggml_impl.h>
+#include <nntrainer_test_util.h>
 #include <thread_manager.h>
 
 // Convert a float to its fp16 bit pattern the same way the production kernels
@@ -423,6 +424,120 @@ TEST(nntrainer_ggml_arm, DISABLED_quantize_mat_q8_0_4x8_benchmark) {
             << iters << " iters)" << std::endl;
   print_latency_stats(st);
   print_samples_us(samples);
+}
+
+static float test_q8_0_4x4(const size_t M, const size_t N, const size_t K) {
+  nntr_ggml_init();
+
+  auto A = generate_activations(K, 11, M);
+  auto W = generate_activations(K, 22, N);
+
+  std::vector<float> C_ref(M * N, 0.0f);
+
+  for (size_t i = 0; i < M; i++) {
+    for (size_t j = 0; j < N; j++) {
+      for (size_t k = 0; k < K; k++) {
+        C_ref[i * N + j] += A[i * K + k] * W[j * K + k];
+      }
+    }
+  }
+
+  const size_t q4_size = (size_t)N * K / 32 * sizeof(block_q8_0_testonly);
+  std::vector<char> Q4(q4_size), B(q4_size);
+  nntr_quantize_q8_0(W.data(), Q4.data(), N, K, nullptr);
+  nntr_repack_q8_0_to_q8_0_4_bl(B.data(), 4, Q4.data(), q4_size, N, K);
+
+  std::vector<float> C(M * N, 0.0f);
+
+  nntrainer::__ggml_q8_0_4x4_q8_0_GEMM(M, N, K, A.data(), K, B.data(), N,
+                                       C.data(), N);
+
+  return cosine_similarity(C_ref.data(), C.data(), M * N);
+}
+
+static float test_q8_0_4x8(const size_t M, const size_t N, const size_t K) {
+  nntr_ggml_init();
+
+  auto A = generate_activations(K, 11, M);
+  auto W = generate_activations(K, 22, N);
+
+  std::vector<float> C_ref(M * N, 0.0f);
+
+  for (size_t i = 0; i < M; i++) {
+    for (size_t j = 0; j < N; j++) {
+      for (size_t k = 0; k < K; k++) {
+        C_ref[i * N + j] += A[i * K + k] * W[j * K + k];
+      }
+    }
+  }
+
+  const size_t q4_size = (size_t)N * K / 32 * sizeof(block_q8_0_testonly);
+  std::vector<char> Q4(q4_size), B(q4_size);
+  nntr_quantize_q8_0(W.data(), Q4.data(), N, K, nullptr);
+  nntr_repack_q8_0_to_q8_0_4_bl(B.data(), 8, Q4.data(), q4_size, N, K);
+
+  std::vector<float> C(M * N, 0.0f);
+
+  nntrainer::__ggml_q8_0_4x8_q8_0_GEMM(M, N, K, A.data(), K, B.data(), N,
+                                       C.data(), N);
+
+  return cosine_similarity(C_ref.data(), C.data(), M * N);
+}
+
+TEST(nntrainer_ggml_arm, gemv_q8_0_4x4_1x128x128) {
+  const size_t M = 1, N = 128, K = 128;
+  float cos = test_q8_0_4x4(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemv_q8_0_4x8_1x128x128) {
+  const size_t M = 1, N = 128, K = 128;
+  float cos = test_q8_0_4x8(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x4_32x128x128) {
+  const size_t M = 32, N = 128, K = 128;
+  float cos = test_q8_0_4x4(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x8_32x128x128) {
+  const size_t M = 32, N = 128, K = 128;
+  float cos = test_q8_0_4x8(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x4_35x128x128) {
+  const size_t M = 35, N = 128, K = 128;
+  float cos = test_q8_0_4x4(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x8_35x128x128) {
+  const size_t M = 35, N = 128, K = 128;
+  float cos = test_q8_0_4x8(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x4_128x128x128) {
+  const size_t M = 128, N = 128, K = 128;
+  float cos = test_q8_0_4x4(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
+}
+
+TEST(nntrainer_ggml_arm, gemm_q8_0_4x8_128x128x128) {
+  const size_t M = 128, N = 128, K = 128;
+  float cos = test_q8_0_4x8(M, N, K);
+
+  EXPECT_GT(cos, 0.999f);
 }
 
 TEST(nntrainer_ggml_arm, DISABLED_quantize_row_q8_0_benchmark) {


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[ggml] Introduce Q8_0 weight gemv/gemm</summary><br />

- Add Q8_0 repack
- Add q8_0_4x4 online quantization
- Add q8_0_4x4_q8_0, q8_0_4x8_q8_0 gemv/gemm
- Add unittest

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR adds Q8_0 gemv/gemm.
- `4x4`: 4 activation rows x 4 weight cols with block 4 packing
- `4x8`: 4 activation rows x 4 weight cols with block 8 packing

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
