### PR TITLE
[test] Fix unittest_opencl_kernels_int4/qk_k to build against the cur…

### DIFF
--- a/test/unittest/unittest_opencl_kernels_int4.cpp
+++ b/test/unittest/unittest_opencl_kernels_int4.cpp
@@ -37,8 +37,8 @@ static void run_dequantization_test_(const uint32_t K, const uint32_t N) {
     generate_random_vector<float>(N * K, -2.0f, 2.0f);
 
   // Dequantization Q4_0
-  if (K % Q4_0 == 0 && N % 8 == 0) {
-    size_t q4_data_size = K * N / Q4_0 * sizeof(block_q4_0);
+  if (K % QK4_0 == 0 && N % 8 == 0) {
+    size_t q4_data_size = K * N / QK4_0 * sizeof(block_q4_0);
     std::vector<uint8_t> q4_weight(q4_data_size);
     std::vector<uint8_t> q4_weight_repack(q4_data_size);
     nntrainer::quantize_q4_0(weight_fp32.data(), q4_weight.data(), N, K,
@@ -127,8 +127,8 @@ static void run_int4_gemv_test_(const uint32_t K, const uint32_t N,
   // Reference Q4_0 GEMM
   std::vector<float> ref_dst(N, 0.0f);
   float mse_q4 = 0.0f;
-  if (K % Q4_0 == 0 && N % 8 == 0) {
-    size_t q4_data_size = K * N / Q4_0 * sizeof(block_q4_0);
+  if (K % QK4_0 == 0 && N % 8 == 0) {
+    size_t q4_data_size = K * N / QK4_0 * sizeof(block_q4_0);
     std::vector<float> q4_output_fp32(N);
     std::vector<uint8_t> q4_weight(q4_data_size);
     std::vector<uint8_t> q4_weight_repack(q4_data_size);
@@ -441,8 +441,8 @@ static void run_int4_gemm_test_(const uint32_t M, const uint32_t K,
 
   // Reference Q4_0 GEMM
   float mse_q4 = 0.0f;
-  if (K % Q4_0 == 0 && N % 8 == 0) {
-    size_t q4_data_size = K * N / Q4_0 * sizeof(block_q4_0);
+  if (K % QK4_0 == 0 && N % 8 == 0) {
+    size_t q4_data_size = K * N / QK4_0 * sizeof(block_q4_0);
     std::vector<float> q4_output_fp32(M * N);
     std::vector<uint8_t> q4_weight(q4_data_size);
     std::vector<uint8_t> q4_weight_repack(q4_data_size);
@@ -493,8 +493,8 @@ static void run_int4_gemm_test_(const uint32_t M, const uint32_t K,
   unsigned int run_count = 5;
   auto t_w1 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::openvino_gemm_cl(input_ptr, weight_ptr, scale_ptr, output_ptr, M,
-                                N, K, scale_group_size);
+    nntrainer::gemm_int4_cl(input_ptr, weight_ptr, scale_ptr, output_ptr, M, N,
+                            K, scale_group_size);
   }
   auto t_w2 = std::chrono::high_resolution_clock::now();
   double avg_time =
@@ -509,8 +509,8 @@ static void run_int4_gemm_test_(const uint32_t M, const uint32_t K,
   // GPU INT4 GEMM
   auto t3 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::openvino_gemm_cl(input_ptr, weight_ptr, scale_ptr, output_ptr, M,
-                                N, K, scale_group_size);
+    nntrainer::gemm_int4_cl(input_ptr, weight_ptr, scale_ptr, output_ptr, M, N,
+                            K, scale_group_size);
   }
 
   auto t4 = std::chrono::high_resolution_clock::now();
@@ -651,15 +651,12 @@ TEST(nntrainer_opencl_kernels_int4, int4_gemm_async_test) {
   unsigned int run_count = 5;
   auto t_w1 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq0,
-                                 (uint16_t *)ws0, out0, M, N0, K,
-                                 scale_group_size);
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq1,
-                                 (uint16_t *)ws1, out1, M, N1, K,
-                                 scale_group_size);
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq2,
-                                 (uint16_t *)ws2, out2, M, N1, K,
-                                 scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq0, (uint16_t *)ws0,
+                             out0, M, N0, K, scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq1, (uint16_t *)ws1,
+                             out1, M, N1, K, scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq2, (uint16_t *)ws2,
+                             out2, M, N1, K, scale_group_size);
   }
   auto t_w2 = std::chrono::high_resolution_clock::now();
   double avg_time =
@@ -674,15 +671,12 @@ TEST(nntrainer_opencl_kernels_int4, int4_gemm_async_test) {
   // In-order kernel execution
   auto t1 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq0,
-                                 (uint16_t *)ws0, out0, M, N0, K,
-                                 scale_group_size);
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq1,
-                                 (uint16_t *)ws1, out1, M, N1, K,
-                                 scale_group_size);
-    nntrainer::openvino_sgemm_cl(activations_f32_ptr, (char *)wq2,
-                                 (uint16_t *)ws2, out2, M, N1, K,
-                                 scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq0, (uint16_t *)ws0,
+                             out0, M, N0, K, scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq1, (uint16_t *)ws1,
+                             out1, M, N1, K, scale_group_size);
+    nntrainer::sgemm_int4_cl(activations_f32_ptr, (char *)wq2, (uint16_t *)ws2,
+                             out2, M, N1, K, scale_group_size);
   }
   auto t2 = std::chrono::high_resolution_clock::now();
   auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
@@ -700,9 +694,8 @@ TEST(nntrainer_opencl_kernels_int4, int4_gemm_async_test) {
   // Async
   auto t3 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::openvino_gemm_async_cl(activations_f32_ptr, weight_vec,
-                                      scale_vec, out_vec, M, n_vec, K,
-                                      scale_group_size);
+    nntrainer::gemm_int4_async_cl(activations_f32_ptr, weight_vec, scale_vec,
+                                  out_vec, M, n_vec, K, scale_group_size);
   }
   auto t4 = std::chrono::high_resolution_clock::now();
   auto gpu_dt = std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3);

--- a/test/unittest/unittest_opencl_kernels_qk_k.cpp
+++ b/test/unittest/unittest_opencl_kernels_qk_k.cpp
@@ -142,7 +142,7 @@ static void run_q4_0_test(const uint32_t M, const uint32_t K,
   std::vector<float> ref_dst(M * N, 0.0f);
   std::vector<float> cpu_q4_dst(M * N, 0.0f);
 
-  const auto data_size = K * N / Q4_0 * sizeof(block_q4_0);
+  const auto data_size = K * N / QK4_0 * sizeof(block_q4_0);
 
   // Generate result from SGEMM
   nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,


### PR DESCRIPTION
Both OpenCL int4/QK-K unit tests fail to compile on upstream/main with -Denable-opencl=true, for two unrelated reasons:

1. blas_kernels.h's INT4 GEMM entry points were renamed from openvino_gemm_cl/openvino_sgemm_cl/openvino_gemm_async_cl to gemm_int4_cl/sgemm_int4_cl/gemm_int4_async_cl ("Standardize Naming Conventions"), but unittest_opencl_kernels_int4.cpp was never updated and still calls the old (now nonexistent) symbols at 9 call sites, so the TU fails with "use of undeclared identifier".

2. Both unittest_opencl_kernels_int4.cpp and unittest_opencl_kernels_qk_k.cpp use a bare `Q4_0` as the Q4_0 block-size constant (`K % Q4_0`, `K * N / Q4_0`). No header defines a plain `Q4_0` in scope here: the only declaration reachable is the scoped enumerator `QScheme::Q4_0` in quantizer.h, which does not leak unqualified. The intended constant is `QK4_0` (= 32), a plain #define already reachable via the q4_0_utils.h include both files already carry.

Both fixes are straight identifier substitutions with no signature or behavior changes: 9 call sites renamed in unittest_opencl_kernels_int4.cpp (cross-checked against blas_kernels.h's current declarations), plus 3 occurrences (6 tokens) of Q4_0 -> QK4_0 in that same file and 1 occurrence in unittest_opencl_kernels_qk_k.cpp.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>