### PR TITLE
[build] Make DeepQ jsoncpp/libcurl dependencies optional

### DIFF
--- a/Applications/ReinforcementLearning/DeepQ/jni/meson.build
+++ b/Applications/ReinforcementLearning/DeepQ/jni/meson.build
@@ -6,8 +6,20 @@ run_command(['cp', '-lr', res_path, nntr_deepq_resdir], check: true)
 
 env_dir='../../Environment'
 
-jsoncpp_dep = dependency('jsoncpp')
-libcurl_dep = dependency('libcurl')
+# DeepQ is the only Application that pulls in jsoncpp + libcurl. Make
+# those optional so a host without the dev packages can still build the
+# rest of the tree (libnntrainer, CausalLM, nntr_quantize). If either
+# dep is missing we skip the DeepQ executable build entirely; the
+# remaining Applications are unaffected.
+jsoncpp_dep = dependency('jsoncpp', required: false)
+libcurl_dep = dependency('libcurl', required: false)
+
+if not jsoncpp_dep.found() or not libcurl_dep.found()
+  warning('Applications/ReinforcementLearning/DeepQ: jsoncpp or libcurl ' +
+          'not found, skipping DeepQ build. Install libjsoncpp-dev / ' +
+          'libcurl4-openssl-dev to enable.')
+  subdir_done()
+endif
 
 deepq_sources = [
   'main.cpp',


### PR DESCRIPTION
Applications/ReinforcementLearning/DeepQ/jni/meson.build resolves jsoncpp and libcurl via dependency(...) with the default required: true. Since enable-app defaults to true and Applications/meson.build unconditionally subdirs into ReinforcementLearning/DeepQ/jni, any host missing libjsoncpp-dev or libcurl4-openssl-dev fails meson configure for the entire project, even when the user only wants libnntrainer, CausalLM, or nntr_quantize built.

Mark both dependencies required: false and skip the DeepQ executable target (via subdir_done()) with a warning naming the required apt packages when either is missing. No behavior change when both dependencies are present.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
