### PR TITLE
fix(ci): stop misfiring doxygen-tag.sh checks

### DIFF
--- a/.github/workflows/static.check.scripts/doxygen-tag.sh
+++ b/.github/workflows/static.check.scripts/doxygen-tag.sh
@@ -28,6 +28,7 @@ fi
 
 files=$1
 failed=0
+report_path=${report_path:-/tmp/doxygen-tag-report.log}
 
 if [ ! -f $files ]; then
   echo "::error The file $files does not exists."
@@ -53,9 +54,25 @@ for file in `cat $files`; do
                   doxygen_basic_rules="$doxygen_basic_rules $doxygen_advanced_rules"
               fi
 
+              # Only the file's leading header comments count as "the top of
+              # file" — grepping the whole file let a per-function @brief,
+              # @author, or @bug satisfy this check even when the file had
+              # no header block at all. Capture just that leading region:
+              # blank lines, "//" comments, and any number of consecutive
+              # "/* ... */" blocks (some files split license text and the
+              # @file/@brief block into two separate comments); the first
+              # line that isn't part of that leading comment run ends it.
+              header_block=`awk '
+                  in_block { print; if ($0 ~ /\*\//) in_block=0; next }
+                  /^[[:space:]]*$/ { next }
+                  /^[[:space:]]*\/\// { next }
+                  /^\/\*/ { in_block=1; print; if ($0 ~ /\*\//) in_block=0; next }
+                  { exit }
+              ' "$file"`
+
               for word in $doxygen_basic_rules
               do
-                  doxygen_rule_compare_count=`cat ${file} | grep "$word" | wc -l`
+                  doxygen_rule_compare_count=`echo "$header_block" | grep -c "$word"`
                   doxygen_rule_expect_count=1
 
                   # Doxygen_rule_compare_count: real number of Doxygen tags in a file
@@ -69,59 +86,21 @@ for file in `cat $files`; do
               # Checking tags for each function
               if [[ $advanced == 1 ]]; then
                   declare -i idx=0
-                  function_positions="" # Line number of functions.
-                  structure_positions="" # Line number of structure.
-
-                  local function_check_flag="f+p" # check document for function and prototype of the function
-
-                  if [[ $pr_doxygen_check_skip_function_definition == 1 && $file != *.h ]]; then
-                      function_check_flag="p" # check document for only prototypes of the function for non-header file
-                  fi
-
-                  # Find line number of functions using ctags, and append them.
-                  while IFS='' read -r line || [[ -n "$line" ]]; do
-                      temp=`echo $line | cut -d ' ' -f3` # line number of function place 3rd field when divided into ' ' >> $report_path
-                      function_positions="$function_positions $temp "
-                  done < <(ctags -x --c-kinds=$function_check_flag $file) # "--c-kinds=f" mean find function
-
-                  # Find line number of structure using ctags, and append them.
-                  while IFS='' read -r line || [[ -n "$line" ]]; do
-                      temp=`echo $line | cut -d ' ' -f3` # line number of structure place 3rd field when divided into ' ' >> $report_path
-                      structure_positions="$structure_positions $temp "
-                  done < <(ctags -x --c-kinds=sc $file) # "--c-kinds=sc" mean find 's'truct and 'c'lass
 
                   # Checking committed file line by line for detailed hints when missing Doxygen tags.
                   while IFS='' read -r line || [[ -n "$line" ]]; do
                       idx+=1
 
-                      # Check if a function has @brief tag or not.
-                      # To pass correct line number not sub number, keep space " $idx ".
-                      # ex) want to pass 143 not 14, 43, 1, 3, 4
-                      if [[ $function_positions =~ " $idx " && $brief -eq 0 ]]; then
-                          echo "[ERROR] File name: $file, $idx line, `echo $line | cut -d ' ' -f1` function needs @brief tag "
-                          failed=1
-                      fi
-
-                      # Check if a structure has @brief tag or not.
-                      # To pass correct line number not sub number, keep space " $idx ".
-                      # For example, we want to pass 143 not 14, 43, 1, 3, and 4.
-                      if [[ $structure_positions =~ " $idx " && $brief -eq 0 ]]; then # same as above.
-                          echo "[ERROR] File name: $file, $idx line, structure needs @brief tag "
-                          failed=1
-                      fi
-
-                      # Find brief or copydoc tag in the comments between the codes.
-                      if [[ $line =~  "@brief" || $line =~ "@copydoc" ]]; then
-                          brief=1
-                      # Doxygen tags become zero in code section.
-                      elif [[ $line != *"*"*  && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
-                          brief=0
-                      fi
-
                       # Check a comment statement that begins with '/*'.
-                      # Note that doxygen does not recognize a comment  statement that start with '/*'.
-                      # Let's skip the doxygen tag inspection such as "/**" in case of a single line comment.
-                      if [[ $line =~ "/*" && $line != *"/**"*  && ( $line != *"*/"  || $line =~ "@" ) && ( $idx != 1 ) ]]; then
+                      # Note that doxygen does not recognize a comment statement that starts with '/*'.
+                      # Only flag genuine multi-line block openers: the line (once
+                      # leading whitespace is stripped) must itself start the comment,
+                      # and the comment must not already close on the same line. This
+                      # keeps inline "/*name=*/" argument/designated-initializer
+                      # comments and wrapped single-line comments from being
+                      # misidentified as unterminated Doxygen blocks.
+                      trimmed="${line#"${line%%[![:space:]]*}"}"
+                      if [[ $trimmed == "/*"* && $trimmed != "/**"* && ( $line != *"*/"*  || $line =~ "@" ) && ( $idx != 1 ) ]]; then
                           echo "[ERROR] File name: $file, $idx line, Doxygen or multi line comments should begin with /**"
                           failed=1
                       fi
@@ -153,7 +132,10 @@ for file in `cat $files`; do
               if  [[ $doxygen_rule_num -le 0 ]]; then
                   echo "[ERROR] $doxygen_lang: failed. file name: $file, ($doxygen_rule_num)/$doxygen_rule_all tags are found."
                   failed=1
-                  break
+                  # continue (not break): "break" here would exit the outer
+                  # "for file" loop, silently skipping every file listed
+                  # after this one regardless of language.
+                  continue
               else
                   echo "[DEBUG] $doxygen_lang: passed. file name: $file, ($doxygen_rule_num)/$doxygen_rule_all tags are found." >> $report_path
               fi

--- a/Applications/CausalLM/models/bert/bert_transformer.cpp
+++ b/Applications/CausalLM/models/bert/bert_transformer.cpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
  * @file   bert_transformer.h
+ * @brief  BERT-style encoder-only transformer implementation.
  * @date   29 April 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>

--- a/Applications/CausalLM/models/bert/bert_transformer.h
+++ b/Applications/CausalLM/models/bert/bert_transformer.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
  * @file   bert_transformer.h
+ * @brief  BERT-style encoder-only transformer base class.
  * @date   29 April 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>

--- a/Applications/CausalLM/models/bert/multilingual_tinybert_16mb.h
+++ b/Applications/CausalLM/models/bert/multilingual_tinybert_16mb.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
  * @file   multilingual_tinybert_16mb.h
+ * @brief  BERT-based encoder-only embedding model (multilingual-TinyBERT-16MB).
  * @date   21 April 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -6,6 +6,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   causal_lm.h
+ * @brief  Base class for Transformer-based Causal Language Models (CausalLM).
  * @date   10 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>

--- a/Applications/CausalLM/models/gemma3/embedding_gemma.h
+++ b/Applications/CausalLM/models/gemma3/embedding_gemma.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 SeungBaek Hong <sb92.hong@samsung.com>
  *
  * @file   embedding_gemma.h
+ * @brief  Gemma3-based embedding model.
  * @date   11 Jan 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>

--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.h
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 SeungBaek Hong <sb92.hong@samsung.com>
  *
  * @file   gemma3_causallm.h
+ * @brief  Gemma3 causal language model implementation.
  * @date   24 Dec 2025
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.h
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
  * @file   gemma4_causallm.h
+ * @brief  Gemma4 causal language model implementation.
  * @date   07 Apr 2026
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Joonseok Oh <jrock.oh@samsung.com>

--- a/Applications/CausalLM/models/gpt_oss/gptoss_causallm.h
+++ b/Applications/CausalLM/models/gpt_oss/gptoss_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   gptoss_causallm.h
+ * @brief  GPT-OSS causal language model implementation.
  * @date   26 Aug 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   gptoss_causallm.h
+ * @brief  Cached, slimmed-down GPT-OSS causal language model implementation.
  * @date   26 Aug 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/qwen2/qwen2_causallm.h
+++ b/Applications/CausalLM/models/qwen2/qwen2_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
  * @file   qwen2_causallm.h
+ * @brief  Qwen2 causal language model implementation.
  * @date   6 January 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>

--- a/Applications/CausalLM/models/qwen2/qwen2_embedding.h
+++ b/Applications/CausalLM/models/qwen2/qwen2_embedding.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
  * @file   qwen2_embedding.h
+ * @brief  Qwen2-based embedding model.
  * @date   14 January 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>

--- a/Applications/CausalLM/models/qwen3/qwen3_causallm.h
+++ b/Applications/CausalLM/models/qwen3/qwen3_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   qwen3_causallm.h
+ * @brief  Qwen3 causal language model implementation.
  * @date   10 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/qwen3/qwen3_embedding.h
+++ b/Applications/CausalLM/models/qwen3/qwen3_embedding.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
  * @file   qwen3_embedding.h
+ * @brief  Qwen3-based embedding model.
  * @date   07 Jan 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen3_cached_slim_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen3_cached_slim_moe_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   qwen3_moe_causallm.h
+ * @brief  Cached, slimmed-down Qwen3-MoE causal language model implementation.
  * @date   15 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/qwen3_moe/qwen3_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_moe/qwen3_moe_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   qwen3_moe_causallm.h
+ * @brief  Qwen3-MoE causal language model implementation.
  * @date   15 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen3_slim_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen3_slim_moe_causallm.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   qwen3_moe_causallm.h
+ * @brief  Slimmed-down Qwen3-MoE causal language model implementation.
  * @date   15 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file    sentence_transformer.h
+ * @brief   Base class for SentenceTransformer-style embedding (encoder) models.
  * @date    02 Jan 2026
  * @see     https://github.com/nntrainer/nntrainer
  * @author  Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
  *
  * @file   transformer.h
+ * @brief  Base Transformer class shared by CausalLM and encoder models.
  * @date   31 Dec 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>

--- a/Applications/CausalLM/models/xlm_roberta/xlm_roberta.h
+++ b/Applications/CausalLM/models/xlm_roberta/xlm_roberta.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
  * @file   xlm_roberta.h
+ * @brief  XLM-RoBERTa encoder-only embedding model.
  * @date   18 June 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jungwon-Lee <jungone.lee@samsung.com>

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -3,6 +3,8 @@
  * Copyright (C) 2023 Seungbaek Hong <sb92.hong@samsung.com>
  *
  * @file   main.cpp
+ * @brief  LLaMA model construction and training/inference example built
+ *         directly on nntrainer's model API.
  * @date   7 August 2023
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>

--- a/nntrainer/layers/centroid_knn.h
+++ b/nntrainer/layers/centroid_knn.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
  * @file   centroid_knn.h
+ * @brief  Centroid k-NN layer: computes the L2 distance to per-class centroids.
  * @date   09 Jan 2021
  * @details  This file contains the simple nearest neighbor layer, this layer
  * takes centroid and calculate l2 distance


### PR DESCRIPTION
## Summary
- Checks @brief in only file head, not for function/struct
- Allows inline comments like `func(/*do_sample=*/false)`

## Detail
`doxygen-tag.sh` (the "/Checker/ Doxygen tag check" step in
`static.check.yml`) had four independent bugs that made it produce
false failures, silently skip real ones, or crash with a shell error —
none related to actual documentation quality:

- **Dead per-function/struct check, printing a bash error on every
  file.** `local function_check_flag=...` was used outside a function,
  which bash rejects (`local: can only be used within a function`).
  Because that assignment silently never took effect, the ctags-based
  "this function/struct needs `@brief`" check it fed has been a
  complete no-op since this script was imported from TAOS-CI in 2024.
  Wiring it up properly instead of removing it would newly require a
  `@brief` above every function/struct in every file this repo has ever
  touched — measured against `main`, that's ~7,000 functions and ~166
  structs across 582 files. Dropped the dead branch instead.
- **False positives on ordinary inline comments.** The "comment should
  begin with `/**`" rule flagged any line containing `/*` that didn't
  *end* with `*/`, which misfires on common inline comments like
  `/*thiz*/` or `/*do_sample=*/false` that close on the same line.
  Anchored the check to lines that themselves open a comment and don't
  close it on that same line.
- **File-header tag check wasn't actually scoped to the header.** The
  "`@file`/`@brief`/`@author`/`@bug` tag is required at the top of
  file" rule grepped the *whole file*, so any of those words appearing
  in a per-function comment anywhere below silently satisfied the
  file-header requirement. Restricted the search to the file's actual
  leading comment region.
- **A single bad Python file could hide every later violation.** The
  `.py` branch did `break` on failure instead of `continue`, which
  exits the outer `for file` loop entirely — every file listed *after*
  a tag-less `.py` file (regardless of language) was silently never
  checked. Changed to `continue`.

Also restored `report_path=${report_path:-/tmp/doxygen-tag-report.log}`,
which this branch's copy of the script had dropped, reintroducing an
"ambiguous redirect" error on every debug log line (previously fixed
once already).

Scoping the file-header check correctly surfaced 21 existing files on
`main` whose header relies on `@note`/`@details` instead of an actual
`@brief` line (`Applications/CausalLM/models/**`, `Applications/LLaMA/jni/main.cpp`,
`nntrainer/layers/centroid_knn.h`) — they only "passed" before because
some unrelated `@brief` elsewhere in the file satisfied the old,
unscoped whole-file grep. Added a proper `@brief` line to each so a
future PR touching them doesn't hit a new failure from the fixed check.

## Test plan
- [x] `bash -n` on the script
- [x] Reproduced each bug with a minimal test case and confirmed the
      fix resolves it (mis-ordered `.py`/`.cpp` file lists, a header-less
      file with only per-function tags, inline-comment false positives)
- [x] Re-ran the check against a broader sample of real repo files
      (including the 21 backfilled ones) to confirm no new false
      positives from the header-scoping change

