### PR TITLE
[kleidiai] Add `matmul_clamp_f16_qai8dxp_qsi4cxp`

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.c
@@ -1,0 +1,193 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.c
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD) &&                \
+  !defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && !defined(_M_ARM64)
+#error                                                                         \
+  "Dotprod extension and fp16 vector arithmetic required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+typedef struct {
+  void *dst;
+  const void *lhs_packed;
+  const void *rhs_packed;
+  const float *clamp_vals;
+  size_t dst_stride_row;
+  size_t m;
+  size_t n;
+  size_t num_blocks;
+} KernelArgs;
+
+void kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  KernelArgs *args_ptr);
+
+// Compute args
+static const size_t kai_m_step = 1;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 1;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 8;
+static const size_t kai_sr = 2;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_recip_qvalue_rhs = 2;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 2;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+static const size_t kai_bl = 32;
+
+inline static size_t kai_get_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_get_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_get_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t rhs_packed_stride =
+    kai_nr * (k_internal / kai_num_bytes_recip_qvalue_rhs);
+
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_get_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_get_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  void *restrict dst,              // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(uint16_t));
+  if (m == 0) {
+    return;
+  }
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t num_blocks = k_internal / kai_bl;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  KernelArgs args;
+
+  args.dst = dst;
+  args.lhs_packed = lhs_packed;
+  args.rhs_packed = rhs_packed;
+  args.clamp_vals = clamp_vals;
+  args.dst_stride_row = dst_stride_row;
+  args.m = m;
+  args.n = n;
+  args.num_blocks = num_blocks;
+
+  kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(&args);
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h
@@ -1,0 +1,166 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f16_neon to dynamically quantize and pack
+/// the LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0 to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be 1.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 4-bit with per-channel
+/// quantization (qsi4cx) values.
+///
+/// @param[in] n_idx Col index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be 1.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple of
+/// n_step.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed. RHS matrix: Quantized Symmetric Signed 4-bit with
+/// per-channel quantization (qsi4cx) and packed. Output tile: (rows x cols) =
+/// m_step x n_step.
+///
+/// Note: Please refer to the get functions for m_step and n_step for the exact
+/// values.
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written. It must be 1.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(uint16_t) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  void *dst,              //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod_asm.S
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod_asm.S
@@ -1,0 +1,146 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if defined(_MSC_VER)
+    #define KAI_ASM_GLOBAL(name) GLOBAL name
+    #define KAI_ASM_FUNCTION_TYPE(name)
+    #define KAI_ASM_FUNCTION_LABEL(name) name PROC
+    #define KAI_ASM_FUNCTION_END(name) ENDP
+
+    #define KAI_ASM_CODE(name) AREA name, CODE, READONLY
+    #define KAI_ASM_ALIGN
+    #define KAI_ASM_LABEL(name) name
+    #define KAI_ASM_INST(hex) DCD hex
+    #define KAI_ASM_END END
+#else
+    #if defined(__APPLE__)
+        #define KAI_ASM_GLOBAL(name) .globl _##name
+        #define KAI_ASM_FUNCTION_TYPE(name)
+        #define KAI_ASM_FUNCTION_LABEL(name) _##name:
+        #define KAI_ASM_FUNCTION_END(name)
+    #else
+        #define KAI_ASM_GLOBAL(name) .global name
+        #define KAI_ASM_FUNCTION_TYPE(name) .type name, %function
+        #define KAI_ASM_FUNCTION_LABEL(name) name:
+        #define KAI_ASM_FUNCTION_END(name) .size name, .-name
+    #endif
+
+    #define KAI_ASM_CODE(name) .text
+    #define KAI_ASM_ALIGN .p2align 4,,11
+    #define KAI_ASM_LABEL(name) name:
+    #define KAI_ASM_INST(hex) .inst hex
+    #define KAI_ASM_END
+#endif
+
+    KAI_ASM_CODE(matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod)
+    KAI_ASM_ALIGN
+
+    KAI_ASM_GLOBAL(kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod)
+
+KAI_ASM_FUNCTION_TYPE(kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod)
+KAI_ASM_FUNCTION_LABEL(kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod)
+    stp x20, x21, [sp, -80]!
+    stp x22, x23, [sp, 16]
+    stp x24, x25, [sp, 32]
+    stp x26, x27, [sp, 48]
+    str x28, [sp, 64]
+    mov x13, #0x20
+    movi v27.16b, #0xf0
+    mov x21, #0x8
+    ldr x12, [x0, #0x38]
+    ldr x20, [x0, #0x28]
+    ldr x11, [x0, #0x8]
+    ldr x10, [x0, #0x10]
+    ldr x9, [x0, #0x30]
+    ldr x28, [x0, #0x0]
+    ldr x27, [x0, #0x20]
+    madd x13, x12, x13, x21
+    ldr x26, [x0, #0x18]
+    mov x25, x20
+KAI_ASM_LABEL(label_1)  // Row loop
+    mov x24, x10
+    mov x23, x9
+    add x22, x28, x27
+KAI_ASM_LABEL(label_2)  // Column loop
+    mov x21, x11
+    movi v26.4s, #0x0
+    mov x20, x12
+KAI_ASM_LABEL(label_3)  // Sub block loop
+    ldr q25, [x24, #0x0]
+    ldr q24, [x21, #0x0]
+    subs x20, x20, #0x1
+    ldr q23, [x24, #0x10]
+    ldr q22, [x24, #0x20]
+    ldr q21, [x24, #0x30]
+    ldr q20, [x21, #0x10]
+    add x24, x24, #0x40
+    add x21, x21, #0x20
+    shl v19.16b, v25.16b, #0x4
+    and v25.16b, v25.16b, v27.16b
+    shl v18.16b, v23.16b, #0x4
+    shl v17.16b, v22.16b, #0x4
+    shl v16.16b, v21.16b, #0x4
+    and v23.16b, v23.16b, v27.16b
+    KAI_ASM_INST(0x4f98e27a)  // sdot v26.4s, v19.16b, v24.4b[0]
+    and v22.16b, v22.16b, v27.16b
+    and v21.16b, v21.16b, v27.16b
+    KAI_ASM_INST(0x4fb8e25a)  // sdot v26.4s, v18.16b, v24.4b[1]
+    KAI_ASM_INST(0x4f98ea3a)  // sdot v26.4s, v17.16b, v24.4b[2]
+    KAI_ASM_INST(0x4fb8ea1a)  // sdot v26.4s, v16.16b, v24.4b[3]
+    KAI_ASM_INST(0x4f94e33a)  // sdot v26.4s, v25.16b, v20.4b[0]
+    KAI_ASM_INST(0x4fb4e2fa)  // sdot v26.4s, v23.16b, v20.4b[1]
+    KAI_ASM_INST(0x4f94eada)  // sdot v26.4s, v22.16b, v20.4b[2]
+    KAI_ASM_INST(0x4fb4eaba)  // sdot v26.4s, v21.16b, v20.4b[3]
+    bgt label_3
+    ldr q22, [x24, #0x0]
+    ld1r { v21.4s }, [x21]
+    add x21, x21, #0x4
+    add x20, x26, #0x4
+    ld1r { v20.4s }, [x21]
+    ldr q16, [x24, #0x10]
+    cmp x23, #0x4
+    ldr q19, [x24, #0x20]
+    ld1r { v18.4s }, [x26]
+    add x24, x24, #0x30
+    ld1r { v17.4s }, [x20]
+    mla v26.4s, v22.4s, v21.s[0]
+    fmul v16.4s, v16.4s, v20.4s
+    scvtf v26.4s, v26.4s
+    fmul v16.4s, v26.4s, v16.4s
+    fadd v16.4s, v16.4s, v19.4s
+    fmax v16.4s, v16.4s, v18.4s
+    fmin v16.4s, v16.4s, v17.4s
+    fcvtn v16.4h, v16.4s
+    blt label_4
+    str d16, [x28, #0x0]
+    b label_7
+KAI_ASM_LABEL(label_4)  // Partial output
+    mov x20, x28
+    tbz x23, #1, label_5
+    st1 { v16.s }[0], [x20], #0x4
+    tbz x23, #0, label_6
+    st1 { v16.h }[2], [x20]
+    b label_6
+KAI_ASM_LABEL(label_5)  // Output block 0: partial_1_0
+    st1 { v16.h }[0], [x20]
+KAI_ASM_LABEL(label_6)  // Output block 0: Done
+KAI_ASM_LABEL(label_7)  // Stores done
+    subs x23, x23, #0x4
+    add x28, x28, #0x8
+    bgt label_2
+    subs x25, x25, #0x1
+    add x11, x11, x13
+    mov x28, x22
+    bgt label_1
+    ldp x22, x23, [sp, 16]
+    ldp x24, x25, [sp, 32]
+    ldp x26, x27, [sp, 48]
+    ldr x28, [sp, 64]
+    ldp x20, x21, [sp], 80
+    ret
+    KAI_ASM_FUNCTION_END(kai_kernel_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod)
+
+    KAI_ASM_END

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.c
@@ -1,0 +1,193 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.c
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD) &&                \
+  !defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && !defined(_M_ARM64)
+#error                                                                         \
+  "Dotprod extension and fp16 vector arithmetic required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+typedef struct {
+  uint16_t *dst;
+  const void *lhs_packed;
+  const void *rhs_packed;
+  const float *clamp_vals;
+  size_t dst_stride_row;
+  size_t m;
+  size_t n;
+  size_t num_blocks;
+} KernelArgs;
+
+void kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  KernelArgs *args_ptr);
+
+// Compute args
+static const size_t kai_m_step = 1;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 1;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 16;
+static const size_t kai_sr = 2;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_recip_qvalue_rhs = 2;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 2;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+static const size_t kai_bl = 32;
+
+inline static size_t kai_get_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_get_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_get_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t rhs_packed_stride =
+    kai_nr * (k_internal / kai_num_bytes_recip_qvalue_rhs);
+
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_get_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_get_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  void *restrict dst,              // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(uint16_t));
+  if (m == 0) {
+    return;
+  }
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t num_blocks = k_internal / kai_bl;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  KernelArgs args;
+
+  args.dst = dst;
+  args.lhs_packed = lhs_packed;
+  args.rhs_packed = rhs_packed;
+  args.clamp_vals = clamp_vals;
+  args.dst_stride_row = dst_stride_row;
+  args.m = m;
+  args.n = n;
+  args.num_blocks = num_blocks;
+
+  kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(&args);
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h
@@ -1,0 +1,166 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f16_neon to dynamically quantize and pack
+/// the LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0 to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be 1.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 4-bit with per-channel
+/// quantization (qsi4cx) values.
+///
+/// @param[in] n_idx Col index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be 1.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple of
+/// n_step.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed. RHS matrix: Quantized Symmetric Signed 4-bit with
+/// per-channel quantization (qsi4cx) and packed. Output tile: (rows x cols) =
+/// m_step x n_step.
+///
+/// Note: Please refer to the get functions for m_step and n_step for the exact
+/// values.
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written. It must be 1.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(uint16_t) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  void *dst,              //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod_asm.S
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod_asm.S
@@ -1,0 +1,149 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if defined(_MSC_VER)
+    #define KAI_ASM_GLOBAL(name) GLOBAL name
+    #define KAI_ASM_FUNCTION_TYPE(name)
+    #define KAI_ASM_FUNCTION_LABEL(name) name PROC
+    #define KAI_ASM_FUNCTION_END(name) ENDP
+
+    #define KAI_ASM_CODE(name) AREA name, CODE, READONLY
+    #define KAI_ASM_ALIGN
+    #define KAI_ASM_LABEL(name) name
+    #define KAI_ASM_INST(hex) DCD hex
+    #define KAI_ASM_END END
+#else
+    #if defined(__APPLE__)
+        #define KAI_ASM_GLOBAL(name) .globl _##name
+        #define KAI_ASM_FUNCTION_TYPE(name)
+        #define KAI_ASM_FUNCTION_LABEL(name) _##name:
+        #define KAI_ASM_FUNCTION_END(name)
+    #else
+        #define KAI_ASM_GLOBAL(name) .global name
+        #define KAI_ASM_FUNCTION_TYPE(name) .type name, %function
+        #define KAI_ASM_FUNCTION_LABEL(name) name:
+        #define KAI_ASM_FUNCTION_END(name) .size name, .-name
+    #endif
+
+    #define KAI_ASM_CODE(name) .text
+    #define KAI_ASM_ALIGN .p2align 4,,11
+    #define KAI_ASM_LABEL(name) name:
+    #define KAI_ASM_INST(hex) .inst hex
+    #define KAI_ASM_END
+#endif
+
+    KAI_ASM_CODE(matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod)
+    KAI_ASM_ALIGN
+
+    KAI_ASM_GLOBAL(kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod)
+
+KAI_ASM_FUNCTION_TYPE(kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod)
+KAI_ASM_FUNCTION_LABEL(kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod)
+    stp x20, x21, [sp, -80]!
+    stp x22, x23, [sp, 16]
+    stp x24, x25, [sp, 32]
+    stp x26, x27, [sp, 48]
+    str x28, [sp, 64]
+    mov x13, #0x20
+    movi v30.16b, #0xf0
+    mov x21, #0x8
+    ldr x12, [x0, #0x38]
+    ldr x20, [x0, #0x28]
+    ldr x11, [x0, #0x8]
+    ldr x10, [x0, #0x10]
+    ldr x9, [x0, #0x30]
+    ldr x28, [x0, #0x0]
+    ldr x27, [x0, #0x20]
+    madd x13, x12, x13, x21
+    ldr x26, [x0, #0x18]
+    mov x25, x20
+KAI_ASM_LABEL(label_1)  // Row loop
+    mov x24, x10
+    mov x23, x9
+    add x22, x28, x27
+KAI_ASM_LABEL(label_2)  // Column loop
+    mov x21, x11
+    movi v29.4s, #0x0
+    movi v28.4s, #0x0
+    mov x20, x12
+KAI_ASM_LABEL(label_3)  // Sub block loop
+    ldr q27, [x24, #0x0]
+    ldr q26, [x24, #0x10]
+    subs x20, x20, #0x1
+    ld1r { v25.2d }, [x21], #0x8
+    ldr q24, [x24, #0x20]
+    ldr q23, [x24, #0x30]
+    add x24, x24, #0x40
+    ld1r { v22.2d }, [x21], #0x8
+    ld1r { v21.2d }, [x21], #0x8
+    shl v20.16b, v27.16b, #0x4
+    shl v19.16b, v26.16b, #0x4
+    ld1r { v18.2d }, [x21], #0x8
+    shl v17.16b, v24.16b, #0x4
+    and v27.16b, v27.16b, v30.16b
+    shl v16.16b, v23.16b, #0x4
+    and v26.16b, v26.16b, v30.16b
+    KAI_ASM_INST(0x4e99969d)  // sdot v29.4s, v20.16b, v25.16b
+    KAI_ASM_INST(0x4e99967c)  // sdot v28.4s, v19.16b, v25.16b
+    and v24.16b, v24.16b, v30.16b
+    and v23.16b, v23.16b, v30.16b
+    KAI_ASM_INST(0x4e96963d)  // sdot v29.4s, v17.16b, v22.16b
+    KAI_ASM_INST(0x4e96961c)  // sdot v28.4s, v16.16b, v22.16b
+    KAI_ASM_INST(0x4e95977d)  // sdot v29.4s, v27.16b, v21.16b
+    KAI_ASM_INST(0x4e95975c)  // sdot v28.4s, v26.16b, v21.16b
+    KAI_ASM_INST(0x4e92971d)  // sdot v29.4s, v24.16b, v18.16b
+    KAI_ASM_INST(0x4e9296fc)  // sdot v28.4s, v23.16b, v18.16b
+    bgt label_3
+    ldr q22, [x24, #0x0]
+    ld1r { v21.4s }, [x21]
+    addp v29.4s, v29.4s, v28.4s
+    add x21, x21, #0x4
+    ld1r { v20.4s }, [x21]
+    ldr q16, [x24, #0x10]
+    add x20, x26, #0x4
+    cmp x23, #0x4
+    ldr q19, [x24, #0x20]
+    ld1r { v18.4s }, [x26]
+    add x24, x24, #0x30
+    ld1r { v17.4s }, [x20]
+    mla v29.4s, v22.4s, v21.s[0]
+    fmul v16.4s, v16.4s, v20.4s
+    scvtf v29.4s, v29.4s
+    fmul v16.4s, v29.4s, v16.4s
+    fadd v16.4s, v16.4s, v19.4s
+    fmax v16.4s, v16.4s, v18.4s
+    fmin v16.4s, v16.4s, v17.4s
+    fcvtn v16.4h, v16.4s
+    blt label_4
+    str d16, [x28, #0x0]
+    b label_7
+KAI_ASM_LABEL(label_4)  // Partial output
+    mov x20, x28
+    tbz x23, #1, label_5
+    st1 { v16.s }[0], [x20], #0x4
+    tbz x23, #0, label_6
+    st1 { v16.h }[2], [x20]
+    b label_6
+KAI_ASM_LABEL(label_5)  // Output block 0: partial_1_0
+    st1 { v16.h }[0], [x20]
+KAI_ASM_LABEL(label_6)  // Output block 0: Done
+KAI_ASM_LABEL(label_7)  // Stores done
+    subs x23, x23, #0x4
+    add x28, x28, #0x8
+    bgt label_2
+    subs x25, x25, #0x1
+    add x11, x11, x13
+    mov x28, x22
+    bgt label_1
+    ldp x22, x23, [sp, 16]
+    ldp x24, x25, [sp, 32]
+    ldp x26, x27, [sp, 48]
+    ldr x28, [sp, 64]
+    ldp x20, x21, [sp], 80
+    ret
+    KAI_ASM_FUNCTION_END(kai_kernel_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod)
+
+    KAI_ASM_END

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.c
@@ -1,0 +1,194 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.c
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD) &&                \
+  !defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && !defined(_M_ARM64)
+#error                                                                         \
+  "Dotprod extension and fp16 vector arithmetic required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+typedef struct {
+  void *dst;
+  const void *lhs_packed;
+  const void *rhs_packed;
+  const float *clamp_vals;
+  size_t dst_stride_row;
+  size_t m;
+  size_t n;
+  size_t num_blocks;
+} KernelArgs;
+
+void kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  KernelArgs *args_ptr);
+
+// Compute args
+static const size_t kai_m_step = 16;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 4;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 8;
+static const size_t kai_sr = 2;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_recip_qvalue_rhs = 2;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 2;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+static const size_t kai_bl = 32;
+
+inline static size_t kai_get_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_get_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_get_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t rhs_packed_stride =
+    kai_nr * (k_internal / kai_num_bytes_recip_qvalue_rhs);
+
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_get_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_get_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t
+kai_get_dst_size_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  void *restrict dst,              // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(uint16_t));
+  if (m == 0) {
+    return;
+  }
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t num_blocks = k_internal / kai_bl;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  KernelArgs args;
+
+  args.dst = dst;
+  args.lhs_packed = lhs_packed;
+  args.rhs_packed = rhs_packed;
+  args.clamp_vals = clamp_vals;
+  args.dst_stride_row = dst_stride_row;
+  args.m = m;
+  args.n = n;
+  args.num_blocks = num_blocks;
+
+  kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(&args);
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h
@@ -1,0 +1,173 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f16_neon to dynamically quantize and pack
+/// the LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0 to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t
+kai_get_mr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t
+kai_get_nr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t
+kai_get_kr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t
+kai_get_sr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be a
+/// multiple of m_step.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 4-bit with per-channel
+/// quantization (qsi4cx) values.
+///
+/// @param[in] n_idx Col index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be a multiple of
+/// m_step.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple of
+/// n_step.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t
+kai_get_dst_size_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed. RHS matrix: Quantized Symmetric Signed 4-bit with
+/// per-channel quantization (qsi4cx) and packed. Output tile: (rows x cols) =
+/// m_step x n_step.
+///
+/// Note: Please refer to the get functions for m_step and n_step for the exact
+/// values.
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(uint16_t) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  void *dst,              //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod_asm.S
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod_asm.S
@@ -1,0 +1,723 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if defined(_MSC_VER)
+    #define KAI_ASM_GLOBAL(name) GLOBAL name
+    #define KAI_ASM_FUNCTION_TYPE(name)
+    #define KAI_ASM_FUNCTION_LABEL(name) name PROC
+    #define KAI_ASM_FUNCTION_END(name) ENDP
+
+    #define KAI_ASM_CODE(name) AREA name, CODE, READONLY
+    #define KAI_ASM_ALIGN
+    #define KAI_ASM_LABEL(name) name
+    #define KAI_ASM_INST(hex) DCD hex
+    #define KAI_ASM_END END
+#else
+    #if defined(__APPLE__)
+        #define KAI_ASM_GLOBAL(name) .globl _##name
+        #define KAI_ASM_FUNCTION_TYPE(name)
+        #define KAI_ASM_FUNCTION_LABEL(name) _##name:
+        #define KAI_ASM_FUNCTION_END(name)
+    #else
+        #define KAI_ASM_GLOBAL(name) .global name
+        #define KAI_ASM_FUNCTION_TYPE(name) .type name, %function
+        #define KAI_ASM_FUNCTION_LABEL(name) name:
+        #define KAI_ASM_FUNCTION_END(name) .size name, .-name
+    #endif
+
+    #define KAI_ASM_CODE(name) .text
+    #define KAI_ASM_ALIGN .p2align 4,,11
+    #define KAI_ASM_LABEL(name) name:
+    #define KAI_ASM_INST(hex) .inst hex
+    #define KAI_ASM_END
+#endif
+
+    KAI_ASM_CODE(matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod)
+    KAI_ASM_ALIGN
+
+    KAI_ASM_GLOBAL(kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod)
+
+KAI_ASM_FUNCTION_TYPE(kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod)
+KAI_ASM_FUNCTION_LABEL(kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod)
+    stp x20, x21, [sp, -144]!
+    stp x22, x23, [sp, 16]
+    stp x24, x25, [sp, 32]
+    stp x26, x27, [sp, 48]
+    str x28, [sp, 64]
+    stp d10, d11, [sp, 72]
+    stp d12, d13, [sp, 88]
+    stp d14, d15, [sp, 104]
+    stp d8, d9, [sp, 120]
+    mov x6, #0x80
+    mov x21, #0x20
+    ldr x20, [x0, #0x28]
+    ldr x7, [x0, #0x38]
+    ldr x8, [x0, #0x8]
+    ldr x17, [x0, #0x10]
+    ldr x16, [x0, #0x30]
+    ldr x15, [x0, #0x0]
+    mov x14, x20
+    ldr x13, [x0, #0x20]
+    madd x6, x7, x6, x21
+    ldr x12, [x0, #0x18]
+    cmp x14, #0x10
+    blt label_14
+KAI_ASM_LABEL(label_1)  // Row loop
+    mov x11, x17
+    mov x10, x16
+    add x9, x15, x13, LSL #4
+KAI_ASM_LABEL(label_2)  // Column loop
+    mov x27, x8
+    movi v31.4s, #0x0
+    movi v30.4s, #0x0
+    mov x23, x7
+    movi v29.4s, #0x0
+    movi v28.4s, #0x0
+    movi v27.4s, #0x0
+    movi v26.4s, #0x0
+    add x22, x27, x6
+    add x21, x22, x6
+    add x20, x21, x6
+    movi v25.4s, #0x0
+    movi v24.4s, #0x0
+    movi v23.4s, #0x0
+    movi v22.4s, #0x0
+    movi v21.4s, #0x0
+    movi v20.4s, #0x0
+    movi v19.4s, #0x0
+    movi v18.4s, #0x0
+    movi v17.4s, #0x0
+    movi v16.4s, #0x0
+KAI_ASM_LABEL(label_3)  // Sub block loop
+    ldr q11, [x11, #0x0]
+    ldr q8, [x27, #0x0]
+    movi v6.16b, #0xf0
+    subs x23, x23, #0x1
+    ldr q1, [x22, #0x0]
+    ldr q15, [x21, #0x0]
+    ldr q3, [x20, #0x0]
+    ldr q13, [x11, #0x10]
+    ldr q10, [x27, #0x10]
+    ldr q7, [x22, #0x10]
+    shl v9.16b, v11.16b, #0x4
+    and v11.16b, v11.16b, v6.16b
+    ldr q4, [x21, #0x10]
+    ldr q0, [x20, #0x10]
+    ldr q5, [x11, #0x20]
+    ldr q2, [x27, #0x20]
+    shl v12.16b, v13.16b, #0x4
+    and v13.16b, v13.16b, v6.16b
+    ldr q14, [x22, #0x20]
+    KAI_ASM_INST(0x4f88e13f)  // sdot v31.4s, v9.16b, v8.4b[0]
+    KAI_ASM_INST(0x4fa8e13e)  // sdot v30.4s, v9.16b, v8.4b[1]
+    KAI_ASM_INST(0x4f88e93d)  // sdot v29.4s, v9.16b, v8.4b[2]
+    KAI_ASM_INST(0x4fa8e93c)  // sdot v28.4s, v9.16b, v8.4b[3]
+    ldr q8, [x21, #0x20]
+    KAI_ASM_INST(0x4f81e13b)  // sdot v27.4s, v9.16b, v1.4b[0]
+    KAI_ASM_INST(0x4fa1e13a)  // sdot v26.4s, v9.16b, v1.4b[1]
+    KAI_ASM_INST(0x4f81e939)  // sdot v25.4s, v9.16b, v1.4b[2]
+    KAI_ASM_INST(0x4fa1e938)  // sdot v24.4s, v9.16b, v1.4b[3]
+    ldr q1, [x20, #0x20]
+    KAI_ASM_INST(0x4f8fe137)  // sdot v23.4s, v9.16b, v15.4b[0]
+    KAI_ASM_INST(0x4fafe136)  // sdot v22.4s, v9.16b, v15.4b[1]
+    KAI_ASM_INST(0x4f8fe935)  // sdot v21.4s, v9.16b, v15.4b[2]
+    KAI_ASM_INST(0x4fafe934)  // sdot v20.4s, v9.16b, v15.4b[3]
+    ldr q15, [x11, #0x30]
+    add x11, x11, #0x40
+    KAI_ASM_INST(0x4f83e133)  // sdot v19.4s, v9.16b, v3.4b[0]
+    KAI_ASM_INST(0x4fa3e132)  // sdot v18.4s, v9.16b, v3.4b[1]
+    KAI_ASM_INST(0x4f83e931)  // sdot v17.4s, v9.16b, v3.4b[2]
+    KAI_ASM_INST(0x4fa3e930)  // sdot v16.4s, v9.16b, v3.4b[3]
+    ldr q3, [x27, #0x30]
+    ldr q9, [x22, #0x30]
+    KAI_ASM_INST(0x4f8ae19f)  // sdot v31.4s, v12.16b, v10.4b[0]
+    KAI_ASM_INST(0x4faae19e)  // sdot v30.4s, v12.16b, v10.4b[1]
+    KAI_ASM_INST(0x4f8ae99d)  // sdot v29.4s, v12.16b, v10.4b[2]
+    KAI_ASM_INST(0x4faae99c)  // sdot v28.4s, v12.16b, v10.4b[3]
+    ldr q10, [x21, #0x30]
+    KAI_ASM_INST(0x4f87e19b)  // sdot v27.4s, v12.16b, v7.4b[0]
+    KAI_ASM_INST(0x4fa7e19a)  // sdot v26.4s, v12.16b, v7.4b[1]
+    KAI_ASM_INST(0x4f87e999)  // sdot v25.4s, v12.16b, v7.4b[2]
+    KAI_ASM_INST(0x4fa7e998)  // sdot v24.4s, v12.16b, v7.4b[3]
+    ldr q7, [x20, #0x30]
+    KAI_ASM_INST(0x4f84e197)  // sdot v23.4s, v12.16b, v4.4b[0]
+    KAI_ASM_INST(0x4fa4e196)  // sdot v22.4s, v12.16b, v4.4b[1]
+    KAI_ASM_INST(0x4f84e995)  // sdot v21.4s, v12.16b, v4.4b[2]
+    KAI_ASM_INST(0x4fa4e994)  // sdot v20.4s, v12.16b, v4.4b[3]
+    ldr q4, [x27, #0x40]
+    KAI_ASM_INST(0x4f80e193)  // sdot v19.4s, v12.16b, v0.4b[0]
+    KAI_ASM_INST(0x4fa0e192)  // sdot v18.4s, v12.16b, v0.4b[1]
+    KAI_ASM_INST(0x4f80e991)  // sdot v17.4s, v12.16b, v0.4b[2]
+    KAI_ASM_INST(0x4fa0e990)  // sdot v16.4s, v12.16b, v0.4b[3]
+    ldr q0, [x22, #0x40]
+    shl v12.16b, v5.16b, #0x4
+    and v5.16b, v5.16b, v6.16b
+    KAI_ASM_INST(0x4f82e19f)  // sdot v31.4s, v12.16b, v2.4b[0]
+    KAI_ASM_INST(0x4fa2e19e)  // sdot v30.4s, v12.16b, v2.4b[1]
+    KAI_ASM_INST(0x4f82e99d)  // sdot v29.4s, v12.16b, v2.4b[2]
+    KAI_ASM_INST(0x4fa2e99c)  // sdot v28.4s, v12.16b, v2.4b[3]
+    ldr q2, [x21, #0x40]
+    KAI_ASM_INST(0x4f8ee19b)  // sdot v27.4s, v12.16b, v14.4b[0]
+    KAI_ASM_INST(0x4faee19a)  // sdot v26.4s, v12.16b, v14.4b[1]
+    KAI_ASM_INST(0x4f8ee999)  // sdot v25.4s, v12.16b, v14.4b[2]
+    KAI_ASM_INST(0x4faee998)  // sdot v24.4s, v12.16b, v14.4b[3]
+    ldr q14, [x20, #0x40]
+    KAI_ASM_INST(0x4f88e197)  // sdot v23.4s, v12.16b, v8.4b[0]
+    KAI_ASM_INST(0x4fa8e196)  // sdot v22.4s, v12.16b, v8.4b[1]
+    KAI_ASM_INST(0x4f88e995)  // sdot v21.4s, v12.16b, v8.4b[2]
+    KAI_ASM_INST(0x4fa8e994)  // sdot v20.4s, v12.16b, v8.4b[3]
+    ldr q8, [x27, #0x50]
+    KAI_ASM_INST(0x4f81e193)  // sdot v19.4s, v12.16b, v1.4b[0]
+    KAI_ASM_INST(0x4fa1e192)  // sdot v18.4s, v12.16b, v1.4b[1]
+    KAI_ASM_INST(0x4f81e991)  // sdot v17.4s, v12.16b, v1.4b[2]
+    KAI_ASM_INST(0x4fa1e990)  // sdot v16.4s, v12.16b, v1.4b[3]
+    ldr q12, [x22, #0x50]
+    shl v1.16b, v15.16b, #0x4
+    and v15.16b, v15.16b, v6.16b
+    ldr q6, [x21, #0x50]
+    KAI_ASM_INST(0x4f83e03f)  // sdot v31.4s, v1.16b, v3.4b[0]
+    KAI_ASM_INST(0x4fa3e03e)  // sdot v30.4s, v1.16b, v3.4b[1]
+    KAI_ASM_INST(0x4f83e83d)  // sdot v29.4s, v1.16b, v3.4b[2]
+    KAI_ASM_INST(0x4fa3e83c)  // sdot v28.4s, v1.16b, v3.4b[3]
+    ldr q3, [x20, #0x50]
+    KAI_ASM_INST(0x4f89e03b)  // sdot v27.4s, v1.16b, v9.4b[0]
+    KAI_ASM_INST(0x4fa9e03a)  // sdot v26.4s, v1.16b, v9.4b[1]
+    KAI_ASM_INST(0x4f89e839)  // sdot v25.4s, v1.16b, v9.4b[2]
+    KAI_ASM_INST(0x4fa9e838)  // sdot v24.4s, v1.16b, v9.4b[3]
+    ldr q9, [x27, #0x60]
+    KAI_ASM_INST(0x4f8ae037)  // sdot v23.4s, v1.16b, v10.4b[0]
+    KAI_ASM_INST(0x4faae036)  // sdot v22.4s, v1.16b, v10.4b[1]
+    KAI_ASM_INST(0x4f8ae835)  // sdot v21.4s, v1.16b, v10.4b[2]
+    KAI_ASM_INST(0x4faae834)  // sdot v20.4s, v1.16b, v10.4b[3]
+    ldr q10, [x22, #0x60]
+    KAI_ASM_INST(0x4f87e033)  // sdot v19.4s, v1.16b, v7.4b[0]
+    KAI_ASM_INST(0x4fa7e032)  // sdot v18.4s, v1.16b, v7.4b[1]
+    KAI_ASM_INST(0x4f87e831)  // sdot v17.4s, v1.16b, v7.4b[2]
+    KAI_ASM_INST(0x4fa7e830)  // sdot v16.4s, v1.16b, v7.4b[3]
+    ldr q7, [x21, #0x60]
+    ldr q1, [x20, #0x60]
+    KAI_ASM_INST(0x4f84e17f)  // sdot v31.4s, v11.16b, v4.4b[0]
+    KAI_ASM_INST(0x4fa4e17e)  // sdot v30.4s, v11.16b, v4.4b[1]
+    KAI_ASM_INST(0x4f84e97d)  // sdot v29.4s, v11.16b, v4.4b[2]
+    KAI_ASM_INST(0x4fa4e97c)  // sdot v28.4s, v11.16b, v4.4b[3]
+    ldr q4, [x27, #0x70]
+    add x27, x27, #0x80
+    KAI_ASM_INST(0x4f80e17b)  // sdot v27.4s, v11.16b, v0.4b[0]
+    KAI_ASM_INST(0x4fa0e17a)  // sdot v26.4s, v11.16b, v0.4b[1]
+    KAI_ASM_INST(0x4f80e979)  // sdot v25.4s, v11.16b, v0.4b[2]
+    KAI_ASM_INST(0x4fa0e978)  // sdot v24.4s, v11.16b, v0.4b[3]
+    ldr q0, [x22, #0x70]
+    add x22, x22, #0x80
+    KAI_ASM_INST(0x4f82e177)  // sdot v23.4s, v11.16b, v2.4b[0]
+    KAI_ASM_INST(0x4fa2e176)  // sdot v22.4s, v11.16b, v2.4b[1]
+    KAI_ASM_INST(0x4f82e975)  // sdot v21.4s, v11.16b, v2.4b[2]
+    KAI_ASM_INST(0x4fa2e974)  // sdot v20.4s, v11.16b, v2.4b[3]
+    ldr q2, [x21, #0x70]
+    add x21, x21, #0x80
+    KAI_ASM_INST(0x4f8ee173)  // sdot v19.4s, v11.16b, v14.4b[0]
+    KAI_ASM_INST(0x4faee172)  // sdot v18.4s, v11.16b, v14.4b[1]
+    KAI_ASM_INST(0x4f8ee971)  // sdot v17.4s, v11.16b, v14.4b[2]
+    KAI_ASM_INST(0x4faee970)  // sdot v16.4s, v11.16b, v14.4b[3]
+    ldr q11, [x20, #0x70]
+    add x20, x20, #0x80
+    KAI_ASM_INST(0x4f88e1bf)  // sdot v31.4s, v13.16b, v8.4b[0]
+    KAI_ASM_INST(0x4fa8e1be)  // sdot v30.4s, v13.16b, v8.4b[1]
+    KAI_ASM_INST(0x4f88e9bd)  // sdot v29.4s, v13.16b, v8.4b[2]
+    KAI_ASM_INST(0x4fa8e9bc)  // sdot v28.4s, v13.16b, v8.4b[3]
+    KAI_ASM_INST(0x4f8ce1bb)  // sdot v27.4s, v13.16b, v12.4b[0]
+    KAI_ASM_INST(0x4face1ba)  // sdot v26.4s, v13.16b, v12.4b[1]
+    KAI_ASM_INST(0x4f8ce9b9)  // sdot v25.4s, v13.16b, v12.4b[2]
+    KAI_ASM_INST(0x4face9b8)  // sdot v24.4s, v13.16b, v12.4b[3]
+    KAI_ASM_INST(0x4f86e1b7)  // sdot v23.4s, v13.16b, v6.4b[0]
+    KAI_ASM_INST(0x4fa6e1b6)  // sdot v22.4s, v13.16b, v6.4b[1]
+    KAI_ASM_INST(0x4f86e9b5)  // sdot v21.4s, v13.16b, v6.4b[2]
+    KAI_ASM_INST(0x4fa6e9b4)  // sdot v20.4s, v13.16b, v6.4b[3]
+    KAI_ASM_INST(0x4f83e1b3)  // sdot v19.4s, v13.16b, v3.4b[0]
+    KAI_ASM_INST(0x4fa3e1b2)  // sdot v18.4s, v13.16b, v3.4b[1]
+    KAI_ASM_INST(0x4f83e9b1)  // sdot v17.4s, v13.16b, v3.4b[2]
+    KAI_ASM_INST(0x4fa3e9b0)  // sdot v16.4s, v13.16b, v3.4b[3]
+    KAI_ASM_INST(0x4f89e0bf)  // sdot v31.4s, v5.16b, v9.4b[0]
+    KAI_ASM_INST(0x4fa9e0be)  // sdot v30.4s, v5.16b, v9.4b[1]
+    KAI_ASM_INST(0x4f89e8bd)  // sdot v29.4s, v5.16b, v9.4b[2]
+    KAI_ASM_INST(0x4fa9e8bc)  // sdot v28.4s, v5.16b, v9.4b[3]
+    KAI_ASM_INST(0x4f8ae0bb)  // sdot v27.4s, v5.16b, v10.4b[0]
+    KAI_ASM_INST(0x4faae0ba)  // sdot v26.4s, v5.16b, v10.4b[1]
+    KAI_ASM_INST(0x4f8ae8b9)  // sdot v25.4s, v5.16b, v10.4b[2]
+    KAI_ASM_INST(0x4faae8b8)  // sdot v24.4s, v5.16b, v10.4b[3]
+    KAI_ASM_INST(0x4f87e0b7)  // sdot v23.4s, v5.16b, v7.4b[0]
+    KAI_ASM_INST(0x4fa7e0b6)  // sdot v22.4s, v5.16b, v7.4b[1]
+    KAI_ASM_INST(0x4f87e8b5)  // sdot v21.4s, v5.16b, v7.4b[2]
+    KAI_ASM_INST(0x4fa7e8b4)  // sdot v20.4s, v5.16b, v7.4b[3]
+    KAI_ASM_INST(0x4f81e0b3)  // sdot v19.4s, v5.16b, v1.4b[0]
+    KAI_ASM_INST(0x4fa1e0b2)  // sdot v18.4s, v5.16b, v1.4b[1]
+    KAI_ASM_INST(0x4f81e8b1)  // sdot v17.4s, v5.16b, v1.4b[2]
+    KAI_ASM_INST(0x4fa1e8b0)  // sdot v16.4s, v5.16b, v1.4b[3]
+    KAI_ASM_INST(0x4f84e1ff)  // sdot v31.4s, v15.16b, v4.4b[0]
+    KAI_ASM_INST(0x4fa4e1fe)  // sdot v30.4s, v15.16b, v4.4b[1]
+    KAI_ASM_INST(0x4f84e9fd)  // sdot v29.4s, v15.16b, v4.4b[2]
+    KAI_ASM_INST(0x4fa4e9fc)  // sdot v28.4s, v15.16b, v4.4b[3]
+    KAI_ASM_INST(0x4f80e1fb)  // sdot v27.4s, v15.16b, v0.4b[0]
+    KAI_ASM_INST(0x4fa0e1fa)  // sdot v26.4s, v15.16b, v0.4b[1]
+    KAI_ASM_INST(0x4f80e9f9)  // sdot v25.4s, v15.16b, v0.4b[2]
+    KAI_ASM_INST(0x4fa0e9f8)  // sdot v24.4s, v15.16b, v0.4b[3]
+    KAI_ASM_INST(0x4f82e1f7)  // sdot v23.4s, v15.16b, v2.4b[0]
+    KAI_ASM_INST(0x4fa2e1f6)  // sdot v22.4s, v15.16b, v2.4b[1]
+    KAI_ASM_INST(0x4f82e9f5)  // sdot v21.4s, v15.16b, v2.4b[2]
+    KAI_ASM_INST(0x4fa2e9f4)  // sdot v20.4s, v15.16b, v2.4b[3]
+    KAI_ASM_INST(0x4f8be1f3)  // sdot v19.4s, v15.16b, v11.4b[0]
+    KAI_ASM_INST(0x4fabe1f2)  // sdot v18.4s, v15.16b, v11.4b[1]
+    KAI_ASM_INST(0x4f8be9f1)  // sdot v17.4s, v15.16b, v11.4b[2]
+    KAI_ASM_INST(0x4fabe9f0)  // sdot v16.4s, v15.16b, v11.4b[3]
+    bgt label_3
+    ldr q5, [x11, #0x0]
+    ld1 { v1.4s }, [x27]
+    add x27, x27, #0x10
+    ldr q4, [x11, #0x10]
+    ldr q0, [x27, #0x0]
+    add x11, x11, #0x20
+    mla v31.4s, v5.4s, v1.s[0]
+    mla v30.4s, v5.4s, v1.s[1]
+    mla v29.4s, v5.4s, v1.s[2]
+    mla v28.4s, v5.4s, v1.s[3]
+    fmul v3.4s, v4.4s, v0.s[0]
+    fmul v2.4s, v4.4s, v0.s[1]
+    fmul v1.4s, v4.4s, v0.s[2]
+    scvtf v31.4s, v31.4s
+    fmul v0.4s, v4.4s, v0.s[3]
+    scvtf v30.4s, v30.4s
+    scvtf v29.4s, v29.4s
+    scvtf v28.4s, v28.4s
+    fmul v31.4s, v31.4s, v3.4s
+    fmul v30.4s, v30.4s, v2.4s
+    fmul v29.4s, v29.4s, v1.4s
+    fmul v28.4s, v28.4s, v0.4s
+    ld1 { v1.4s }, [x22]
+    add x22, x22, #0x10
+    ldr q0, [x22, #0x0]
+    mla v27.4s, v5.4s, v1.s[0]
+    mla v26.4s, v5.4s, v1.s[1]
+    mla v25.4s, v5.4s, v1.s[2]
+    mla v24.4s, v5.4s, v1.s[3]
+    fmul v3.4s, v4.4s, v0.s[0]
+    fmul v2.4s, v4.4s, v0.s[1]
+    fmul v1.4s, v4.4s, v0.s[2]
+    scvtf v27.4s, v27.4s
+    fmul v0.4s, v4.4s, v0.s[3]
+    scvtf v26.4s, v26.4s
+    scvtf v25.4s, v25.4s
+    scvtf v24.4s, v24.4s
+    fmul v27.4s, v27.4s, v3.4s
+    fmul v26.4s, v26.4s, v2.4s
+    fmul v25.4s, v25.4s, v1.4s
+    fmul v24.4s, v24.4s, v0.4s
+    ld1 { v1.4s }, [x21]
+    add x21, x21, #0x10
+    ldr q0, [x21, #0x0]
+    mla v23.4s, v5.4s, v1.s[0]
+    mla v22.4s, v5.4s, v1.s[1]
+    mla v21.4s, v5.4s, v1.s[2]
+    mla v20.4s, v5.4s, v1.s[3]
+    fmul v3.4s, v4.4s, v0.s[0]
+    fmul v2.4s, v4.4s, v0.s[1]
+    fmul v1.4s, v4.4s, v0.s[2]
+    scvtf v23.4s, v23.4s
+    fmul v0.4s, v4.4s, v0.s[3]
+    scvtf v22.4s, v22.4s
+    scvtf v21.4s, v21.4s
+    scvtf v20.4s, v20.4s
+    fmul v23.4s, v23.4s, v3.4s
+    fmul v22.4s, v22.4s, v2.4s
+    fmul v21.4s, v21.4s, v1.4s
+    fmul v20.4s, v20.4s, v0.4s
+    ld1 { v1.4s }, [x20]
+    add x20, x20, #0x10
+    ldr q0, [x20, #0x0]
+    mla v19.4s, v5.4s, v1.s[0]
+    mla v18.4s, v5.4s, v1.s[1]
+    mla v17.4s, v5.4s, v1.s[2]
+    mla v16.4s, v5.4s, v1.s[3]
+    fmul v3.4s, v4.4s, v0.s[0]
+    fmul v2.4s, v4.4s, v0.s[1]
+    fmul v1.4s, v4.4s, v0.s[2]
+    scvtf v19.4s, v19.4s
+    fmul v0.4s, v4.4s, v0.s[3]
+    scvtf v18.4s, v18.4s
+    scvtf v17.4s, v17.4s
+    scvtf v16.4s, v16.4s
+    fmul v19.4s, v19.4s, v3.4s
+    fmul v18.4s, v18.4s, v2.4s
+    fmul v17.4s, v17.4s, v1.4s
+    fmul v16.4s, v16.4s, v0.4s
+    ldr q2, [x11, #0x0]
+    ld1r { v1.4s }, [x12]
+    add x20, x12, #0x4
+    cmp x10, #0x4
+    ld1r { v0.4s }, [x20]
+    add x11, x11, #0x10
+    fadd v31.4s, v31.4s, v2.4s
+    fadd v30.4s, v30.4s, v2.4s
+    fadd v29.4s, v29.4s, v2.4s
+    fadd v28.4s, v28.4s, v2.4s
+    fadd v27.4s, v27.4s, v2.4s
+    fadd v26.4s, v26.4s, v2.4s
+    fadd v25.4s, v25.4s, v2.4s
+    fadd v24.4s, v24.4s, v2.4s
+    fadd v23.4s, v23.4s, v2.4s
+    fadd v22.4s, v22.4s, v2.4s
+    fadd v21.4s, v21.4s, v2.4s
+    fadd v20.4s, v20.4s, v2.4s
+    fadd v19.4s, v19.4s, v2.4s
+    fadd v18.4s, v18.4s, v2.4s
+    fadd v17.4s, v17.4s, v2.4s
+    fadd v16.4s, v16.4s, v2.4s
+    fmax v31.4s, v31.4s, v1.4s
+    fmax v30.4s, v30.4s, v1.4s
+    fmax v29.4s, v29.4s, v1.4s
+    fmax v28.4s, v28.4s, v1.4s
+    fmax v27.4s, v27.4s, v1.4s
+    fmax v26.4s, v26.4s, v1.4s
+    fmax v25.4s, v25.4s, v1.4s
+    fmax v24.4s, v24.4s, v1.4s
+    fmax v23.4s, v23.4s, v1.4s
+    fmax v22.4s, v22.4s, v1.4s
+    fmax v21.4s, v21.4s, v1.4s
+    fmax v20.4s, v20.4s, v1.4s
+    fmax v19.4s, v19.4s, v1.4s
+    fmax v18.4s, v18.4s, v1.4s
+    fmax v17.4s, v17.4s, v1.4s
+    fmax v16.4s, v16.4s, v1.4s
+    fmin v31.4s, v31.4s, v0.4s
+    fmin v30.4s, v30.4s, v0.4s
+    fmin v29.4s, v29.4s, v0.4s
+    fmin v28.4s, v28.4s, v0.4s
+    fmin v27.4s, v27.4s, v0.4s
+    fmin v26.4s, v26.4s, v0.4s
+    fmin v25.4s, v25.4s, v0.4s
+    fmin v24.4s, v24.4s, v0.4s
+    fmin v23.4s, v23.4s, v0.4s
+    fmin v22.4s, v22.4s, v0.4s
+    fmin v21.4s, v21.4s, v0.4s
+    fmin v20.4s, v20.4s, v0.4s
+    fmin v19.4s, v19.4s, v0.4s
+    fmin v18.4s, v18.4s, v0.4s
+    fmin v17.4s, v17.4s, v0.4s
+    fmin v16.4s, v16.4s, v0.4s
+    fcvtn v31.4h, v31.4s
+    fcvtn v30.4h, v30.4s
+    fcvtn v29.4h, v29.4s
+    fcvtn v28.4h, v28.4s
+    fcvtn v27.4h, v27.4s
+    fcvtn v26.4h, v26.4s
+    fcvtn v25.4h, v25.4s
+    fcvtn v24.4h, v24.4s
+    fcvtn v23.4h, v23.4s
+    fcvtn v22.4h, v22.4s
+    fcvtn v21.4h, v21.4s
+    fcvtn v20.4h, v20.4s
+    fcvtn v19.4h, v19.4s
+    fcvtn v18.4h, v18.4s
+    fcvtn v17.4h, v17.4s
+    fcvtn v16.4h, v16.4s
+    blt label_8
+    mov x20, x15
+    str d31, [x20, #0x0]
+    add x20, x20, x13
+    str d30, [x20, #0x0]
+    add x20, x20, x13
+    str d29, [x20, #0x0]
+    add x20, x20, x13
+    str d28, [x20, #0x0]
+    add x20, x20, x13
+    str d27, [x20, #0x0]
+    add x20, x20, x13
+    str d26, [x20, #0x0]
+    add x20, x20, x13
+    str d25, [x20, #0x0]
+    add x20, x20, x13
+    str d24, [x20, #0x0]
+    add x20, x20, x13
+    str d23, [x20, #0x0]
+    add x20, x20, x13
+    str d22, [x20, #0x0]
+    add x20, x20, x13
+    str d21, [x20, #0x0]
+    add x20, x20, x13
+    str d20, [x20, #0x0]
+    add x20, x20, x13
+    str d19, [x20, #0x0]
+    add x20, x20, x13
+    str d18, [x20, #0x0]
+    add x20, x20, x13
+    str d17, [x20, #0x0]
+    add x20, x20, x13
+    str d16, [x20, #0x0]
+    b label_13
+KAI_ASM_LABEL(label_8)  // Partial output
+    mov x28, x15
+    add x26, x28, x13, LSL #2
+    add x25, x26, x13, LSL #1
+    add x24, x26, x13
+    add x23, x25, x13
+    add x22, x28, x13, LSL #1
+    add x21, x28, x13
+    add x20, x22, x13
+    add x27, x23, x13
+    tbz x10, #1, label_9
+    st1 { v24.s }[0], [x23], #0x4
+    st1 { v25.s }[0], [x25], #0x4
+    st1 { v26.s }[0], [x24], #0x4
+    st1 { v27.s }[0], [x26], #0x4
+    st1 { v28.s }[0], [x20], #0x4
+    st1 { v29.s }[0], [x22], #0x4
+    st1 { v30.s }[0], [x21], #0x4
+    st1 { v31.s }[0], [x28], #0x4
+    tbz x10, #0, label_10
+    st1 { v24.h }[2], [x23]
+    st1 { v25.h }[2], [x25]
+    st1 { v26.h }[2], [x24]
+    st1 { v27.h }[2], [x26]
+    st1 { v28.h }[2], [x20]
+    st1 { v29.h }[2], [x22]
+    st1 { v30.h }[2], [x21]
+    st1 { v31.h }[2], [x28]
+    b label_10
+KAI_ASM_LABEL(label_9)  // Output block 0: partial_1_0
+    st1 { v24.h }[0], [x23]
+    st1 { v25.h }[0], [x25]
+    st1 { v26.h }[0], [x24]
+    st1 { v27.h }[0], [x26]
+    st1 { v28.h }[0], [x20]
+    st1 { v29.h }[0], [x22]
+    st1 { v30.h }[0], [x21]
+    st1 { v31.h }[0], [x28]
+KAI_ASM_LABEL(label_10)  // Output block 0: Done
+    add x26, x27, x13, LSL #2
+    add x25, x27, x13, LSL #1
+    add x24, x26, x13, LSL #1
+    add x23, x27, x13
+    add x22, x25, x13
+    add x21, x26, x13
+    add x20, x24, x13
+    tbz x10, #1, label_11
+    st1 { v16.s }[0], [x20], #0x4
+    st1 { v17.s }[0], [x24], #0x4
+    st1 { v18.s }[0], [x21], #0x4
+    st1 { v19.s }[0], [x26], #0x4
+    st1 { v20.s }[0], [x22], #0x4
+    st1 { v21.s }[0], [x25], #0x4
+    st1 { v22.s }[0], [x23], #0x4
+    st1 { v23.s }[0], [x27], #0x4
+    tbz x10, #0, label_12
+    st1 { v16.h }[2], [x20]
+    st1 { v17.h }[2], [x24]
+    st1 { v18.h }[2], [x21]
+    st1 { v19.h }[2], [x26]
+    st1 { v20.h }[2], [x22]
+    st1 { v21.h }[2], [x25]
+    st1 { v22.h }[2], [x23]
+    st1 { v23.h }[2], [x27]
+    b label_12
+KAI_ASM_LABEL(label_11)  // Output block 1: partial_1_0
+    st1 { v16.h }[0], [x20]
+    st1 { v17.h }[0], [x24]
+    st1 { v18.h }[0], [x21]
+    st1 { v19.h }[0], [x26]
+    st1 { v20.h }[0], [x22]
+    st1 { v21.h }[0], [x25]
+    st1 { v22.h }[0], [x23]
+    st1 { v23.h }[0], [x27]
+KAI_ASM_LABEL(label_12)  // Output block 1: Done
+KAI_ASM_LABEL(label_13)  // Output stage exit
+    subs x10, x10, #0x4
+    add x15, x15, #0x8
+    bgt label_2
+    mov x20, #0x4
+    sub x14, x14, #0x10
+    cmp x14, #0x10
+    mov x15, x9
+    madd x8, x20, x6, x8
+    bge label_1
+KAI_ASM_LABEL(label_14)  // Row loop skip
+    cbz x14, label_23
+KAI_ASM_LABEL(label_15)  // Row tail: Row loop
+    mov x26, x17
+    mov x25, x16
+    add x24, x15, x13, LSL #2
+KAI_ASM_LABEL(label_16)  // Row tail: Column loop
+    mov x27, x8
+    movi v31.4s, #0x0
+    movi v30.4s, #0x0
+    mov x20, x7
+    movi v29.4s, #0x0
+    movi v28.4s, #0x0
+KAI_ASM_LABEL(label_17)  // Row tail: Sub block loop
+    ldr q4, [x26, #0x0]
+    ldr q3, [x27, #0x0]
+    movi v2.16b, #0xf0
+    subs x20, x20, #0x1
+    ldr q1, [x26, #0x10]
+    ldr q0, [x27, #0x10]
+    ldr q27, [x26, #0x20]
+    ldr q26, [x27, #0x20]
+    ldr q25, [x26, #0x30]
+    ldr q24, [x27, #0x30]
+    shl v23.16b, v4.16b, #0x4
+    and v4.16b, v4.16b, v2.16b
+    ldr q22, [x27, #0x40]
+    ldr q21, [x27, #0x50]
+    shl v20.16b, v1.16b, #0x4
+    and v1.16b, v1.16b, v2.16b
+    ldr q19, [x27, #0x60]
+    ldr q18, [x27, #0x70]
+    shl v17.16b, v27.16b, #0x4
+    and v27.16b, v27.16b, v2.16b
+    KAI_ASM_INST(0x4f83e2ff)  // sdot v31.4s, v23.16b, v3.4b[0]
+    KAI_ASM_INST(0x4fa3e2fe)  // sdot v30.4s, v23.16b, v3.4b[1]
+    shl v16.16b, v25.16b, #0x4
+    add x26, x26, #0x40
+    KAI_ASM_INST(0x4f83eafd)  // sdot v29.4s, v23.16b, v3.4b[2]
+    KAI_ASM_INST(0x4fa3eafc)  // sdot v28.4s, v23.16b, v3.4b[3]
+    and v25.16b, v25.16b, v2.16b
+    add x27, x27, #0x80
+    KAI_ASM_INST(0x4f80e29f)  // sdot v31.4s, v20.16b, v0.4b[0]
+    KAI_ASM_INST(0x4fa0e29e)  // sdot v30.4s, v20.16b, v0.4b[1]
+    KAI_ASM_INST(0x4f80ea9d)  // sdot v29.4s, v20.16b, v0.4b[2]
+    KAI_ASM_INST(0x4fa0ea9c)  // sdot v28.4s, v20.16b, v0.4b[3]
+    KAI_ASM_INST(0x4f9ae23f)  // sdot v31.4s, v17.16b, v26.4b[0]
+    KAI_ASM_INST(0x4fbae23e)  // sdot v30.4s, v17.16b, v26.4b[1]
+    KAI_ASM_INST(0x4f9aea3d)  // sdot v29.4s, v17.16b, v26.4b[2]
+    KAI_ASM_INST(0x4fbaea3c)  // sdot v28.4s, v17.16b, v26.4b[3]
+    KAI_ASM_INST(0x4f98e21f)  // sdot v31.4s, v16.16b, v24.4b[0]
+    KAI_ASM_INST(0x4fb8e21e)  // sdot v30.4s, v16.16b, v24.4b[1]
+    KAI_ASM_INST(0x4f98ea1d)  // sdot v29.4s, v16.16b, v24.4b[2]
+    KAI_ASM_INST(0x4fb8ea1c)  // sdot v28.4s, v16.16b, v24.4b[3]
+    KAI_ASM_INST(0x4f96e09f)  // sdot v31.4s, v4.16b, v22.4b[0]
+    KAI_ASM_INST(0x4fb6e09e)  // sdot v30.4s, v4.16b, v22.4b[1]
+    KAI_ASM_INST(0x4f96e89d)  // sdot v29.4s, v4.16b, v22.4b[2]
+    KAI_ASM_INST(0x4fb6e89c)  // sdot v28.4s, v4.16b, v22.4b[3]
+    KAI_ASM_INST(0x4f95e03f)  // sdot v31.4s, v1.16b, v21.4b[0]
+    KAI_ASM_INST(0x4fb5e03e)  // sdot v30.4s, v1.16b, v21.4b[1]
+    KAI_ASM_INST(0x4f95e83d)  // sdot v29.4s, v1.16b, v21.4b[2]
+    KAI_ASM_INST(0x4fb5e83c)  // sdot v28.4s, v1.16b, v21.4b[3]
+    KAI_ASM_INST(0x4f93e37f)  // sdot v31.4s, v27.16b, v19.4b[0]
+    KAI_ASM_INST(0x4fb3e37e)  // sdot v30.4s, v27.16b, v19.4b[1]
+    KAI_ASM_INST(0x4f93eb7d)  // sdot v29.4s, v27.16b, v19.4b[2]
+    KAI_ASM_INST(0x4fb3eb7c)  // sdot v28.4s, v27.16b, v19.4b[3]
+    KAI_ASM_INST(0x4f92e33f)  // sdot v31.4s, v25.16b, v18.4b[0]
+    KAI_ASM_INST(0x4fb2e33e)  // sdot v30.4s, v25.16b, v18.4b[1]
+    KAI_ASM_INST(0x4f92eb3d)  // sdot v29.4s, v25.16b, v18.4b[2]
+    KAI_ASM_INST(0x4fb2eb3c)  // sdot v28.4s, v25.16b, v18.4b[3]
+    bgt label_17
+    ldr q18, [x26, #0x0]
+    ld1 { v17.4s }, [x27]
+    add x27, x27, #0x10
+    ldr q20, [x26, #0x10]
+    ldr q16, [x27, #0x0]
+    add x26, x26, #0x20
+    mla v31.4s, v18.4s, v17.s[0]
+    mla v30.4s, v18.4s, v17.s[1]
+    mla v29.4s, v18.4s, v17.s[2]
+    mla v28.4s, v18.4s, v17.s[3]
+    fmul v19.4s, v20.4s, v16.s[0]
+    fmul v18.4s, v20.4s, v16.s[1]
+    fmul v17.4s, v20.4s, v16.s[2]
+    scvtf v31.4s, v31.4s
+    fmul v16.4s, v20.4s, v16.s[3]
+    scvtf v30.4s, v30.4s
+    scvtf v29.4s, v29.4s
+    scvtf v28.4s, v28.4s
+    fmul v31.4s, v31.4s, v19.4s
+    fmul v30.4s, v30.4s, v18.4s
+    fmul v29.4s, v29.4s, v17.4s
+    fmul v28.4s, v28.4s, v16.4s
+    ldr q18, [x26, #0x0]
+    ld1r { v17.4s }, [x12]
+    add x20, x12, #0x4
+    cmp x25, #0x4
+    ld1r { v16.4s }, [x20]
+    add x26, x26, #0x10
+    fadd v31.4s, v31.4s, v18.4s
+    fadd v30.4s, v30.4s, v18.4s
+    fadd v29.4s, v29.4s, v18.4s
+    fadd v28.4s, v28.4s, v18.4s
+    fmax v31.4s, v31.4s, v17.4s
+    fmax v30.4s, v30.4s, v17.4s
+    fmax v29.4s, v29.4s, v17.4s
+    fmax v28.4s, v28.4s, v17.4s
+    fmin v31.4s, v31.4s, v16.4s
+    fmin v30.4s, v30.4s, v16.4s
+    fmin v29.4s, v29.4s, v16.4s
+    fmin v28.4s, v28.4s, v16.4s
+    fcvtn v19.4h, v31.4s
+    fcvtn v18.4h, v30.4s
+    fcvtn v17.4h, v29.4s
+    fcvtn v16.4h, v28.4s
+    blt label_19
+    mov x20, x15
+    cmp x14, #0x1
+    str d19, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    cmp x14, #0x2
+    str d18, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    cmp x14, #0x3
+    str d17, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    str d16, [x20, #0x0]
+    b label_22
+KAI_ASM_LABEL(label_19)  // Row tail: Partial output
+    mov x23, x15
+    cmp x14, #0x1
+    add x22, x23, x13
+    csel x22, x22, x23, GT
+    cmp x14, #0x2
+    add x21, x23, x13, LSL #1
+    csel x21, x21, x22, GT
+    cmp x14, #0x3
+    add x20, x21, x13
+    csel x20, x20, x21, GT
+    tbz x25, #1, label_20
+    st1 { v16.s }[0], [x20], #0x4
+    st1 { v17.s }[0], [x21], #0x4
+    st1 { v18.s }[0], [x22], #0x4
+    st1 { v19.s }[0], [x23], #0x4
+    tbz x25, #0, label_21
+    st1 { v16.h }[2], [x20]
+    st1 { v17.h }[2], [x21]
+    st1 { v18.h }[2], [x22]
+    st1 { v19.h }[2], [x23]
+    b label_21
+KAI_ASM_LABEL(label_20)  // Row tail: Output block 0: partial_1_0
+    st1 { v16.h }[0], [x20]
+    st1 { v17.h }[0], [x21]
+    st1 { v18.h }[0], [x22]
+    st1 { v19.h }[0], [x23]
+KAI_ASM_LABEL(label_21)  // Row tail: Output block 0: Done
+KAI_ASM_LABEL(label_22)  // Row tail: Output stage exit
+    subs x25, x25, #0x4
+    add x15, x15, #0x8
+    bgt label_16
+    subs x14, x14, #0x4
+    add x8, x8, x6
+    mov x15, x24
+    bgt label_15
+KAI_ASM_LABEL(label_23)  // Row tail: Row loop skip
+    ldp x22, x23, [sp, 16]
+    ldp x24, x25, [sp, 32]
+    ldp x26, x27, [sp, 48]
+    ldr x28, [sp, 64]
+    ldp d10, d11, [sp, 72]
+    ldp d12, d13, [sp, 88]
+    ldp d14, d15, [sp, 104]
+    ldp d8, d9, [sp, 120]
+    ldp x20, x21, [sp], 144
+    ret
+    KAI_ASM_FUNCTION_END(kai_kernel_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod)
+
+    KAI_ASM_END

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.c
@@ -1,0 +1,188 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.c
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_MATMUL_INT8) &&            \
+  !defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && !defined(_M_ARM64)
+#error                                                                         \
+  "I8mm extension and fp16 vector arithmetic required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+typedef struct {
+  void *dst;
+  const void *lhs_packed;
+  const void *rhs_packed;
+  const float *clamp_vals;
+  size_t dst_stride_row;
+  size_t m;
+  size_t n;
+  size_t num_blocks;
+} KernelArgs;
+
+void kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  KernelArgs *args_ptr);
+
+// Compute args
+static const size_t kai_m_step = 16;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 4;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 16;
+static const size_t kai_sr = 2;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_recip_qvalue_rhs = 2;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 2;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+static const size_t kai_bl = 32;
+
+inline static size_t kai_get_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_get_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_get_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t rhs_packed_stride =
+    kai_nr * (k_internal / kai_num_bytes_recip_qvalue_rhs);
+
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_n_step;
+}
+
+size_t kai_get_mr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_mr;
+}
+
+size_t kai_get_nr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_nr;
+}
+
+size_t kai_get_kr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_kr;
+}
+
+size_t kai_get_sr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_get_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_get_rhs_packed_stride(k);
+}
+
+size_t kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  void *restrict dst,              // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(uint16_t));
+  if (m == 0) {
+    return;
+  }
+  const size_t k_internal = kai_get_k_roundedup(k);
+  size_t num_blocks = k_internal / kai_bl;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  KernelArgs args;
+
+  args.dst = dst;
+  args.lhs_packed = lhs_packed;
+  args.rhs_packed = rhs_packed;
+  args.clamp_vals = clamp_vals;
+  args.dst_stride_row = dst_stride_row;
+  args.m = m;
+  args.n = n;
+  args.num_blocks = num_blocks;
+
+  kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(&args);
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h
@@ -1,0 +1,167 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f16_neon to dynamically quantize and pack
+/// the LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0 to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be a
+/// multiple of m_step.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 4-bit with per-channel
+/// quantization (qsi4cx) values.
+///
+/// @param[in] n_idx Col index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be a multiple of
+/// m_step.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple of
+/// n_step.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed. RHS matrix: Quantized Symmetric Signed 4-bit with
+/// per-channel quantization (qsi4cx) and packed. Output tile: (rows x cols) =
+/// m_step x n_step.
+///
+/// Note: Please refer to the get functions for m_step and n_step for the exact
+/// values.
+///
+/// Features used: i8mm
+///
+/// @param[in]  m              The number of output rows written.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(uint16_t) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  void *dst,              //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm_asm.S
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm_asm.S
@@ -1,0 +1,663 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if defined(_MSC_VER)
+    #define KAI_ASM_GLOBAL(name) GLOBAL name
+    #define KAI_ASM_FUNCTION_TYPE(name)
+    #define KAI_ASM_FUNCTION_LABEL(name) name PROC
+    #define KAI_ASM_FUNCTION_END(name) ENDP
+
+    #define KAI_ASM_CODE(name) AREA name, CODE, READONLY
+    #define KAI_ASM_ALIGN
+    #define KAI_ASM_LABEL(name) name
+    #define KAI_ASM_INST(hex) DCD hex
+    #define KAI_ASM_END END
+#else
+    #if defined(__APPLE__)
+        #define KAI_ASM_GLOBAL(name) .globl _##name
+        #define KAI_ASM_FUNCTION_TYPE(name)
+        #define KAI_ASM_FUNCTION_LABEL(name) _##name:
+        #define KAI_ASM_FUNCTION_END(name)
+    #else
+        #define KAI_ASM_GLOBAL(name) .global name
+        #define KAI_ASM_FUNCTION_TYPE(name) .type name, %function
+        #define KAI_ASM_FUNCTION_LABEL(name) name:
+        #define KAI_ASM_FUNCTION_END(name) .size name, .-name
+    #endif
+
+    #define KAI_ASM_CODE(name) .text
+    #define KAI_ASM_ALIGN .p2align 4,,11
+    #define KAI_ASM_LABEL(name) name:
+    #define KAI_ASM_INST(hex) .inst hex
+    #define KAI_ASM_END
+#endif
+
+    KAI_ASM_CODE(matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm)
+    KAI_ASM_ALIGN
+
+    KAI_ASM_GLOBAL(kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm)
+
+KAI_ASM_FUNCTION_TYPE(kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm)
+KAI_ASM_FUNCTION_LABEL(kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm)
+    stp x20, x21, [sp, -144]!
+    stp x22, x23, [sp, 16]
+    stp x24, x25, [sp, 32]
+    stp x26, x27, [sp, 48]
+    str x28, [sp, 64]
+    stp d10, d11, [sp, 72]
+    stp d12, d13, [sp, 88]
+    stp d14, d15, [sp, 104]
+    stp d8, d9, [sp, 120]
+    mov x6, #0x80
+    mov x21, #0x20
+    ldr x20, [x0, #0x28]
+    ldr x7, [x0, #0x38]
+    ldr x8, [x0, #0x8]
+    ldr x17, [x0, #0x10]
+    ldr x16, [x0, #0x30]
+    ldr x15, [x0, #0x0]
+    mov x14, x20
+    ldr x13, [x0, #0x20]
+    madd x6, x7, x6, x21
+    ldr x12, [x0, #0x18]
+    cmp x14, #0x10
+    blt label_14
+KAI_ASM_LABEL(label_1)  // Row loop
+    mov x11, x17
+    mov x10, x16
+    add x9, x15, x13, LSL #4
+KAI_ASM_LABEL(label_2)  // Column loop
+    mov x27, x8
+    movi v31.4s, #0x0
+    movi v30.4s, #0x0
+    mov x23, x7
+    movi v29.4s, #0x0
+    movi v28.4s, #0x0
+    movi v27.4s, #0x0
+    movi v26.4s, #0x0
+    add x22, x27, x6
+    add x21, x22, x6
+    add x20, x21, x6
+    movi v25.4s, #0x0
+    movi v24.4s, #0x0
+    movi v23.4s, #0x0
+    movi v22.4s, #0x0
+    movi v21.4s, #0x0
+    movi v20.4s, #0x0
+    movi v19.4s, #0x0
+    movi v18.4s, #0x0
+    movi v17.4s, #0x0
+    movi v16.4s, #0x0
+KAI_ASM_LABEL(label_3)  // Sub block loop
+    ldr q14, [x11, #0x0]
+    ldr q12, [x11, #0x10]
+    movi v1.16b, #0xf0
+    subs x23, x23, #0x1
+    ldr q11, [x27, #0x0]
+    ldr q10, [x27, #0x10]
+    ldr q9, [x22, #0x0]
+    ldr q8, [x22, #0x10]
+    ldr q7, [x21, #0x0]
+    ldr q6, [x21, #0x10]
+    shl v4.16b, v14.16b, #0x4
+    shl v5.16b, v12.16b, #0x4
+    ldr q3, [x20, #0x0]
+    ldr q2, [x20, #0x10]
+    and v14.16b, v14.16b, v1.16b
+    and v12.16b, v12.16b, v1.16b
+    ldr q13, [x11, #0x20]
+    ldr q15, [x11, #0x30]
+    add x11, x11, #0x40
+    ldr q0, [x27, #0x20]
+    KAI_ASM_INST(0x4e84a57f)  // smmla v31.4s, v11.16b, v4.16b
+    KAI_ASM_INST(0x4e85a57e)  // smmla v30.4s, v11.16b, v5.16b
+    ldr q11, [x27, #0x30]
+    KAI_ASM_INST(0x4e84a55d)  // smmla v29.4s, v10.16b, v4.16b
+    KAI_ASM_INST(0x4e85a55c)  // smmla v28.4s, v10.16b, v5.16b
+    ldr q10, [x22, #0x20]
+    KAI_ASM_INST(0x4e84a53b)  // smmla v27.4s, v9.16b, v4.16b
+    KAI_ASM_INST(0x4e85a53a)  // smmla v26.4s, v9.16b, v5.16b
+    ldr q9, [x22, #0x30]
+    KAI_ASM_INST(0x4e84a519)  // smmla v25.4s, v8.16b, v4.16b
+    KAI_ASM_INST(0x4e85a518)  // smmla v24.4s, v8.16b, v5.16b
+    ldr q8, [x21, #0x20]
+    KAI_ASM_INST(0x4e84a4f7)  // smmla v23.4s, v7.16b, v4.16b
+    KAI_ASM_INST(0x4e85a4f6)  // smmla v22.4s, v7.16b, v5.16b
+    ldr q7, [x21, #0x30]
+    KAI_ASM_INST(0x4e84a4d5)  // smmla v21.4s, v6.16b, v4.16b
+    KAI_ASM_INST(0x4e85a4d4)  // smmla v20.4s, v6.16b, v5.16b
+    ldr q6, [x20, #0x20]
+    KAI_ASM_INST(0x4e84a473)  // smmla v19.4s, v3.16b, v4.16b
+    KAI_ASM_INST(0x4e85a472)  // smmla v18.4s, v3.16b, v5.16b
+    ldr q3, [x20, #0x30]
+    KAI_ASM_INST(0x4e84a451)  // smmla v17.4s, v2.16b, v4.16b
+    ldr q4, [x27, #0x40]
+    KAI_ASM_INST(0x4e85a450)  // smmla v16.4s, v2.16b, v5.16b
+    ldr q2, [x27, #0x50]
+    shl v5.16b, v13.16b, #0x4
+    and v13.16b, v13.16b, v1.16b
+    KAI_ASM_INST(0x4e85a41f)  // smmla v31.4s, v0.16b, v5.16b
+    KAI_ASM_INST(0x4e85a57d)  // smmla v29.4s, v11.16b, v5.16b
+    KAI_ASM_INST(0x4e85a55b)  // smmla v27.4s, v10.16b, v5.16b
+    KAI_ASM_INST(0x4e85a539)  // smmla v25.4s, v9.16b, v5.16b
+    KAI_ASM_INST(0x4e85a517)  // smmla v23.4s, v8.16b, v5.16b
+    KAI_ASM_INST(0x4e85a4f5)  // smmla v21.4s, v7.16b, v5.16b
+    KAI_ASM_INST(0x4e85a4d3)  // smmla v19.4s, v6.16b, v5.16b
+    KAI_ASM_INST(0x4e85a471)  // smmla v17.4s, v3.16b, v5.16b
+    shl v5.16b, v15.16b, #0x4
+    KAI_ASM_INST(0x4e8ea49f)  // smmla v31.4s, v4.16b, v14.16b
+    KAI_ASM_INST(0x4e8ea45d)  // smmla v29.4s, v2.16b, v14.16b
+    and v15.16b, v15.16b, v1.16b
+    ldr q1, [x22, #0x40]
+    KAI_ASM_INST(0x4e85a41e)  // smmla v30.4s, v0.16b, v5.16b
+    ldr q0, [x22, #0x50]
+    KAI_ASM_INST(0x4e85a57c)  // smmla v28.4s, v11.16b, v5.16b
+    ldr q11, [x21, #0x40]
+    KAI_ASM_INST(0x4e85a55a)  // smmla v26.4s, v10.16b, v5.16b
+    ldr q10, [x21, #0x50]
+    KAI_ASM_INST(0x4e85a538)  // smmla v24.4s, v9.16b, v5.16b
+    ldr q9, [x20, #0x40]
+    KAI_ASM_INST(0x4e85a516)  // smmla v22.4s, v8.16b, v5.16b
+    ldr q8, [x20, #0x50]
+    KAI_ASM_INST(0x4e85a4f4)  // smmla v20.4s, v7.16b, v5.16b
+    ldr q7, [x27, #0x60]
+    KAI_ASM_INST(0x4e85a4d2)  // smmla v18.4s, v6.16b, v5.16b
+    ldr q6, [x27, #0x70]
+    KAI_ASM_INST(0x4e85a470)  // smmla v16.4s, v3.16b, v5.16b
+    ldr q5, [x22, #0x60]
+    KAI_ASM_INST(0x4e8ca49e)  // smmla v30.4s, v4.16b, v12.16b
+    ldr q4, [x22, #0x70]
+    ldr q3, [x21, #0x60]
+    KAI_ASM_INST(0x4e8ca45c)  // smmla v28.4s, v2.16b, v12.16b
+    KAI_ASM_INST(0x4e8ea43b)  // smmla v27.4s, v1.16b, v14.16b
+    ldr q2, [x21, #0x70]
+    KAI_ASM_INST(0x4e8ca43a)  // smmla v26.4s, v1.16b, v12.16b
+    ldr q1, [x20, #0x60]
+    KAI_ASM_INST(0x4e8ea419)  // smmla v25.4s, v0.16b, v14.16b
+    KAI_ASM_INST(0x4e8ca418)  // smmla v24.4s, v0.16b, v12.16b
+    ldr q0, [x20, #0x70]
+    KAI_ASM_INST(0x4e8ea577)  // smmla v23.4s, v11.16b, v14.16b
+    add x27, x27, #0x80
+    KAI_ASM_INST(0x4e8ca576)  // smmla v22.4s, v11.16b, v12.16b
+    KAI_ASM_INST(0x4e8ea555)  // smmla v21.4s, v10.16b, v14.16b
+    add x22, x22, #0x80
+    add x21, x21, #0x80
+    KAI_ASM_INST(0x4e8ca554)  // smmla v20.4s, v10.16b, v12.16b
+    KAI_ASM_INST(0x4e8ea533)  // smmla v19.4s, v9.16b, v14.16b
+    add x20, x20, #0x80
+    KAI_ASM_INST(0x4e8ca532)  // smmla v18.4s, v9.16b, v12.16b
+    KAI_ASM_INST(0x4e8ea511)  // smmla v17.4s, v8.16b, v14.16b
+    KAI_ASM_INST(0x4e8ca510)  // smmla v16.4s, v8.16b, v12.16b
+    KAI_ASM_INST(0x4e8da4ff)  // smmla v31.4s, v7.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa4fe)  // smmla v30.4s, v7.16b, v15.16b
+    KAI_ASM_INST(0x4e8da4dd)  // smmla v29.4s, v6.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa4dc)  // smmla v28.4s, v6.16b, v15.16b
+    KAI_ASM_INST(0x4e8da4bb)  // smmla v27.4s, v5.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa4ba)  // smmla v26.4s, v5.16b, v15.16b
+    KAI_ASM_INST(0x4e8da499)  // smmla v25.4s, v4.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa498)  // smmla v24.4s, v4.16b, v15.16b
+    KAI_ASM_INST(0x4e8da477)  // smmla v23.4s, v3.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa476)  // smmla v22.4s, v3.16b, v15.16b
+    KAI_ASM_INST(0x4e8da455)  // smmla v21.4s, v2.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa454)  // smmla v20.4s, v2.16b, v15.16b
+    KAI_ASM_INST(0x4e8da433)  // smmla v19.4s, v1.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa432)  // smmla v18.4s, v1.16b, v15.16b
+    KAI_ASM_INST(0x4e8da411)  // smmla v17.4s, v0.16b, v13.16b
+    KAI_ASM_INST(0x4e8fa410)  // smmla v16.4s, v0.16b, v15.16b
+    bgt label_3
+    ldr q7, [x11, #0x0]
+    ld1 { v4.4s }, [x27]
+    uzp1 v3.2d, v31.2d, v30.2d
+    uzp2 v2.2d, v31.2d, v30.2d
+    ldr q6, [x11, #0x10]
+    uzp1 v1.2d, v29.2d, v28.2d
+    uzp2 v0.2d, v29.2d, v28.2d
+    add x27, x27, #0x10
+    ldr q28, [x27, #0x0]
+    add x11, x11, #0x20
+    mla v3.4s, v7.4s, v4.s[0]
+    mla v2.4s, v7.4s, v4.s[1]
+    mla v1.4s, v7.4s, v4.s[2]
+    mla v0.4s, v7.4s, v4.s[3]
+    fmul v31.4s, v6.4s, v28.s[0]
+    fmul v30.4s, v6.4s, v28.s[1]
+    fmul v29.4s, v6.4s, v28.s[2]
+    fmul v28.4s, v6.4s, v28.s[3]
+    scvtf v3.4s, v3.4s
+    scvtf v2.4s, v2.4s
+    scvtf v1.4s, v1.4s
+    scvtf v0.4s, v0.4s
+    fmul v31.4s, v3.4s, v31.4s
+    fmul v30.4s, v2.4s, v30.4s
+    fmul v29.4s, v1.4s, v29.4s
+    fmul v28.4s, v0.4s, v28.4s
+    ld1 { v5.4s }, [x22]
+    uzp1 v4.2d, v27.2d, v26.2d
+    uzp2 v3.2d, v27.2d, v26.2d
+    add x22, x22, #0x10
+    ldr q2, [x22, #0x0]
+    uzp1 v1.2d, v25.2d, v24.2d
+    uzp2 v0.2d, v25.2d, v24.2d
+    mla v4.4s, v7.4s, v5.s[0]
+    mla v3.4s, v7.4s, v5.s[1]
+    mla v1.4s, v7.4s, v5.s[2]
+    mla v0.4s, v7.4s, v5.s[3]
+    fmul v27.4s, v6.4s, v2.s[0]
+    fmul v26.4s, v6.4s, v2.s[1]
+    fmul v25.4s, v6.4s, v2.s[2]
+    scvtf v4.4s, v4.4s
+    fmul v24.4s, v6.4s, v2.s[3]
+    scvtf v3.4s, v3.4s
+    scvtf v1.4s, v1.4s
+    scvtf v0.4s, v0.4s
+    fmul v27.4s, v4.4s, v27.4s
+    fmul v26.4s, v3.4s, v26.4s
+    fmul v25.4s, v1.4s, v25.4s
+    fmul v24.4s, v0.4s, v24.4s
+    ld1 { v5.4s }, [x21]
+    uzp1 v4.2d, v23.2d, v22.2d
+    uzp2 v3.2d, v23.2d, v22.2d
+    add x21, x21, #0x10
+    ldr q2, [x21, #0x0]
+    uzp1 v1.2d, v21.2d, v20.2d
+    uzp2 v0.2d, v21.2d, v20.2d
+    mla v4.4s, v7.4s, v5.s[0]
+    mla v3.4s, v7.4s, v5.s[1]
+    mla v1.4s, v7.4s, v5.s[2]
+    mla v0.4s, v7.4s, v5.s[3]
+    fmul v23.4s, v6.4s, v2.s[0]
+    fmul v22.4s, v6.4s, v2.s[1]
+    fmul v21.4s, v6.4s, v2.s[2]
+    scvtf v4.4s, v4.4s
+    fmul v20.4s, v6.4s, v2.s[3]
+    scvtf v3.4s, v3.4s
+    scvtf v1.4s, v1.4s
+    scvtf v0.4s, v0.4s
+    fmul v23.4s, v4.4s, v23.4s
+    fmul v22.4s, v3.4s, v22.4s
+    fmul v21.4s, v1.4s, v21.4s
+    fmul v20.4s, v0.4s, v20.4s
+    ld1 { v5.4s }, [x20]
+    uzp1 v4.2d, v19.2d, v18.2d
+    uzp2 v3.2d, v19.2d, v18.2d
+    add x20, x20, #0x10
+    ldr q2, [x20, #0x0]
+    uzp1 v1.2d, v17.2d, v16.2d
+    uzp2 v0.2d, v17.2d, v16.2d
+    mla v4.4s, v7.4s, v5.s[0]
+    mla v3.4s, v7.4s, v5.s[1]
+    mla v1.4s, v7.4s, v5.s[2]
+    mla v0.4s, v7.4s, v5.s[3]
+    fmul v19.4s, v6.4s, v2.s[0]
+    fmul v18.4s, v6.4s, v2.s[1]
+    fmul v17.4s, v6.4s, v2.s[2]
+    scvtf v4.4s, v4.4s
+    fmul v16.4s, v6.4s, v2.s[3]
+    scvtf v3.4s, v3.4s
+    scvtf v1.4s, v1.4s
+    scvtf v0.4s, v0.4s
+    fmul v19.4s, v4.4s, v19.4s
+    fmul v18.4s, v3.4s, v18.4s
+    fmul v17.4s, v1.4s, v17.4s
+    fmul v16.4s, v0.4s, v16.4s
+    ldr q2, [x11, #0x0]
+    ld1r { v1.4s }, [x12]
+    add x20, x12, #0x4
+    cmp x10, #0x4
+    ld1r { v0.4s }, [x20]
+    add x11, x11, #0x10
+    fadd v31.4s, v31.4s, v2.4s
+    fadd v30.4s, v30.4s, v2.4s
+    fadd v29.4s, v29.4s, v2.4s
+    fadd v28.4s, v28.4s, v2.4s
+    fadd v27.4s, v27.4s, v2.4s
+    fadd v26.4s, v26.4s, v2.4s
+    fadd v25.4s, v25.4s, v2.4s
+    fadd v24.4s, v24.4s, v2.4s
+    fadd v23.4s, v23.4s, v2.4s
+    fadd v22.4s, v22.4s, v2.4s
+    fadd v21.4s, v21.4s, v2.4s
+    fadd v20.4s, v20.4s, v2.4s
+    fadd v19.4s, v19.4s, v2.4s
+    fadd v18.4s, v18.4s, v2.4s
+    fadd v17.4s, v17.4s, v2.4s
+    fadd v16.4s, v16.4s, v2.4s
+    fmax v31.4s, v31.4s, v1.4s
+    fmax v30.4s, v30.4s, v1.4s
+    fmax v29.4s, v29.4s, v1.4s
+    fmax v28.4s, v28.4s, v1.4s
+    fmax v27.4s, v27.4s, v1.4s
+    fmax v26.4s, v26.4s, v1.4s
+    fmax v25.4s, v25.4s, v1.4s
+    fmax v24.4s, v24.4s, v1.4s
+    fmax v23.4s, v23.4s, v1.4s
+    fmax v22.4s, v22.4s, v1.4s
+    fmax v21.4s, v21.4s, v1.4s
+    fmax v20.4s, v20.4s, v1.4s
+    fmax v19.4s, v19.4s, v1.4s
+    fmax v18.4s, v18.4s, v1.4s
+    fmax v17.4s, v17.4s, v1.4s
+    fmax v16.4s, v16.4s, v1.4s
+    fmin v31.4s, v31.4s, v0.4s
+    fmin v30.4s, v30.4s, v0.4s
+    fmin v29.4s, v29.4s, v0.4s
+    fmin v28.4s, v28.4s, v0.4s
+    fmin v27.4s, v27.4s, v0.4s
+    fmin v26.4s, v26.4s, v0.4s
+    fmin v25.4s, v25.4s, v0.4s
+    fmin v24.4s, v24.4s, v0.4s
+    fmin v23.4s, v23.4s, v0.4s
+    fmin v22.4s, v22.4s, v0.4s
+    fmin v21.4s, v21.4s, v0.4s
+    fmin v20.4s, v20.4s, v0.4s
+    fmin v19.4s, v19.4s, v0.4s
+    fmin v18.4s, v18.4s, v0.4s
+    fmin v17.4s, v17.4s, v0.4s
+    fmin v16.4s, v16.4s, v0.4s
+    fcvtn v31.4h, v31.4s
+    fcvtn v30.4h, v30.4s
+    fcvtn v29.4h, v29.4s
+    fcvtn v28.4h, v28.4s
+    fcvtn v27.4h, v27.4s
+    fcvtn v26.4h, v26.4s
+    fcvtn v25.4h, v25.4s
+    fcvtn v24.4h, v24.4s
+    fcvtn v23.4h, v23.4s
+    fcvtn v22.4h, v22.4s
+    fcvtn v21.4h, v21.4s
+    fcvtn v20.4h, v20.4s
+    fcvtn v19.4h, v19.4s
+    fcvtn v18.4h, v18.4s
+    fcvtn v17.4h, v17.4s
+    fcvtn v16.4h, v16.4s
+    blt label_8
+    mov x20, x15
+    str d31, [x20, #0x0]
+    add x20, x20, x13
+    str d30, [x20, #0x0]
+    add x20, x20, x13
+    str d29, [x20, #0x0]
+    add x20, x20, x13
+    str d28, [x20, #0x0]
+    add x20, x20, x13
+    str d27, [x20, #0x0]
+    add x20, x20, x13
+    str d26, [x20, #0x0]
+    add x20, x20, x13
+    str d25, [x20, #0x0]
+    add x20, x20, x13
+    str d24, [x20, #0x0]
+    add x20, x20, x13
+    str d23, [x20, #0x0]
+    add x20, x20, x13
+    str d22, [x20, #0x0]
+    add x20, x20, x13
+    str d21, [x20, #0x0]
+    add x20, x20, x13
+    str d20, [x20, #0x0]
+    add x20, x20, x13
+    str d19, [x20, #0x0]
+    add x20, x20, x13
+    str d18, [x20, #0x0]
+    add x20, x20, x13
+    str d17, [x20, #0x0]
+    add x20, x20, x13
+    str d16, [x20, #0x0]
+    b label_13
+KAI_ASM_LABEL(label_8)  // Partial output
+    mov x28, x15
+    add x26, x28, x13, LSL #2
+    add x25, x26, x13, LSL #1
+    add x24, x26, x13
+    add x23, x25, x13
+    add x22, x28, x13, LSL #1
+    add x21, x28, x13
+    add x20, x22, x13
+    add x27, x23, x13
+    tbz x10, #1, label_9
+    st1 { v24.s }[0], [x23], #0x4
+    st1 { v25.s }[0], [x25], #0x4
+    st1 { v26.s }[0], [x24], #0x4
+    st1 { v27.s }[0], [x26], #0x4
+    st1 { v28.s }[0], [x20], #0x4
+    st1 { v29.s }[0], [x22], #0x4
+    st1 { v30.s }[0], [x21], #0x4
+    st1 { v31.s }[0], [x28], #0x4
+    tbz x10, #0, label_10
+    st1 { v24.h }[2], [x23]
+    st1 { v25.h }[2], [x25]
+    st1 { v26.h }[2], [x24]
+    st1 { v27.h }[2], [x26]
+    st1 { v28.h }[2], [x20]
+    st1 { v29.h }[2], [x22]
+    st1 { v30.h }[2], [x21]
+    st1 { v31.h }[2], [x28]
+    b label_10
+KAI_ASM_LABEL(label_9)  // Output block 0: partial_1_0
+    st1 { v24.h }[0], [x23]
+    st1 { v25.h }[0], [x25]
+    st1 { v26.h }[0], [x24]
+    st1 { v27.h }[0], [x26]
+    st1 { v28.h }[0], [x20]
+    st1 { v29.h }[0], [x22]
+    st1 { v30.h }[0], [x21]
+    st1 { v31.h }[0], [x28]
+KAI_ASM_LABEL(label_10)  // Output block 0: Done
+    add x26, x27, x13, LSL #2
+    add x25, x27, x13, LSL #1
+    add x24, x26, x13, LSL #1
+    add x23, x27, x13
+    add x22, x25, x13
+    add x21, x26, x13
+    add x20, x24, x13
+    tbz x10, #1, label_11
+    st1 { v16.s }[0], [x20], #0x4
+    st1 { v17.s }[0], [x24], #0x4
+    st1 { v18.s }[0], [x21], #0x4
+    st1 { v19.s }[0], [x26], #0x4
+    st1 { v20.s }[0], [x22], #0x4
+    st1 { v21.s }[0], [x25], #0x4
+    st1 { v22.s }[0], [x23], #0x4
+    st1 { v23.s }[0], [x27], #0x4
+    tbz x10, #0, label_12
+    st1 { v16.h }[2], [x20]
+    st1 { v17.h }[2], [x24]
+    st1 { v18.h }[2], [x21]
+    st1 { v19.h }[2], [x26]
+    st1 { v20.h }[2], [x22]
+    st1 { v21.h }[2], [x25]
+    st1 { v22.h }[2], [x23]
+    st1 { v23.h }[2], [x27]
+    b label_12
+KAI_ASM_LABEL(label_11)  // Output block 1: partial_1_0
+    st1 { v16.h }[0], [x20]
+    st1 { v17.h }[0], [x24]
+    st1 { v18.h }[0], [x21]
+    st1 { v19.h }[0], [x26]
+    st1 { v20.h }[0], [x22]
+    st1 { v21.h }[0], [x25]
+    st1 { v22.h }[0], [x23]
+    st1 { v23.h }[0], [x27]
+KAI_ASM_LABEL(label_12)  // Output block 1: Done
+KAI_ASM_LABEL(label_13)  // Output stage exit
+    subs x10, x10, #0x4
+    add x15, x15, #0x8
+    bgt label_2
+    mov x20, #0x4
+    sub x14, x14, #0x10
+    cmp x14, #0x10
+    mov x15, x9
+    madd x8, x20, x6, x8
+    bge label_1
+KAI_ASM_LABEL(label_14)  // Row loop skip
+    cbz x14, label_23
+KAI_ASM_LABEL(label_15)  // Row tail: Row loop
+    mov x26, x17
+    mov x25, x16
+    add x24, x15, x13, LSL #2
+KAI_ASM_LABEL(label_16)  // Row tail: Column loop
+    mov x27, x8
+    movi v31.4s, #0x0
+    movi v30.4s, #0x0
+    mov x20, x7
+    movi v29.4s, #0x0
+    movi v28.4s, #0x0
+KAI_ASM_LABEL(label_17)  // Row tail: Sub block loop
+    ldr q4, [x26, #0x0]
+    ldr q3, [x26, #0x10]
+    movi v2.16b, #0xf0
+    subs x20, x20, #0x1
+    ldr q1, [x27, #0x0]
+    ldr q0, [x27, #0x10]
+    ldr q27, [x26, #0x20]
+    ldr q26, [x26, #0x30]
+    add x26, x26, #0x40
+    ldr q25, [x27, #0x20]
+    ldr q24, [x27, #0x30]
+    shl v23.16b, v4.16b, #0x4
+    shl v22.16b, v3.16b, #0x4
+    ldr q21, [x27, #0x40]
+    ldr q20, [x27, #0x50]
+    and v4.16b, v4.16b, v2.16b
+    and v3.16b, v3.16b, v2.16b
+    ldr q19, [x27, #0x60]
+    ldr q18, [x27, #0x70]
+    shl v17.16b, v27.16b, #0x4
+    shl v16.16b, v26.16b, #0x4
+    KAI_ASM_INST(0x4e97a43f)  // smmla v31.4s, v1.16b, v23.16b
+    KAI_ASM_INST(0x4e96a43e)  // smmla v30.4s, v1.16b, v22.16b
+    and v27.16b, v27.16b, v2.16b
+    add x27, x27, #0x80
+    KAI_ASM_INST(0x4e97a41d)  // smmla v29.4s, v0.16b, v23.16b
+    KAI_ASM_INST(0x4e96a41c)  // smmla v28.4s, v0.16b, v22.16b
+    and v26.16b, v26.16b, v2.16b
+    KAI_ASM_INST(0x4e91a73f)  // smmla v31.4s, v25.16b, v17.16b
+    KAI_ASM_INST(0x4e90a73e)  // smmla v30.4s, v25.16b, v16.16b
+    KAI_ASM_INST(0x4e91a71d)  // smmla v29.4s, v24.16b, v17.16b
+    KAI_ASM_INST(0x4e90a71c)  // smmla v28.4s, v24.16b, v16.16b
+    KAI_ASM_INST(0x4e84a6bf)  // smmla v31.4s, v21.16b, v4.16b
+    KAI_ASM_INST(0x4e83a6be)  // smmla v30.4s, v21.16b, v3.16b
+    KAI_ASM_INST(0x4e84a69d)  // smmla v29.4s, v20.16b, v4.16b
+    KAI_ASM_INST(0x4e83a69c)  // smmla v28.4s, v20.16b, v3.16b
+    KAI_ASM_INST(0x4e9ba67f)  // smmla v31.4s, v19.16b, v27.16b
+    KAI_ASM_INST(0x4e9aa67e)  // smmla v30.4s, v19.16b, v26.16b
+    KAI_ASM_INST(0x4e9ba65d)  // smmla v29.4s, v18.16b, v27.16b
+    KAI_ASM_INST(0x4e9aa65c)  // smmla v28.4s, v18.16b, v26.16b
+    bgt label_17
+    ldr q18, [x26, #0x0]
+    ld1 { v17.4s }, [x27]
+    uzp1 v24.2d, v31.2d, v30.2d
+    uzp2 v23.2d, v31.2d, v30.2d
+    ldr q22, [x26, #0x10]
+    uzp1 v21.2d, v29.2d, v28.2d
+    uzp2 v20.2d, v29.2d, v28.2d
+    add x27, x27, #0x10
+    ldr q16, [x27, #0x0]
+    add x26, x26, #0x20
+    mla v24.4s, v18.4s, v17.s[0]
+    mla v23.4s, v18.4s, v17.s[1]
+    mla v21.4s, v18.4s, v17.s[2]
+    mla v20.4s, v18.4s, v17.s[3]
+    fmul v19.4s, v22.4s, v16.s[0]
+    fmul v18.4s, v22.4s, v16.s[1]
+    fmul v17.4s, v22.4s, v16.s[2]
+    fmul v16.4s, v22.4s, v16.s[3]
+    scvtf v24.4s, v24.4s
+    scvtf v23.4s, v23.4s
+    scvtf v21.4s, v21.4s
+    scvtf v20.4s, v20.4s
+    fmul v31.4s, v24.4s, v19.4s
+    fmul v30.4s, v23.4s, v18.4s
+    fmul v29.4s, v21.4s, v17.4s
+    fmul v28.4s, v20.4s, v16.4s
+    ldr q18, [x26, #0x0]
+    ld1r { v17.4s }, [x12]
+    add x20, x12, #0x4
+    cmp x25, #0x4
+    ld1r { v16.4s }, [x20]
+    add x26, x26, #0x10
+    fadd v31.4s, v31.4s, v18.4s
+    fadd v30.4s, v30.4s, v18.4s
+    fadd v29.4s, v29.4s, v18.4s
+    fadd v28.4s, v28.4s, v18.4s
+    fmax v31.4s, v31.4s, v17.4s
+    fmax v30.4s, v30.4s, v17.4s
+    fmax v29.4s, v29.4s, v17.4s
+    fmax v28.4s, v28.4s, v17.4s
+    fmin v31.4s, v31.4s, v16.4s
+    fmin v30.4s, v30.4s, v16.4s
+    fmin v29.4s, v29.4s, v16.4s
+    fmin v28.4s, v28.4s, v16.4s
+    fcvtn v19.4h, v31.4s
+    fcvtn v18.4h, v30.4s
+    fcvtn v17.4h, v29.4s
+    fcvtn v16.4h, v28.4s
+    blt label_19
+    mov x20, x15
+    cmp x14, #0x1
+    str d19, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    cmp x14, #0x2
+    str d18, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    cmp x14, #0x3
+    str d17, [x20, #0x0]
+    add x20, x20, x13
+    ble label_22
+    str d16, [x20, #0x0]
+    b label_22
+KAI_ASM_LABEL(label_19)  // Row tail: Partial output
+    mov x23, x15
+    cmp x14, #0x1
+    add x22, x23, x13
+    csel x22, x22, x23, GT
+    cmp x14, #0x2
+    add x21, x23, x13, LSL #1
+    csel x21, x21, x22, GT
+    cmp x14, #0x3
+    add x20, x21, x13
+    csel x20, x20, x21, GT
+    tbz x25, #1, label_20
+    st1 { v16.s }[0], [x20], #0x4
+    st1 { v17.s }[0], [x21], #0x4
+    st1 { v18.s }[0], [x22], #0x4
+    st1 { v19.s }[0], [x23], #0x4
+    tbz x25, #0, label_21
+    st1 { v16.h }[2], [x20]
+    st1 { v17.h }[2], [x21]
+    st1 { v18.h }[2], [x22]
+    st1 { v19.h }[2], [x23]
+    b label_21
+KAI_ASM_LABEL(label_20)  // Row tail: Output block 0: partial_1_0
+    st1 { v16.h }[0], [x20]
+    st1 { v17.h }[0], [x21]
+    st1 { v18.h }[0], [x22]
+    st1 { v19.h }[0], [x23]
+KAI_ASM_LABEL(label_21)  // Row tail: Output block 0: Done
+KAI_ASM_LABEL(label_22)  // Row tail: Output stage exit
+    subs x25, x25, #0x4
+    add x15, x15, #0x8
+    bgt label_16
+    subs x14, x14, #0x4
+    add x8, x8, x6
+    mov x15, x24
+    bgt label_15
+KAI_ASM_LABEL(label_23)  // Row tail: Row loop skip
+    ldp x22, x23, [sp, 16]
+    ldp x24, x25, [sp, 32]
+    ldp x26, x27, [sp, 48]
+    ldr x28, [sp, 64]
+    ldp d10, d11, [sp, 72]
+    ldp d12, d13, [sp, 88]
+    ldp d14, d15, [sp, 104]
+    ldp d8, d9, [sp, 120]
+    ldp x20, x21, [sp], 144
+    ret
+    KAI_ASM_FUNCTION_END(kai_kernel_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm)
+
+    KAI_ASM_END

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h
@@ -1,0 +1,73 @@
+/**
+ * @file kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h copied from kleidiai
+ *
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// All micro-kernels variants of the same type share the same interfaces
+// In this case, the micro-kernel type is: matmul_clamp_f16_qai8dxp_qsi4cxp
+
+/// Micro-kernel helper functions ("get" methods)
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_m_step_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_n_step_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_mr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_nr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_kr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_sr_func_t)(void);
+typedef size_t (
+  *kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_lhs_packed_offset_func_t)(
+  size_t m_idx, size_t k);
+typedef size_t (
+  *kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_rhs_packed_offset_func_t)(
+  size_t n_idx, size_t k);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_dst_offset_func_t)(
+  size_t m_idx, size_t n_idx, size_t dst_stride);
+typedef size_t (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_dst_size_func_t)(
+  size_t m, size_t n);
+
+/// Micro-kernel core function ("run" method)
+typedef void (*kai_matmul_clamp_f16_qai8dxp_qsi4cxp_run_matmul_func_t)(
+  size_t m, size_t n, size_t k, const void *lhs_p, const void *rhs_p, void *dst,
+  size_t dst_stride_row, size_t dst_stride_col, float scalar_min,
+  float scalar_max);
+
+/// Micro-kernel interface
+/**
+ * @brief  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_ukernel
+ */
+struct kai_matmul_clamp_f16_qai8dxp_qsi4cxp_ukernel {
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_m_step_func_t get_m_step;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_n_step_func_t get_n_step;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_mr_func_t get_mr;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_nr_func_t get_nr;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_kr_func_t get_kr;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_sr_func_t get_sr;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_lhs_packed_offset_func_t
+    get_lhs_packed_offset;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_rhs_packed_offset_func_t
+    get_rhs_packed_offset;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_dst_offset_func_t get_dst_offset;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_get_dst_size_func_t get_dst_size;
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_run_matmul_func_t run_matmul;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f16_qai8dxp_qsi4cxp/meson.build
@@ -1,0 +1,26 @@
+matmul_clamp_f16_qai8dxp_qsi4cxp_headers = [
+    'kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h',
+    'kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h',
+    'kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h',
+    'kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h',
+    'kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h',
+]
+
+matmul_clamp_f16_qai8dxp_qsi4cxp_sources = [
+    'kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.c',
+    'kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod_asm.S',
+    'kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.c',
+    'kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod_asm.S',
+    'kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.c',
+    'kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod_asm.S',
+    'kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.c',
+    'kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm_asm.S',
+]
+
+foreach s : matmul_clamp_f16_qai8dxp_qsi4cxp_sources
+  nntrainer_sources += meson.current_source_dir() / s
+endforeach
+
+foreach h : matmul_clamp_f16_qai8dxp_qsi4cxp_headers
+  nntrainer_headers += meson.current_source_dir() / h
+endforeach

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build
@@ -2,6 +2,12 @@ kai_headers = [
     'kai_common.h'
 ]
 
+if get_option('enable-fp16')
+subdir('matmul_clamp_f16_qai8dxp_qsi4cxp')
+nntrainer_inc += include_directories('matmul_clamp_f16_qai8dxp_qsi4cxp')
+nntrainer_inc_abs += meson.current_source_dir() / 'matmul_clamp_f16_qai8dxp_qsi4cxp'
+endif
+
 subdir('matmul_clamp_f32_qai8dxp_qsi4cxp')
 nntrainer_inc += include_directories('matmul_clamp_f32_qai8dxp_qsi4cxp')
 nntrainer_inc_abs += meson.current_source_dir() / 'matmul_clamp_f32_qai8dxp_qsi4cxp'

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.c
@@ -1,0 +1,581 @@
+/**
+ * @file kai_lhs_quant_pack_qai8dxp_f16_neon.c
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_lhs_quant_pack_qai8dxp_f16_neon.c copied from kleidiai
+ *
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if !defined(__aarch64__) || !defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) || \
+  !defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#error This file must be compiled for AArch64, FEAT_FP16.
+#else // Architectural features check.
+
+#include "kai_lhs_quant_pack_qai8dxp_f16_neon.h"
+
+#include <arm_fp16.h>
+#include <arm_neon.h>
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+#define FLT16_MAX 65504.0
+#define FLT16_MIN (-65504.0F)
+
+static const size_t kai_num_bytes_per_multiplier = sizeof(float);
+static const size_t kai_num_bytes_per_offset = sizeof(int32_t);
+
+inline static size_t kai_k_roundedup(size_t k) {
+  // Round up k to be a multiple of 32.
+  size_t kai_k_multiple_of = 32;
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_lhs_packed_stride(size_t k, size_t mr, size_t kr,
+                                           size_t sr) {
+  KAI_UNUSED(kr);
+  KAI_UNUSED(sr);
+
+  const size_t k_internal = kai_k_roundedup(k);
+
+  KAI_ASSERT((k_internal % 2) == 0);
+
+  return mr * (k_internal * sizeof(int8_t) + kai_num_bytes_per_multiplier +
+               kai_num_bytes_per_offset);
+}
+
+size_t kai_get_m_step_lhs_quant_pack_qai8dxp_f16_neon(size_t mr) { return mr; }
+
+size_t kai_get_lhs_offset_lhs_quant_pack_qai8dxp_f16_neon(size_t m_idx,
+                                                          size_t lhs_stride) {
+  return m_idx * lhs_stride;
+}
+
+size_t kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f16_neon(
+  size_t m_idx, size_t k, size_t mr, size_t kr, size_t sr) {
+  // It always points to the beginning of the row
+  return (m_idx / mr) * kai_lhs_packed_stride(k, mr, kr, sr);
+}
+
+size_t kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f16_neon(
+  size_t m, size_t k, size_t mr, size_t kr, size_t sr) {
+  const size_t num_rows = kai_roundup(m, mr) / mr;
+
+  return num_rows * kai_lhs_packed_stride(k, mr, kr, sr);
+}
+
+void kai_run_lhs_quant_pack_qai8dxp_f16_neon(
+  size_t m, size_t k, size_t mr, size_t kr, size_t sr, size_t m_idx_start,
+  const void *restrict lhs, size_t lhs_stride, void *restrict lhs_packed) {
+  KAI_ASSERT((kr % sr) == 0);
+  KAI_ASSUME((kr / sr == 8) || (kr / sr == 4));
+
+  if (m == 0) {
+    return;
+  }
+
+  const size_t num_rows = m;
+
+  float16_t const *src_ptr = (float16_t const *)lhs;
+
+  const size_t dst_stride = kai_lhs_packed_stride(k, mr, kr, sr);
+  const size_t k_internal = kai_k_roundedup(k);
+  const int32_t k_block_len = (int32_t)(kr / sr);
+
+  const int32_t num_blocks_k = (int32_t)(k / k_block_len);
+  const int32_t num_blocks_k_internal = (int32_t)(k_internal / k_block_len);
+  const size_t lhs_row_length = lhs_stride / sizeof(float16_t);
+
+  const float16x8_t vmax = vdupq_n_f16((float16_t)FLT16_MIN);
+  const float16x8_t vmin = vdupq_n_f16((float16_t)FLT16_MAX);
+
+  // As we load 8-element vectors, limit vectorized loop to avoid reading
+  // out-of-bounds
+  const int32_t blocks_lim_k = num_blocks_k - (8 / k_block_len);
+
+  size_t row_idx = 0;
+
+  // Improved performance with 4x loop unrolling where packing parameters allow
+  if (mr == 4) {
+    for (; row_idx + 3 < m; row_idx += 4) {
+      // Find min/max for each channel
+      int32_t k_idx = 0;
+      float16x8_t vmax0 = vmax;
+      float16x8_t vmin0 = vmin;
+      float16x8_t vmax1 = vmax;
+      float16x8_t vmin1 = vmin;
+      float16x8_t vmax2 = vmax;
+      float16x8_t vmin2 = vmin;
+      float16x8_t vmax3 = vmax;
+      float16x8_t vmin3 = vmin;
+
+      for (; k_idx <= ((int32_t)k - 8); k_idx += 8) {
+        const float16x8_t src0 = vld1q_f16(src_ptr + k_idx);
+        const float16x8_t src1 = vld1q_f16(src_ptr + k_idx + lhs_row_length);
+        const float16x8_t src2 =
+          vld1q_f16(src_ptr + k_idx + (2 * lhs_row_length));
+        const float16x8_t src3 =
+          vld1q_f16(src_ptr + k_idx + (3 * lhs_row_length));
+
+        vmax0 = vmaxq_f16(src0, vmax0);
+        vmax1 = vmaxq_f16(src1, vmax1);
+        vmax2 = vmaxq_f16(src2, vmax2);
+        vmax3 = vmaxq_f16(src3, vmax3);
+        vmin0 = vminq_f16(src0, vmin0);
+        vmin1 = vminq_f16(src1, vmin1);
+        vmin2 = vminq_f16(src2, vmin2);
+        vmin3 = vminq_f16(src3, vmin3);
+      }
+
+      float16_t max0 = vmaxvq_f16(vmax0);
+      float16_t min0 = vminvq_f16(vmin0);
+      float16_t max1 = vmaxvq_f16(vmax1);
+      float16_t min1 = vminvq_f16(vmin1);
+      float16_t max2 = vmaxvq_f16(vmax2);
+      float16_t min2 = vminvq_f16(vmin2);
+      float16_t max3 = vmaxvq_f16(vmax3);
+      float16_t min3 = vminvq_f16(vmin3);
+      // Process leftover elements with a scalar loop.
+      for (; k_idx < (int32_t)k; ++k_idx) {
+        const float16_t src0 = *(src_ptr + (size_t)k_idx);
+        max0 = vmaxh_f16(src0, max0);
+        min0 = vminh_f16(src0, min0);
+        const float16_t src1 = *(src_ptr + (size_t)k_idx + lhs_row_length);
+        max1 = vmaxh_f16(src1, max1);
+        min1 = vminh_f16(src1, min1);
+        const float16_t src2 =
+          *(src_ptr + (size_t)k_idx + (2 * lhs_row_length));
+        max2 = vmaxh_f16(src2, max2);
+        min2 = vminh_f16(src2, min2);
+        const float16_t src3 =
+          *(src_ptr + (size_t)k_idx + (3 * lhs_row_length));
+        max3 = vmaxh_f16(src3, max3);
+        min3 = vminh_f16(src3, min3);
+      }
+
+      // Maximum/minimum int8 values
+      const float qmin = (float)INT8_MIN;
+      const float qmax = (float)INT8_MAX;
+
+      const float rmin0 = fminf(0.0F, min0);
+      const float rmax0 = fmaxf(0.0F, max0);
+      const float scale0 =
+        rmin0 == rmax0 ? 1.F : (qmax - qmin) / (rmax0 - rmin0);
+      const float rmin1 = fminf(0.0F, min1);
+      const float rmax1 = fmaxf(0.0F, max1);
+      const float scale1 =
+        rmin1 == rmax1 ? 1.F : (qmax - qmin) / (rmax1 - rmin1);
+      const float rmin2 = fminf(0.0F, min2);
+      const float rmax2 = fmaxf(0.0F, max2);
+      const float scale2 =
+        rmin2 == rmax2 ? 1.F : (qmax - qmin) / (rmax2 - rmin2);
+      const float rmin3 = fminf(0.0F, min3);
+      const float rmax3 = fmaxf(0.0F, max3);
+      const float scale3 =
+        rmin3 == rmax3 ? 1.F : (qmax - qmin) / (rmax3 - rmin3);
+
+      // Reciprocal to quantize
+      const float recip_scale0 = scale0 ? 1.0F / scale0 : 0.0F;
+      const float recip_scale1 = scale1 ? 1.0F / scale1 : 0.0F;
+      const float recip_scale2 = scale2 ? 1.0F / scale2 : 0.0F;
+      const float recip_scale3 = scale3 ? 1.0F / scale3 : 0.0F;
+
+      const float descaled_min0 = rmin0 * scale0;
+      const float descaled_max0 = rmax0 * scale0;
+      const float descaled_min1 = rmin1 * scale1;
+      const float descaled_max1 = rmax1 * scale1;
+      const float descaled_min2 = rmin2 * scale2;
+      const float descaled_max2 = rmax2 * scale2;
+      const float descaled_min3 = rmin3 * scale3;
+      const float descaled_max3 = rmax3 * scale3;
+
+      const float zero_point_from_min_error0 = qmin + descaled_min0;
+      const float zero_point_from_max_error0 = qmax + descaled_max0;
+      const float zero_point_from_min_error1 = qmin + descaled_min1;
+      const float zero_point_from_max_error1 = qmax + descaled_max1;
+      const float zero_point_from_min_error2 = qmin + descaled_min2;
+      const float zero_point_from_max_error2 = qmax + descaled_max2;
+      const float zero_point_from_min_error3 = qmin + descaled_min3;
+      const float zero_point_from_max_error3 = qmax + descaled_max3;
+
+      float zero_point0 =
+        (zero_point_from_min_error0 + zero_point_from_max_error0 > 0)
+          ? qmin - descaled_min0
+          : qmax - descaled_max0;
+      float zero_point1 =
+        (zero_point_from_min_error1 + zero_point_from_max_error1 > 0)
+          ? qmin - descaled_min1
+          : qmax - descaled_max1;
+      float zero_point2 =
+        (zero_point_from_min_error2 + zero_point_from_max_error2 > 0)
+          ? qmin - descaled_min2
+          : qmax - descaled_max2;
+      float zero_point3 =
+        (zero_point_from_min_error3 + zero_point_from_max_error3 > 0)
+          ? qmin - descaled_min3
+          : qmax - descaled_max3;
+
+      zero_point0 = fmaxf(zero_point0, qmin);
+      zero_point0 = fminf(zero_point0, qmax);
+      zero_point1 = fmaxf(zero_point1, qmin);
+      zero_point1 = fminf(zero_point1, qmax);
+      zero_point2 = fmaxf(zero_point2, qmin);
+      zero_point2 = fminf(zero_point2, qmax);
+      zero_point3 = fmaxf(zero_point3, qmin);
+      zero_point3 = fminf(zero_point3, qmax);
+
+      // Round to nearest integer
+      const int32_t nudged_zero_point0 = (int32_t)rintf(zero_point0);
+      const int32_t nudged_zero_point1 = (int32_t)rintf(zero_point1);
+      const int32_t nudged_zero_point2 = (int32_t)rintf(zero_point2);
+      const int32_t nudged_zero_point3 = (int32_t)rintf(zero_point3);
+
+      const size_t dst_x = ((row_idx + m_idx_start) % mr);
+
+      uint8_t *dst_ptr = (uint8_t *)lhs_packed + (dst_x * k_block_len);
+
+      // Quantize the channels
+      int32_t block_idx = 0;
+      const int32_t block_incr = 8 / k_block_len;
+
+      for (; block_idx <= blocks_lim_k; block_idx += block_incr) {
+        // Clamp at the last valid k-index
+        const int32_t k_idx_start = block_idx * k_block_len;
+
+        const float16x8_t src0 = vld1q_f16(src_ptr + k_idx_start);
+        const float16x8_t src1 =
+          vld1q_f16(src_ptr + k_idx_start + lhs_row_length);
+        const float16x8_t src2 =
+          vld1q_f16(src_ptr + k_idx_start + (2 * lhs_row_length));
+        const float16x8_t src3 =
+          vld1q_f16(src_ptr + k_idx_start + (3 * lhs_row_length));
+
+        // Scale the values.
+        const int32x4_t v0_0_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_f32_f16(vget_low_f16(src0)), scale0));
+        const int32x4_t v0_1_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_high_f32_f16(src0), scale0));
+        const int32x4_t v1_0_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_f32_f16(vget_low_f16(src1)), scale1));
+        const int32x4_t v1_1_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_high_f32_f16(src1), scale1));
+        const int32x4_t v2_0_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_f32_f16(vget_low_f16(src2)), scale2));
+        const int32x4_t v2_1_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_high_f32_f16(src2), scale2));
+        const int32x4_t v3_0_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_f32_f16(vget_low_f16(src3)), scale3));
+        const int32x4_t v3_1_s32 =
+          vcvtq_s32_f32(vmulq_n_f32(vcvt_high_f32_f16(src3), scale3));
+
+        const int16x4_t v0_0_s16 = vqmovn_s32(v0_0_s32);
+        const int16x4_t v0_1_s16 = vqmovn_s32(v0_1_s32);
+        const int16x4_t v1_0_s16 = vqmovn_s32(v1_0_s32);
+        const int16x4_t v1_1_s16 = vqmovn_s32(v1_1_s32);
+        const int16x4_t v2_0_s16 = vqmovn_s32(v2_0_s32);
+        const int16x4_t v2_1_s16 = vqmovn_s32(v2_1_s32);
+        const int16x4_t v3_0_s16 = vqmovn_s32(v3_0_s32);
+        const int16x4_t v3_1_s16 = vqmovn_s32(v3_1_s32);
+
+        int16x8_t v0_s16;
+        int16x8_t v1_s16;
+        int16x8_t v2_s16;
+        int16x8_t v3_s16;
+        if (k_block_len == 8) {
+          v0_s16 = vcombine_s16(v0_0_s16, v0_1_s16);
+          v1_s16 = vcombine_s16(v1_0_s16, v1_1_s16);
+          v2_s16 = vcombine_s16(v2_0_s16, v2_1_s16);
+          v3_s16 = vcombine_s16(v3_0_s16, v3_1_s16);
+        } else { // k_block_len == 4
+          v0_s16 = vcombine_s16(v0_0_s16, v1_0_s16);
+          v1_s16 = vcombine_s16(v2_0_s16, v3_0_s16);
+          v2_s16 = vcombine_s16(v0_1_s16, v1_1_s16);
+          v3_s16 = vcombine_s16(v2_1_s16, v3_1_s16);
+        }
+
+        // Add zero points.
+        const int16x8_t vnzp0 = vdupq_n_s16((int16_t)nudged_zero_point0);
+        const int16x8_t vnzp1 = vdupq_n_s16((int16_t)nudged_zero_point1);
+        const int16x8_t vnzp2 = vdupq_n_s16((int16_t)nudged_zero_point2);
+        const int16x8_t vnzp3 = vdupq_n_s16((int16_t)nudged_zero_point3);
+
+        v0_s16 = vaddq_s16(v0_s16, vnzp0);
+        v0_s16 = vmaxq_s16(v0_s16, vdupq_n_s16(INT8_MIN));
+        v0_s16 = vminq_s16(v0_s16, vdupq_n_s16(INT8_MAX));
+        v1_s16 = vaddq_s16(v1_s16, vnzp1);
+        v1_s16 = vmaxq_s16(v1_s16, vdupq_n_s16(INT8_MIN));
+        v1_s16 = vminq_s16(v1_s16, vdupq_n_s16(INT8_MAX));
+        v2_s16 = vaddq_s16(v2_s16, vnzp2);
+        v2_s16 = vmaxq_s16(v2_s16, vdupq_n_s16(INT8_MIN));
+        v2_s16 = vminq_s16(v2_s16, vdupq_n_s16(INT8_MAX));
+        v3_s16 = vaddq_s16(v3_s16, vnzp3);
+        v3_s16 = vmaxq_s16(v3_s16, vdupq_n_s16(INT8_MIN));
+        v3_s16 = vminq_s16(v3_s16, vdupq_n_s16(INT8_MAX));
+
+        int8x8_t v0_s8 = vqmovn_s16(v0_s16);
+        int8x8_t v1_s8 = vqmovn_s16(v1_s16);
+        int8x8_t v2_s8 = vqmovn_s16(v2_s16);
+        int8x8_t v3_s8 = vqmovn_s16(v3_s16);
+
+        vst1_s8((int8_t *)(dst_ptr), v0_s8);
+        vst1_s8((int8_t *)(dst_ptr + sizeof(int8x8_t)), v1_s8);
+        vst1_s8((int8_t *)(dst_ptr + 2 * sizeof(int8x8_t)), v2_s8);
+        vst1_s8((int8_t *)(dst_ptr + 3 * sizeof(int8x8_t)), v3_s8);
+        dst_ptr += block_incr * mr * k_block_len * sizeof(int8_t);
+      }
+
+      for (; block_idx < num_blocks_k_internal; ++block_idx) {
+        // left over k
+        for (int32_t k_block_idx = 0; k_block_idx < k_block_len;
+             ++k_block_idx) {
+          // Clamp at the last valid k-index.
+          const size_t k_idx_start =
+            KAI_MIN((size_t)((block_idx * k_block_len) + k_block_idx), k - 1);
+
+          const float src0 = (float)(*(src_ptr + k_idx_start));
+          const float src1 = (float)(*(src_ptr + k_idx_start + lhs_row_length));
+          const float src2 =
+            (float)(*(src_ptr + k_idx_start + (2 * lhs_row_length)));
+          const float src3 =
+            (float)(*(src_ptr + k_idx_start + (3 * lhs_row_length)));
+
+          // Scale the value.
+          int32_t d0_s32 = (int32_t)(roundf(src0 * scale0));
+          int32_t d1_s32 = (int32_t)(roundf(src1 * scale1));
+          int32_t d2_s32 = (int32_t)(roundf(src2 * scale2));
+          int32_t d3_s32 = (int32_t)(roundf(src3 * scale3));
+
+          d0_s32 = d0_s32 + nudged_zero_point0;
+          d0_s32 = KAI_MAX(d0_s32, INT8_MIN);
+          d0_s32 = KAI_MIN(d0_s32, INT8_MAX);
+
+          d1_s32 = d1_s32 + nudged_zero_point1;
+          d1_s32 = KAI_MAX(d1_s32, INT8_MIN);
+          d1_s32 = KAI_MIN(d1_s32, INT8_MAX);
+
+          d2_s32 = d2_s32 + nudged_zero_point2;
+          d2_s32 = KAI_MAX(d2_s32, INT8_MIN);
+          d2_s32 = KAI_MIN(d2_s32, INT8_MAX);
+
+          d3_s32 = d3_s32 + nudged_zero_point3;
+          d3_s32 = KAI_MAX(d3_s32, INT8_MIN);
+          d3_s32 = KAI_MIN(d3_s32, INT8_MAX);
+
+          *(int8_t *)dst_ptr = (int8_t)d0_s32;
+          *(int8_t *)(dst_ptr + k_block_len * sizeof(int8_t)) = (int8_t)d1_s32;
+          *(int8_t *)(dst_ptr + 2 * (k_block_len * sizeof(int8_t))) =
+            (int8_t)d2_s32;
+          *(int8_t *)(dst_ptr + 3 * (k_block_len * sizeof(int8_t))) =
+            (int8_t)d3_s32;
+          dst_ptr += sizeof(int8_t);
+        }
+        dst_ptr += (mr - 1) * k_block_len * sizeof(int8_t);
+      }
+
+      uint8_t *dst_base =
+        (uint8_t *)lhs_packed + mr * (k_internal * sizeof(int8_t));
+
+      dst_ptr = dst_base + dst_x * kai_num_bytes_per_offset;
+
+      // LHS offset at the beginning of the row.
+      *((int32_t *)(dst_ptr)) = -nudged_zero_point0;
+      *((int32_t *)(dst_ptr + kai_num_bytes_per_offset)) = -nudged_zero_point1;
+      *((int32_t *)(dst_ptr + 2 * kai_num_bytes_per_offset)) =
+        -nudged_zero_point2;
+      *((int32_t *)(dst_ptr + 3 * kai_num_bytes_per_offset)) =
+        -nudged_zero_point3;
+
+      // Assuming the same sizeof() for kai_num_bytes_per_offset and
+      // kai_num_bytes_per_multiplier.
+      KAI_ASSERT(kai_num_bytes_per_offset == kai_num_bytes_per_multiplier);
+
+      dst_ptr += mr * kai_num_bytes_per_offset;
+
+      // Store the scale quantization params.
+      *((float *)(dst_ptr)) = recip_scale0;
+      *((float *)(dst_ptr + kai_num_bytes_per_multiplier)) = recip_scale1;
+      *((float *)(dst_ptr + 2 * kai_num_bytes_per_multiplier)) = recip_scale2;
+      *((float *)(dst_ptr + 3 * kai_num_bytes_per_multiplier)) = recip_scale3;
+
+      // Update src_ptr. Note: now lhs contains fp16 values (2 bytes each).
+      src_ptr += (4 * lhs_row_length);
+
+      // Move to the next row as we have interleaved all Mr rows.
+      lhs_packed = (void *)((uint8_t *)lhs_packed + dst_stride);
+    }
+  }
+
+  for (; row_idx < num_rows; ++row_idx) {
+    // Find min/max for each channel
+    int32_t k_idx = 0;
+    float16x8_t vmax0 = vmax;
+    float16x8_t vmin0 = vmin;
+
+    for (; k_idx <= ((int32_t)k - 8); k_idx += 8) {
+      const float16x8_t src0_0 = vld1q_f16(src_ptr + (size_t)k_idx);
+      vmax0 = vmaxq_f16(vmax0, src0_0);
+      vmin0 = vminq_f16(vmin0, src0_0);
+    }
+    // Get the max/min
+    float16_t max0 = vmaxvq_f16(vmax0);
+    float16_t min0 = vminvq_f16(vmin0);
+
+    for (; k_idx < (int32_t)k; ++k_idx) {
+      const float16_t src0 = *(src_ptr + (size_t)k_idx);
+      max0 = vmaxh_f16(src0, max0);
+      min0 = vminh_f16(src0, min0);
+    }
+
+    // Maximum/minimum int8 values
+    const float qmin = (float)INT8_MIN;
+    const float qmax = (float)INT8_MAX;
+
+    const float rmin0 = fminf(0.0F, min0);
+    const float rmax0 = fmaxf(0.0F, max0);
+    const float scale0 = rmin0 == rmax0 ? 1.F : (qmax - qmin) / (rmax0 - rmin0);
+
+    // Reciprocal to quantize
+    const float recip_scale0 = scale0 ? 1.0F / scale0 : 0.0F;
+
+    const float descaled_min0 = rmin0 * scale0;
+    const float descaled_max0 = rmax0 * scale0;
+
+    const float zero_point_from_min_error0 = qmin + descaled_min0;
+    const float zero_point_from_max_error0 = qmax + descaled_max0;
+
+    float zero_point0 =
+      zero_point_from_min_error0 + zero_point_from_max_error0 > 0
+        ? qmin - descaled_min0
+        : qmax - descaled_max0;
+
+    zero_point0 = fmaxf(zero_point0, qmin);
+    zero_point0 = fminf(zero_point0, qmax);
+
+    // Round to nearest integer
+    const int32_t nudged_zero_point0 = (int32_t)rintf(zero_point0);
+
+    const size_t dst_x = ((row_idx + m_idx_start) % mr);
+
+    uint8_t *dst_ptr =
+      (uint8_t *)lhs_packed + (dst_x * k_block_len * sizeof(int8_t));
+
+    // Quantize the channels
+    int32_t block_idx = 0;
+    if (k_block_len == 8) {
+      for (; block_idx < blocks_lim_k; ++block_idx) {
+        const int32_t k_idx_start = block_idx * k_block_len;
+
+        const float16x8_t src_0 = vld1q_f16(src_ptr + k_idx_start);
+
+        // Scale the values
+        const float32x4_t v0_f32 =
+          vmulq_n_f32(vcvt_f32_f16(vget_low_f16(src_0)), scale0);
+        const float32x4_t v1_f32 =
+          vmulq_n_f32(vcvt_high_f32_f16(src_0), scale0);
+        const int32x4_t v0_s32 = vcvtnq_s32_f32(v0_f32);
+        const int32x4_t v1_s32 = vcvtnq_s32_f32(v1_f32);
+
+        const int16x4_t v0_s16 = vqmovn_s32(v0_s32);
+        const int16x4_t v1_s16 = vqmovn_s32(v1_s32);
+        int16x8_t v_s16 = vcombine_s16(v0_s16, v1_s16);
+
+        // Add zero points
+        int16_t nzp_s16 = (int16_t)nudged_zero_point0;
+        int16x8_t vnzp_s16 = vdupq_n_s16(nzp_s16);
+        v_s16 = vaddq_s16(v_s16, vnzp_s16);
+        v_s16 = vmaxq_s16(v_s16, vdupq_n_s16(INT8_MIN));
+        v_s16 = vminq_s16(v_s16, vdupq_n_s16(INT8_MAX));
+
+        int8x8_t v_s8 = vqmovn_s16(v_s16);
+        vst1_s8((int8_t *)(dst_ptr), v_s8);
+
+        dst_ptr += mr * k_block_len * sizeof(int8_t);
+      }
+    } else if (k_block_len == 4) {
+      for (; block_idx < blocks_lim_k; ++block_idx) {
+        const int32_t k_idx_start = block_idx * k_block_len;
+
+        const float16x4_t src_0 = vld1_f16(src_ptr + k_idx_start);
+
+        // Scale the values
+        const float32x4_t v0_f32 = vmulq_n_f32(vcvt_f32_f16(src_0), scale0);
+        const int32x4_t v0_s32 = vcvtnq_s32_f32(v0_f32);
+
+        int16x4_t v0_s16 = vqmovn_s32(v0_s32);
+
+        // Add zero points
+        int16_t nzp_s16 = (int16_t)nudged_zero_point0;
+        int16x4_t vnzp_s16 = vdup_n_s16(nzp_s16);
+        v0_s16 = vadd_s16(v0_s16, vnzp_s16);
+        v0_s16 = vmax_s16(v0_s16, vdup_n_s16(INT8_MIN));
+        v0_s16 = vmin_s16(v0_s16, vdup_n_s16(INT8_MAX));
+
+        int8x8_t v_s8 = vqmovn_s16(vcombine_s16(v0_s16, vdup_n_s16(0)));
+
+        *((int8_t *)(dst_ptr)) = vget_lane_s8(v_s8, 0);
+        *((int8_t *)(dst_ptr + 1)) = vget_lane_s8(v_s8, 1);
+        *((int8_t *)(dst_ptr + 2)) = vget_lane_s8(v_s8, 2);
+        *((int8_t *)(dst_ptr + 3)) = vget_lane_s8(v_s8, 3);
+
+        dst_ptr += mr * k_block_len * sizeof(int8_t);
+      }
+    }
+
+    for (; block_idx < num_blocks_k_internal; ++block_idx) {
+      // left over k
+      for (int32_t k_block_idx = 0; k_block_idx < k_block_len; ++k_block_idx) {
+        // Clamp at the last valid k-index
+        const size_t k_idx_start =
+          KAI_MIN((size_t)((block_idx * k_block_len) + k_block_idx), k - 1);
+
+        const float src0 = (float)(*(src_ptr + k_idx_start));
+
+        // Scale the values
+        int32_t d0_s32 = (int32_t)(roundf(src0 * scale0));
+
+        d0_s32 = d0_s32 + nudged_zero_point0;
+        d0_s32 = KAI_MAX(d0_s32, INT8_MIN);
+        d0_s32 = KAI_MIN(d0_s32, INT8_MAX);
+
+        *((int8_t *)(dst_ptr)) = (int8_t)d0_s32;
+        dst_ptr += sizeof(int8_t);
+      }
+      dst_ptr += (mr - 1) * k_block_len * sizeof(int8_t);
+    }
+
+    dst_ptr = (uint8_t *)lhs_packed + mr * (k_internal * sizeof(int8_t));
+
+    dst_ptr += dst_x * kai_num_bytes_per_offset;
+
+    // LHS offset at the beginning of the row
+    *((int32_t *)(dst_ptr)) = -nudged_zero_point0;
+
+    // Assuming the same sizeof() for kai_num_bytes_per_offset and
+    // kai_num_bytes_per_multiplier
+    KAI_ASSERT(kai_num_bytes_per_offset == kai_num_bytes_per_multiplier);
+
+    dst_ptr += mr * kai_num_bytes_per_offset;
+
+    // Store the scale quantization params
+    *((float *)(dst_ptr)) = recip_scale0;
+
+    src_ptr += lhs_row_length;
+
+    // Move to the next row if we have interleaved all Mr rows
+    if ((((row_idx + 1) + m_idx_start) % mr) == 0) {
+      lhs_packed = (void *)((uint8_t *)lhs_packed + dst_stride);
+    }
+  }
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.h
@@ -1,0 +1,102 @@
+/**
+ * @file kai_lhs_quant_pack_qai8dxp_f16_neon.h
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_lhs_quant_pack_qai8dxp_f16_neon.h copied from kleidiai
+ *
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <arm_fp16.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @param[in] mr The number of M rows to interleave on the same output row.
+///
+/// @return the m step value
+size_t kai_get_m_step_lhs_quant_pack_qai8dxp_f16_neon(size_t mr);
+
+/// Gets the offset in bytes for the LHS matrix (not packed)
+///
+/// This function should be called before passing the pointer to the LHS matrix
+/// to the micro-kernel.
+///
+/// @param[in] m_idx      Row index in the LHS matrix (not packed).
+/// @param[in] lhs_stride The number of bytes in in each row of the LHS matrix
+/// (not packed)
+///
+/// @return the offset in bytes to the LHS matrix
+size_t kai_get_lhs_offset_lhs_quant_pack_qai8dxp_f16_neon(size_t m_idx,
+                                                          size_t lhs_stride);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed 8-bit quantized asymmetric per-row (qa8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed).
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+/// @param[in] mr    The number of M rows to interleave on the same output row.
+/// @param[in] kr    The number of columns loaded in the single inner most loop
+/// of the matmul micro-kernel.
+/// @param[in] sr    The number of kr splits. It can be 1 (no splits) up to kr.
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f16_neon(
+  size_t m_idx, size_t k, size_t mr, size_t kr, size_t sr);
+
+/// Gets the size in bytes for the quantized and packed LHS matrix
+///
+/// @param[in] m  Total number of rows in the LHS matrix (not packed).
+/// @param[in] k  Total number of columns in the LHS matrix (not packed).
+/// @param[in] mr The number of M rows to interleave on the same output row.
+/// @param[in] kr The number of columns loaded in the single inner most loop of
+/// the matmul micro-kernel.
+/// @param[in] sr The number of kr splits. It can be 1 (no splits) up to kr.
+///
+/// @return the packed LHS matrix size in bytes
+size_t kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f16_neon(
+  size_t m, size_t k, size_t mr, size_t kr, size_t sr);
+
+/// Run the micro-kernel to quantize and pack the LHS matrix.
+///
+/// @param[in]  m           The number of output rows written.
+/// @param[in]  k           The number of channels. The common dimension of LHS
+/// & RHS. It must be multiple of 8.
+/// @param[in]  mr          The number of M rows to interleave on the same
+/// output row.
+/// @param[in]  kr          The number of columns loaded in the single inner
+/// most loop of the matmul micro-kernel.
+/// @param[in]  sr          The number of kr splits. It can be 1 (no splits) up
+/// to kr.
+///                         However, kr must be multiple of sr.
+/// @param[in]  m_idx_start The starting M index.
+/// @param[in]  lhs         LHS of the vector-by-matrix.
+/// @param[in]  lhs_stride  Stride in bytes between two rows of LHS.
+/// @param[out] lhs_packed  The quantized and packed LHS matrix.
+void kai_run_lhs_quant_pack_qai8dxp_f16_neon(size_t m, size_t k, size_t mr,
+                                             size_t kr, size_t sr,
+                                             size_t m_idx_start,
+                                             const void *lhs, size_t lhs_stride,
+                                             void *lhs_packed);
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
@@ -20,6 +20,16 @@ pack_headers = [
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h',
 ]
 
+if get_option('enable-fp16')
+pack_sources += [
+  'kai_lhs_quant_pack_qai8dxp_f16_neon.c',
+]
+
+pack_headers += [
+  'kai_lhs_quant_pack_qai8dxp_f16_neon.h',
+]
+endif
+
 foreach s : pack_sources
   nntrainer_sources += meson.current_source_dir() / s
 endforeach

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface.h
@@ -123,6 +123,100 @@ void __kai_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                 float lower_bound = -FLT_MAX,
                                 float upper_bound = FLT_MAX);
 
+#ifdef ENABLE_FP16
+/**
+ * matmul_clamp_f16_qai8dxp_qsi4cxp
+ */
+
+/**
+ * @brief get name of ukernel
+ *
+ * @param[in] idx_variant index of ukernel
+ * @return std::string name of ukernel
+ */
+std::string __kai_get_num_ukernel_name_f16_qai8dxp_qsi4cxp(size_t idx_variant);
+
+/**
+ * @brief get number of ukernels
+ *
+ * @return size_t number of ukernels
+ */
+size_t __kai_get_num_ukernel_variants_f16_qai8dxp_qsi4cxp();
+
+/**
+ * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
+ * qsi4cxp
+ * Note that nxk is the format of quantized rhs, not the shape of rhs
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ * @return size_t size of memory to allocate
+ */
+size_t __kai_get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                                       size_t idx_variant,
+                                                       bool is_nxk);
+
+/**
+ * @brief rhs matrix packing from nxk qs4cxs1s0 to qsi4cxp
+ * Note that rhs_qs4cx must be stored with UINT4 shape (zero point = 8)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[out] rhs_packed_mtx_qs4cx packed rhs
+ * @param[in] rhs_native_mtx_qs4cx quantized matrix data
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ */
+void __kai_rhs_pack_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                          void *rhs_packed_mtx_qs4cx,
+                                          void *rhs_native_mtx_qs4cx,
+                                          void *rhs_scales_f32,
+                                          size_t idx_variant, bool is_nxk);
+
+/**
+ * @brief run f16_qai8dxp_qsi4cxp GEMM with online rhs packing
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f16 matrix data (F16)
+ * @param[in] rhs_native_mtx_qs4cx quantized matrix data
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[out] dst_act_mtx_f16 output data (F16)
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void __kai_gemm_f16_qai8dxp_qsi4cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f16,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, void *dst_act_mtx_f16,
+  size_t idx_variant, bool is_nxk, float lower_bound = -FLT_MAX,
+  float upper_bound = FLT_MAX);
+
+/**
+ * @brief run f16_qai8dxp_qsi4cxp GEMM with offline packed rhs
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f16 matrix data (F16)
+ * @param[in] rhs_packed_mtx_qs4cx quantized matrix data, packed already
+ * @param[out] dst_act_mtx_f16 output data (F16)
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void __kai_gemm_f16_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                                    void *lhs_native_mtx_f16,
+                                    void *rhs_packed_mtx_qs4cx,
+                                    void *dst_act_mtx_f16, size_t idx_variant,
+                                    float lower_bound = -FLT_MAX,
+                                    float upper_bound = FLT_MAX);
+#endif // ENABLE_FP16
 } // namespace nntrainer
 
 /**

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp
@@ -1,0 +1,330 @@
+/**
+ * Copyright (C) 2024 Arm Limited and/or its affiliates
+ *
+ * @file   kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ *
+ * @brief  Modified computational backend components of
+ * kleidiai. Portions of this file are derived from Arm
+ * Limited code licensed under the Apache License, Version 2.0, with
+ * modifications
+ *
+ * @note   Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @modifications
+ *   - [2026-07-21] Integrated and adapted Arm-provided code into
+ *     nntrainer CPU backend for FP16 support
+ *
+ * @bug    No known bugs except for NYI items
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <kleidiai_interface.h>
+#include <thread_manager.h>
+
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp_qsi4cxp_interface.h"
+
+// Include micro-kernel variants
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod.h"
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod.h"
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod.h"
+
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h"
+#endif
+
+// Include packing kernels
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.h"
+#include "kai/pack/kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.h"
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h"
+
+#define INT4_MIN (-8)
+#define INT4_MAX (7)
+
+namespace {
+
+// Micro-kernel interface
+/**
+ * @brief kai_matmul_ukernel_f16_qa8dxp_qs4cxp
+ */
+struct kai_matmul_ukernel_f16_qa8dxp_qs4cxp {
+  kai_matmul_clamp_f16_qai8dxp_qsi4cxp_ukernel ukernel;
+  std::string name = {};
+};
+
+kai_matmul_ukernel_f16_qa8dxp_qs4cxp ukernel_variants[] = {
+  {kai_get_m_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   kai_run_matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod,
+   "matmul_clamp_f16_qai8dxp1x4_qsi4cxp4x4_1x4_neon_dotprod"},
+  {kai_get_m_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   kai_run_matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod,
+   "matmul_clamp_f16_qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod"},
+  {kai_get_m_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   kai_run_matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod,
+   "matmul_clamp_f16_qai8dxp4x4_qsi4cxp4x4_16x4_neon_dotprod"},
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+  {kai_get_m_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_n_step_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_mr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_nr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_kr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_sr_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_lhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_rhs_packed_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_dst_offset_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_get_dst_size_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   kai_run_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm,
+   "matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm"},
+#endif
+
+};
+
+const size_t num_ukernel_variants =
+  sizeof(ukernel_variants) / sizeof(ukernel_variants[0]);
+} // namespace
+
+namespace nntrainer {
+std::string __kai_get_num_ukernel_name_f16_qai8dxp_qsi4cxp(size_t idx_variant) {
+  return ukernel_variants[idx_variant].name;
+}
+
+size_t __kai_get_num_ukernel_variants_f16_qai8dxp_qsi4cxp() {
+  return num_ukernel_variants;
+}
+
+size_t __kai_get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                                       size_t idx_variant,
+                                                       bool is_nxk) {
+  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  if (is_nxk) {
+    return kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(n, k, nr, kr,
+                                                                  sr);
+  } else {
+    return kai_get_rhs_packed_size_rhs_pack_kxn_qsi4cxp_qs4cxs1s0(n, k, nr, kr,
+                                                                  sr);
+  }
+}
+
+void __kai_rhs_pack_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                          void *rhs_packed_mtx_qs4cx,
+                                          void *rhs_native_mtx_qs4cx,
+                                          void *rhs_scales_f32,
+                                          size_t idx_variant, bool is_nxk) {
+  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  if (is_nxk) {
+    struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params nxk_params;
+    nxk_params.lhs_zero_point = 1;
+    nxk_params.rhs_zero_point = 8;
+
+    // use custom optimized rhs pack
+    kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon(
+      1, n, k, nr, kr, sr,                     // Packing arguments
+      (const uint8_t *)(rhs_native_mtx_qs4cx), // RHS
+      NULL,                                    // Bias
+      (const float *)(rhs_scales_f32),         // Scale
+      rhs_packed_mtx_qs4cx,                    // RHS packed
+      0, &nxk_params);
+  } else {
+    struct kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0_params kxn_params;
+    kxn_params.lhs_zero_point = 1;
+    kxn_params.rhs_zero_point = 8;
+    // RHS packing
+    kai_run_rhs_pack_kxn_qsi4cxp_qs4cxs1s0(
+      1, n, k, nr, kr, sr,                     // Packing arguments
+      (const uint8_t *)(rhs_native_mtx_qs4cx), // RHS
+      NULL,                                    // Bias
+      (const float *)(rhs_scales_f32),         // Scale
+      rhs_packed_mtx_qs4cx,                    // RHS packed
+      0, &kxn_params);
+  }
+}
+
+void __kai_gemm_f16_qai8dxp_qsi4cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f16,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, void *dst_act_mtx_f16,
+  size_t idx_variant, bool is_nxk, float lower_bound, float upper_bound) {
+  // Get the size in bytes for the packed matrices
+  const size_t rhs_packed_size =
+    __kai_get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(n, k, idx_variant, is_nxk);
+
+  // Allocate the matrices
+  uint8_t *rhs_packed_mtx_qs4cx = new uint8_t[rhs_packed_size];
+
+  // RHS packing
+  __kai_rhs_pack_f16_qsi4cxp_qs4cxs1s0(n, k, rhs_packed_mtx_qs4cx,
+                                       rhs_native_mtx_qs4cx, rhs_scales_f32,
+                                       idx_variant, is_nxk);
+
+  // call packed gemm
+  __kai_gemm_f16_qai8dxp_qsi4cxp(m, n, k, lhs_native_mtx_f16,
+                                 rhs_packed_mtx_qs4cx, dst_act_mtx_f16,
+                                 idx_variant, lower_bound, upper_bound);
+
+  delete[] rhs_packed_mtx_qs4cx;
+}
+
+void __kai_gemm_f16_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                                    void *lhs_native_mtx_f16,
+                                    void *rhs_packed_mtx_qs4cx,
+                                    void *dst_act_mtx_f16, size_t idx_variant,
+                                    float lower_bound, float upper_bound) {
+  const size_t mr = ukernel_variants[idx_variant].ukernel.get_mr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  // LHS packing
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f16_neon(m, k, mr, kr, sr);
+  uint8_t *lhs_packed_mtx_qa8dx = new uint8_t[lhs_packed_size];
+
+  size_t m_step = ukernel_variants[idx_variant].ukernel.get_m_step();
+  size_t m_loop = (m + m_step - 1) / m_step;
+
+  size_t n_step = ukernel_variants[idx_variant].ukernel.get_n_step();
+  size_t n_loop = (n + n_step - 1) / n_step;
+
+  auto &tm = nntrainer::ThreadManager::Global();
+
+  /// @todo find better heuristic
+  if (m_step > n_step) {
+    // parallelize over m
+    tm.parallel_for(0, m_loop, [&](size_t i) {
+      size_t m_start = i * m_step;
+      size_t m_to_process = std::min(m_step, m - m_start);
+
+      size_t lhs_offset = m_start * k;
+      uint16_t *lhs_ptr = (uint16_t *)lhs_native_mtx_f16 + lhs_offset;
+
+      const size_t lhs_packed_offset =
+        ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+
+      // LHS packing
+      kai_run_lhs_quant_pack_qai8dxp_f16_neon(
+        m_to_process, k,      // Dimensions
+        mr, kr, sr, 0,        // Packing arguments
+        lhs_ptr,              // LHS
+        k * sizeof(uint16_t), // LHS stride
+        lhs_packed_ptr);      // LHS packed
+
+      const size_t rhs_packed_offset =
+        ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(0, k);
+      const void *rhs_packed_ptr =
+        (const void *)((const char *)rhs_packed_mtx_qs4cx + rhs_packed_offset);
+
+      const size_t dst_stride = n * sizeof(uint16_t);
+      const size_t dst_offset =
+        ukernel_variants[idx_variant].ukernel.get_dst_offset(m_start, 0,
+                                                             dst_stride);
+      void *dst_ptr = (void *)((uint8_t *)dst_act_mtx_f16 + dst_offset);
+
+      ukernel_variants[idx_variant].ukernel.run_matmul(
+        m_to_process, n, k,      // Dimensions
+        lhs_packed_ptr,          // LHS packed
+        rhs_packed_ptr,          // RHS packed
+        dst_ptr,                 // DST
+        dst_stride,              // DST stride (row)
+        sizeof(uint16_t),        // DST stride (col)
+        lower_bound, upper_bound // Min and max for the clamp operation
+      );
+    });
+  } else {
+    // parallelize over m
+    tm.parallel_for(0, m_loop, [&](size_t i) {
+      size_t m_start = i * m_step;
+      size_t m_to_process = std::min(m_step, m - m_start);
+
+      size_t lhs_offset = m_start * k;
+      uint16_t *lhs_ptr = (uint16_t *)lhs_native_mtx_f16 + lhs_offset;
+
+      const size_t lhs_packed_offset =
+        ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+
+      // LHS packing
+      kai_run_lhs_quant_pack_qai8dxp_f16_neon(
+        m_to_process, k,      // Dimensions
+        mr, kr, sr, 0,        // Packing arguments
+        lhs_ptr,              // LHS
+        k * sizeof(uint16_t), // LHS stride
+        lhs_packed_ptr);      // LHS packed
+    });
+
+    // parallelize over n
+    tm.parallel_for(0, n_loop, [&](size_t i) {
+      size_t n_start = i * n_step;
+      size_t n_to_process = std::min(n_step, n - n_start);
+
+      uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx;
+
+      const size_t rhs_packed_offset =
+        ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_start, k);
+      const void *rhs_packed_ptr =
+        (const void *)((const char *)rhs_packed_mtx_qs4cx + rhs_packed_offset);
+
+      const size_t dst_stride = n * sizeof(uint16_t);
+      const size_t dst_offset =
+        ukernel_variants[idx_variant].ukernel.get_dst_offset(0, n_start,
+                                                             dst_stride);
+      void *dst_ptr = (void *)((uint8_t *)dst_act_mtx_f16 + dst_offset);
+
+      ukernel_variants[idx_variant].ukernel.run_matmul(
+        m, n_to_process, k,      // Dimensions
+        lhs_packed_ptr,          // LHS packed
+        rhs_packed_ptr,          // RHS packed
+        dst_ptr,                 // DST
+        dst_stride,              // DST stride (row)
+        sizeof(uint16_t),        // DST stride (col)
+        lower_bound, upper_bound // Min and max for the clamp operation
+      );
+    });
+  }
+
+  delete[] lhs_packed_mtx_qa8dx;
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/meson.build
@@ -6,6 +6,12 @@ kai_interface_sources = [
     'kleidiai_interface_qsi8d32p_qsi4c32p.cpp',
 ]
 
+if get_option('enable-fp16')
+kai_interface_sources += [
+  'kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp',
+]
+endif
+
 subdir('kai')
 nntrainer_inc += include_directories('kai')
 nntrainer_inc_abs += meson.current_source_dir() / 'kai'

--- a/test/unittest/unittest_nntrainer_kleidiai.cpp
+++ b/test/unittest/unittest_nntrainer_kleidiai.cpp
@@ -210,6 +210,105 @@ INSTANTIATE_TEST_SUITE_P(
     return ret;
   });
 
+#ifdef ENABLE_FP16
+
+void test_f16_qai8dxp_qsi4cxp_cosine_similarity(size_t M, size_t N, size_t K) {
+  constexpr double cosine_threshold = 0.99;
+
+  std::vector<float> activation_f32 = generate_random_vector<float>(M * K);
+  std::vector<__fp16> activation_f16(M * K);
+  for (size_t i = 0; i < M * K; i++) {
+    activation_f16[i] = static_cast<__fp16>(activation_f32[i]);
+  }
+
+  std::vector<float> weight = generate_random_vector<float>(N * K);
+  std::vector<float> ref_dst(M * N);
+  std::vector<__fp16> dst_f16(M * N);
+  std::vector<float> dst(M * N);
+
+  const size_t rhs_native_size_qs4cx = N * (K + 1) / 2 * sizeof(uint8_t);
+  const size_t rhs_scales_size_f32 = N * sizeof(float);
+
+  uint8_t *rhs_native_mtx_qs4cx = new uint8_t[rhs_native_size_qs4cx];
+  uint8_t *rhs_scales_f32 = new uint8_t[rhs_scales_size_f32];
+
+  nntrainer::quant_qs4cx_f32(N, K, weight.data(), rhs_native_mtx_qs4cx,
+                             rhs_scales_f32, true);
+
+  // Calculate reference output using pure F32xF32->F32 GEMM/GEMV
+  if (M == 1) {
+    // GEMV: ref_dst[n] = sum_k(activation_f32[k] * weight[n, k])
+    for (size_t n = 0; n < N; n++) {
+      float sum = 0.0f;
+      for (size_t k = 0; k < K; k++) {
+        sum += activation_f32[k] * weight[n * K + k];
+      }
+      ref_dst[n] = sum;
+    }
+  } else {
+    // GEMM: ref_dst[m, n] = sum_k(activation_f32[m, k] * weight[n, k])
+    for (size_t m = 0; m < M; m++) {
+      for (size_t n = 0; n < N; n++) {
+        float sum = 0.0f;
+        for (size_t k = 0; k < K; k++) {
+          sum += activation_f32[m * K + k] * weight[n * K + k];
+        }
+        ref_dst[m * N + n] = sum;
+      }
+    }
+  }
+
+  const size_t num_idx_variants =
+    nntrainer::__kai_get_num_ukernel_variants_f16_qai8dxp_qsi4cxp();
+  size_t max_rhs_packed_size = 0;
+  for (size_t idx_variant = 0; idx_variant < num_idx_variants; idx_variant++) {
+    size_t rhs_packed_size =
+      nntrainer::__kai_get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(
+        N, K, idx_variant, true);
+    max_rhs_packed_size = std::max(max_rhs_packed_size, rhs_packed_size);
+  }
+
+  uint8_t *rhs_packed_mtx_qs4cx = new uint8_t[max_rhs_packed_size];
+
+  // Test each F16 variant
+  for (size_t idx_variant = 0; idx_variant < num_idx_variants; idx_variant++) {
+    nntrainer::__kai_rhs_pack_f16_qsi4cxp_qs4cxs1s0(
+      N, K, rhs_packed_mtx_qs4cx, rhs_native_mtx_qs4cx, rhs_scales_f32,
+      idx_variant, true);
+
+    // Direct F16 GEMM call (outputs __fp16)
+    nntrainer::__kai_gemm_f16_qai8dxp_qsi4cxp(M, N, K, activation_f16.data(),
+                                              rhs_packed_mtx_qs4cx,
+                                              dst_f16.data(), idx_variant);
+
+    // Convert F16 output to F32 for cosine similarity comparison
+    for (size_t i = 0; i < M * N; i++) {
+      dst[i] = static_cast<float>(dst_f16[i]);
+    }
+
+    // Compute cosine similarity
+    double cosine_sim = cosine_similarity(ref_dst.data(), dst.data(), M * N);
+
+    // Expect high cosine similarity (directional alignment)
+    EXPECT_GE(cosine_sim, cosine_threshold)
+      << "Low cosine similarity at F16 variant " << idx_variant;
+  }
+
+  delete[] rhs_packed_mtx_qs4cx;
+  delete[] rhs_native_mtx_qs4cx;
+  delete[] rhs_scales_f32;
+}
+
+TEST(nntrainer_kleidiai, gemv_f16_qai8dxp_qsi4cxp_cosine_similarity) {
+  test_f16_qai8dxp_qsi4cxp_cosine_similarity(1, 512, 3072);
+}
+
+TEST(nntrainer_kleidiai, gemm_f16_qai8dxp_qsi4cxp_cosine_similarity) {
+  test_f16_qai8dxp_qsi4cxp_cosine_similarity(768, 768, 768);
+}
+
+#endif
+
 /**
  * @brief Clean and invalidate the given buffer from the caches.
  */


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[kleidiai] Add matmul_clamp_f16_qai8dxp_qsi4cxp</summary><br />

- Add ukernels for matmul_clamp_f16_qai8dxp_qsi4cxp
- Add pack kernel for matmul_clamp_f16_qai8dxp_qsi4cxp
- Add unittest for gemm / gemv

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
This PR updates the following kleidiai kernel
- lhs: FP16 -> channel wise int 8
- rhs: channel wise int 4
- out: FP16

Note that this kernel is effectively available for android only.
- other platforms doesn't use aarch64 + FP16 as of now

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>