### PR TITLE
fix(ci): stop cpp-linter failing outright on large PRs

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -12,7 +12,7 @@ jobs:
           echo "Install mandatory dev packages to avoid false-positive reports from cpp-linter"
           sudo apt-get update
           sudo apt-get install libstdc++-*-dev
-      - uses: cpp-linter/cpp-linter-action@v2.9.0
+      - uses: cpp-linter/cpp-linter-action@v2.20.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `cpp-linter/cpp-linter-action` was pinned to `v2.9.0`, which has no fallback for GitHub's PR-diff API: once a PR crosses GitHub's diff-endpoint size caps, the API returns HTTP 406 (`"... lines (20000)"`), and v2.9.0 crashes the whole linter step instead of reporting an actual lint result — so large, otherwise-valid PRs fail CI for a reason unrelated to code formatting.
- Bump the pin to `v2.20.0` (current latest release), which added a paginated-files-API fallback in v2.13.0 (handles up to GitHub's 3000-file ceiling instead of crashing) and a fix in v2.13.3 for a related crash on renamed files with no diff content.

## Why the version bump is safe

11 minor versions and ~2.5 years separate v2.9.0 and v2.20.0, so there's real change in between — this isn't a no-op bump:
- Internal dependency updates: `cpp-linter` core package 1.7.1 → 1.12.x, `clang-tools` 0.11 → 0.16.
- New inputs added: `ignore-tidy`, `ignore-format`, `passive-reviews` (v2.12.0), `summary-output-file` (v2.20.0).
- Glob pattern support added to `ignore`/`ignore-format`/`ignore-tidy` (v2.12.0).
- Default clang version bumped twice: to 16 in v2.15.0, to 20 in v2.17.0.
- clang-tools installation switched from static binaries to PyPI wheels (v2.18.0).
- Internal build tooling migrated to uv/nu shell (v2.16.1), Python pinned to 3.12 (v2.16.6).
- v2.16.0 was a broken pre-release the maintainers explicitly flagged "don't use" (#313) — not used here.

None of this affects the specific inputs this workflow sets:
- New inputs are opt-in with safe defaults; we don't set them, so nothing changes.
- We pin `version: 14` explicitly, so the default-version bumps don't apply. clang-tools still supports LLVM 12–22 and falls back from binary to wheel automatically, so `14` keeps working after the packaging switch.
- Our `ignore: '.github|Applications/CausalLM/third_party'` has no glob wildcards, so it resolves identically whether matched as a plain path or a glob pattern (confirmed against the current `FileFilter.is_file_in_list` implementation, which walks parent directories via `PurePath.match()`).
- Everything else that changed (dependency bumps, internal tooling migration, Python pin) is implementation detail inside the composite action / its own release process, not something a consuming workflow like ours needs to account for.