### PR TITLE
[ThreadManager] Prevent nested parallel deadlock

### DIFF
--- a/nntrainer/utils/thread_manager.cpp
+++ b/nntrainer/utils/thread_manager.cpp
@@ -32,11 +32,27 @@ inline size_t modulo_decrement(size_t i, size_t n) {
   return i - 1;
 }
 
+class ParallelRegionGuard {
+public:
+  explicit ParallelRegionGuard(bool &in_parallel_region) :
+    in_parallel_region_(in_parallel_region),
+    previous_value_(in_parallel_region) {
+    in_parallel_region_ = true;
+  }
+
+  ~ParallelRegionGuard() { in_parallel_region_ = previous_value_; }
+
+private:
+  bool &in_parallel_region_;
+  bool previous_value_;
+};
+
 } // namespace
 
 namespace nntrainer {
 
 ThreadManagerConfig ThreadManager::config_ = {};
+thread_local bool ThreadManager::in_parallel_region_ = false;
 
 ThreadManager::ThreadManager() {}
 
@@ -244,6 +260,7 @@ inline bool ThreadManager::try_decrement(std::atomic<size_t> &value) {
 }
 
 void ThreadManager::thread_parallelize(size_t my_tid) {
+  ParallelRegionGuard parallel_region_guard(in_parallel_region_);
 
   // process my job
   size_t range_start =

--- a/nntrainer/utils/thread_manager.h
+++ b/nntrainer/utils/thread_manager.h
@@ -150,15 +150,18 @@ public:
    * @param fn callback to run in parallel
    * @details This method parallelizes the following for loop.
    * for(i = begin ; i < end ; i++) { fn(i); }
-   * @warning callback should not contain another parallel_for()
-   * i.e. nested parallel_for is forbidden.
+   * @note A parallel_for() invoked directly from a callback on the same thread
+   * executes sequentially to avoid re-entering the shared thread pool.
+   * @warning The parallel-region context is not propagated to threads spawned
+   * by a callback. A callback must not wait for another thread that calls
+   * parallel_for() on the same ThreadManager.
    */
   template <typename F> void parallel_for(size_t begin, size_t end, F &&fn) {
     if (begin >= end) {
       return;
     }
 
-    if (end - begin == 1 || compute_workers_.empty()) {
+    if (end - begin == 1 || compute_workers_.empty() || in_parallel_region_) {
       for (size_t i = begin; i < end; i++)
         fn(i);
       return;
@@ -327,6 +330,7 @@ private:
 
   // ─── Config ─────────────────────────────────────────
   static ThreadManagerConfig config_;
+  static thread_local bool in_parallel_region_;
 };
 
 } // namespace nntrainer

--- a/test/unittest/unittest_thread_manager.cpp
+++ b/test/unittest/unittest_thread_manager.cpp
@@ -92,6 +92,33 @@ TEST(ThreadManager, ParallelForMultipleCalls) {
   }
 }
 
+// ─── ThreadManager Nested Tests ────────────────────────────
+
+TEST(ThreadManager, NestedParallelForExecutesSequentially) {
+  auto &tm = nntrainer::ThreadManager::Global();
+  const size_t OUTER_SIZE = 8;
+  const size_t INNER_SIZE = 16;
+  std::vector<std::atomic<int>> flags(OUTER_SIZE * INNER_SIZE);
+  std::atomic<bool> same_thread{true};
+  for (auto &flag : flags)
+    flag.store(0);
+
+  tm.parallel_for(0, OUTER_SIZE, [&](size_t outer) {
+    auto outer_thread = std::this_thread::get_id();
+    tm.parallel_for(0, INNER_SIZE, [&](size_t inner) {
+      if (std::this_thread::get_id() != outer_thread)
+        same_thread.store(false, std::memory_order_relaxed);
+      flags[outer * INNER_SIZE + inner].fetch_add(1);
+    });
+  });
+
+  EXPECT_TRUE(same_thread.load(std::memory_order_relaxed));
+  for (size_t i = 0; i < flags.size(); ++i) {
+    EXPECT_EQ(flags[i].load(), 1)
+      << "Index " << i << " not executed exactly once";
+  }
+}
+
 // ─── ThreadManager Query Tests ──────────────────────────────
 
 TEST(ThreadManager, ThreadCounts) {


### PR DESCRIPTION
## Dependency of the PR

None

## Commits to be reviewed in this PR

<details><summary>[ThreadManager] Prevent nested parallel deadlock</summary><br />

[ThreadManager] Prevent nested parallel deadlock

Track callback execution per thread and run directly nested parallel_for calls sequentially. This avoids re-entering the shared execution mutex while preserving serialization for independent callers.

The fallback applies only when parallel_for is invoked directly from a callback on the same thread; execution context is not propagated to child threads.

Add regression coverage that verifies nested callbacks execute sequentially on the calling thread and every iteration executes exactly once.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

- clang-format 14.0.6 check passed.
- C++ syntax check passed.
- An isolated Linux harness verified direct nesting and independent callers.
- The full Meson test target was skipped because the available container lost its Docker backend connection.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Prevent direct nested parallel_for calls from re-entering the shared execution mutex.
- Execute directly nested work sequentially while preserving serialization for independent callers.
- Document the cross-thread nesting limitation and add regression coverage.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>