### PR TITLE
[CI] Cancel in-progress PR workflows on new push

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/causallm_android.yml
+++ b/.github/workflows/causallm_android.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check_count.yml
+++ b/.github/workflows/check_count.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review:
     types: [edited, dismissed, submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_review:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,11 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '34 18 * * 5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -2,6 +2,10 @@ name: C++ Format Checker
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpp-linter:
     runs-on: ubuntu-22.04

--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Tizen GBS build on Ubuntu

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Ubuntu pdebuild on Ubuntu

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   simple_script_checkers:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   meson_test:
 

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   meson_test:
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows_arm_clang.yml
+++ b/.github/workflows/windows_arm_clang.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows_cross_compile.yml
+++ b/.github/workflows/windows_cross_compile.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cross-build:
     runs-on: windows-latest

--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build with Yocto / meta-neural-network on Ubuntu


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CI] Cancel in-progress PR workflows on new push</summary><br />

Add a top-level concurrency block to every pull_request-triggered
workflow so that a new push (including force push) to a PR branch
cancels the previous in-progress run instead of letting it keep
consuming runners.

The group key uses the PR number and falls back to github.ref, so
workflows that also run on push/schedule (e.g. codeql) stay correct.

Applied to the 14 pull_request-triggered workflows:
android, causallm_android, check_count, codeql, cpp_linter,
gbs_build, pdebuild, static.check, ubuntu_clean_meson_build,
ubuntu_clean_meson_build_clang, windows, windows_arm_clang,
windows_cross_compile, yocto.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
This PR cancels unnecessary CI runs such as new pushes.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>