### PR TITLE
[causallm] Warn when a prompt is silently truncated to fit the prefil…

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -441,8 +441,20 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   unsigned int num_allow_str = MAX_SEQ_LEN - NUM_TO_GENERATE;
   unsigned int text_len = _len;
 
-  if (_len > num_allow_str)
+  if (_len > num_allow_str) {
     text_len = num_allow_str;
+    // Truncation drops tokens from the tail of the prompt, which is where
+    // instructions in "summarize this document"-style prompts live: a
+    // silently truncated prompt can make the model continue the body
+    // instead of following a dropped trailing instruction. Always warn
+    // with the exact counts.
+    std::cerr << "[CausalLM] WARNING: prompt (" << _len
+              << " tokens) exceeds the max allowed prefill length ("
+              << num_allow_str
+              << " = max_seq_len - num_to_generate); "
+                 "truncating "
+              << (_len - num_allow_str) << " tail tokens." << std::endl;
+  }
 
   // feed only available length
   // if _input is allowed, it feeds all of the _input


### PR DESCRIPTION

CausalLM::run() clamps the tokenized prompt to num_allow_str (MAX_SEQ_LEN - NUM_TO_GENERATE) tokens with no diagnostic when the prompt is longer. Because the excess tokens are dropped from the END of the prompt, any trailing instruction (e.g. "... Now summarize the above.") can be cut entirely, and the model then continues the body instead of following the instruction — with nothing in the output or logs to explain why.

Warn to stderr whenever this clamp actually fires, printing the input token count, the allowed length, and the number of tail tokens dropped. This is a pure diagnostic: the clamp behavior and generated tokens are unchanged; a prompt within num_allow_str prints nothing extra.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
