### PR TITLE
[utils] ThreadManager::Global(): out-of-line singleton (per-DLL insta…

### DIFF
--- a/nntrainer/utils/thread_manager.cpp
+++ b/nntrainer/utils/thread_manager.cpp
@@ -40,6 +40,13 @@ ThreadManagerConfig ThreadManager::config_ = {};
 
 ThreadManager::ThreadManager() {}
 
+ThreadManager &ThreadManager::Global() {
+  // Out-of-line on purpose — single process-wide instance (see header note).
+  static ThreadManager instance;
+  instance.initializeOnce();
+  return instance;
+}
+
 ThreadManager::~ThreadManager() {
 #if defined(__linux__) || defined(__ANDROID__)
   active_threads_.store(compute_workers_.size(), std::memory_order_relaxed);

--- a/nntrainer/utils/thread_manager.h
+++ b/nntrainer/utils/thread_manager.h
@@ -12,7 +12,7 @@
  * @bug    No known bugs except for NYI items
  */
 
-/*
+/**
 Copyright 2019 Google LLC
 Copyright (c) 2017 Facebook Inc.
 Copyright (c) 2015-2017 Georgia Institute of Technology
@@ -80,6 +80,9 @@ namespace nntrainer {
 #error "Platform-specific implementation of CACHELINE_ALIGNED required"
 #endif
 
+/**
+ * @brief Configuration for ThreadManager: compute threads and affinity settings
+ */
 struct ThreadManagerConfig {
   uint32_t compute_threads = defaultComputeThreads();
   bool enable_affinity = true;
@@ -108,6 +111,9 @@ private:
   }
 };
 
+/**
+ * @brief Per-thread range information for parallel work distribution
+ */
 struct CACHELINE_ALIGNED thread_info {
   CACHELINE_ALIGNED std::atomic<size_t> range_start;
   CACHELINE_ALIGNED std::atomic<size_t> range_end;
@@ -142,6 +148,14 @@ class ThreadManager : public Singleton<ThreadManager> {
 public:
   ThreadManager();
   ~ThreadManager();
+
+  /**
+   * @brief Get the process-wide instance (out-of-line override of
+   *        Singleton<T>::Global() — one worker pool per process under shared
+   *        linking; see opencl::ContextManager::Global() for the full
+   *        static-vs-shared note).
+   */
+  static ThreadManager &Global();
 
   /**
    * @brief parallize loop for given function


### PR DESCRIPTION
Move the ThreadManager::Global() accessor out of line: declare it in the header and define the function-local static in thread_manager.cpp instead of inheriting the inline Singleton<T>::Global() template body.

On MSVC, an inline/header Global() is instantiated once per DLL, so a shared-linked build ends up with a separate worker pool per module. Defining Global() out of line pins it to a single translation unit and yields one process-wide instance. This mirrors the same fix already shipped for the OpenCL context/buffer/command-queue managers and compute_ops getComputeOps.

Behavior is identical on Linux/Android (still one function-local static instance); this only changes where the singleton is emitted.

Depends-on: (none -- independent, off b3a5face2)

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>

