### PR TITLE
[nntrainer] Add the QS4CX-FP16 model tensor type (int4 weight, fp16 act)

### DIFF
--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -203,13 +203,15 @@ struct ModelTensorDataTypeInfo {
     WQ40A32,
     WQ40A16,
     WQS4CXA32,
+    WQS4CXA16,
   };
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::W3A32,   Enum::W4A16,    Enum::W4A32,    Enum::W8A16,
-    Enum::W8A32,   Enum::W16A16,   Enum::W16A32,   Enum::W32A16,
-    Enum::W32A32,  Enum::WQ16AQ16, Enum::WU16AU16, Enum::W8AU16,
-    Enum::WU4AU8,  Enum::WU4AU16,  Enum::WU8AU8,   Enum::WU8AU16,
-    Enum::WQ4KA32, Enum::WQ40A32,  Enum::WQ40A16,  Enum::WQS4CXA32,
+    Enum::W3A32,     Enum::W4A16,    Enum::W4A32,    Enum::W8A16,
+    Enum::W8A32,     Enum::W16A16,   Enum::W16A32,   Enum::W32A16,
+    Enum::W32A32,    Enum::WQ16AQ16, Enum::WU16AU16, Enum::W8AU16,
+    Enum::WU4AU8,    Enum::WU4AU16,  Enum::WU8AU8,   Enum::WU8AU16,
+    Enum::WQ4KA32,   Enum::WQ40A32,  Enum::WQ40A16,  Enum::WQS4CXA32,
+    Enum::WQS4CXA16,
   };
 
   static constexpr const char *EnumStr[] = {
@@ -217,7 +219,8 @@ struct ModelTensorDataTypeInfo {
     "QINT8-FP32",  "FP16-FP16",     "FP16-FP32",     "FP32-FP16",
     "FP32-FP32",   "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16",
     "UINT4-UINT8", "UINT4-UINT16",  "UINT8-UINT8",   "UINT8-UINT16",
-    "Q4_K-FP32",   "Q4_0-FP32",     "Q4_0-FP16",     "QS4CX-FP32"};
+    "Q4_K-FP32",   "Q4_0-FP32",     "Q4_0-FP16",     "QS4CX-FP32",
+    "QS4CX-FP16"};
 };
 
 /**


### PR DESCRIPTION
Upstream already supports the QS4CX weight type with an fp32 activation (WQS4CXA32 / "QS4CX-FP32"). This adds the fp16-activation sibling — WQS4CXA16 / "QS4CX-FP16" — to the ModelTensorDataTypeInfo enum, its EnumList, and EnumStr, so a model whose config declares a per-channel int4 weight with fp16 activations parses at load instead of failing with "No matching enum for value: QS4CX-FP16".

The enum is indexed (EnumList/EnumStr run in parallel with the enum values), so this is purely additive; no dtype-mapping switch changes (the same as the existing QS4CX-FP32 entry, which no code path switches on by name).

Repro:
  meson setup build -Denable-transformer=true -Denable-fp16=true \
    -Denable-opencl=true --buildtype=plain
  ninja -C build


Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>