### PR TITLE
[cpu_backend] Add symmetric channel-wise int8(QS8CX) quantization

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -650,6 +650,13 @@ void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
 #endif
 }
 
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32) {
+  __fallback_quant_nxk_qs8cx_f32(n, k, (const float *)rhs_native_mtx_f32,
+                                 (int8_t *)rhs_native_mtx_qs8cx,
+                                 (float *)rhs_scales_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
 #ifndef ARMV7

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1523,6 +1523,27 @@ void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
                           void *rhs_scales_f32, void *rhs_native_mtx_f32);
 
 /**
+ * @brief qs8cx quantization of rhs matrix in nxk format. Typically a weight
+ * quantization, and the weight must be transposed in (N, K).
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ * Note that the output is stored as signed int8.
+ *
+ * @warning You should allocate memory for outputs before use:
+ *  - rhs_native_mtx_qs8cx
+ *    n * k * sizeof(int8_t)
+ *  - rhs_scales_f32
+ *    n * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_f32 matrix data before quantization
+ * @param[out] rhs_native_mtx_qs8cx quantized matrix data after quantization
+ * @param[out] rhs_scales_f32 matrix quant scale after quantization
+ */
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
+
+/**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
  * qsi4cxp
  * Note that nxk is the format of quantized rhs, not the shape of rhs

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -427,6 +427,13 @@ void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
     (const float *)rhs_scales_f32, (float *)rhs_native_mtx_f32);
 }
 
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32) {
+  __fallback_quant_nxk_qs8cx_f32(n, k, (const float *)rhs_native_mtx_f32,
+                                 (int8_t *)rhs_native_mtx_qs8cx,
+                                 (float *)rhs_scales_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
   return __fallback_get_rhs_packed_size_qsi4cxp_qs4cxs1s0(n, k, idx_variant,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1306,7 +1306,6 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
-} /* namespace nntrainer */
 
 /**
  * @brief     Create a Q4_0 weights (without XOR 0x88) from int4 weights
@@ -1345,7 +1344,6 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                        size_t scale_group_size,
                                        void *dst_q4_0x);
 
-namespace nnatrainer {
 /**
  * kleidiai
  */
@@ -1412,6 +1410,27 @@ void dequant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs4cx,
  */
 void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
                           void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
+ * @brief qs8cx quantization of rhs matrix in nxk format. Typically a weight
+ * quantization, and the weight must be transposed in (N, K).
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ * Note that the output is stored as signed int8.
+ *
+ * @warning You should allocate memory for outputs before use:
+ *  - rhs_native_mtx_qs8cx
+ *    n * k * sizeof(int8_t)
+ *  - rhs_scales_f32
+ *    n * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_f32 matrix data before quantization
+ * @param[out] rhs_native_mtx_qs8cx quantized matrix data after quantization
+ * @param[out] rhs_scales_f32 matrix quant scale after quantization
+ */
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
 
 /**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
@@ -1483,7 +1502,7 @@ void gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                           float *dst_act_mtx_f32, size_t idx_variant,
                           float lower_bound = -FLT_MAX,
                           float upper_bound = FLT_MAX);
-} // namespace nnatrainer
+} // namespace nntrainer
 
 #endif /* __cplusplus */
 #endif /* __FALLBACK_H__ */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -909,6 +909,53 @@ void __fallback_dequant_kxn_qs4cx_f32(size_t n, size_t k,
   }
 }
 
+void __fallback_quant_nxk_qs8cx_f32(size_t n, size_t k, const float *rhs_f32,
+                                    int8_t *rhs_qs8cx, float *rhs_scales_f32) {
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    const float *src_ptr = rhs_f32 + n_idx * k;
+    int8_t *dst_ptr = rhs_qs8cx + n_idx * k;
+
+    float max0 = -FLT_MAX;
+    float min0 = FLT_MAX;
+
+    // Find min/max for each channel
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      max0 = std::max(src0_0, max0);
+      min0 = std::min(src0_0, min0);
+    }
+
+    // Maximum/minimum int8 values
+    const float qmin = (float)INT8_MIN;
+    const float qmax = (float)INT8_MAX;
+
+    const float rmin0 = std::min(0.0f, min0);
+    const float rmax0 = std::max(0.0f, max0);
+
+    const float scale0 = rmin0 == rmax0 ? 1.f : (qmax - qmin) / (rmax0 - rmin0);
+
+    // Reciprocal to quantize
+    const float recip_scale0 = scale0 ? 1.0f / scale0 : 0.0f;
+
+    // Quantize the channels
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      // Scale the values
+      int32_t v0_s32 = (int32_t)(std::round(src0_0 * scale0));
+
+      // Maximum/minimum int8 values
+      v0_s32 = std::max(v0_s32, (int32_t)INT8_MIN);
+      v0_s32 = std::min(v0_s32, (int32_t)INT8_MAX);
+
+      dst_ptr[k_idx] = (int8_t)v0_s32;
+    }
+
+    rhs_scales_f32[n_idx] = recip_scale0;
+  }
+}
+
 void __fallback_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
                                 int8_t *lhs_qa8dx) {
   const size_t dst_stride =

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1353,6 +1353,20 @@ void __fallback_dequant_kxn_qs4cx_f32(size_t n, size_t k,
                                       float *rhs_f32);
 
 /**
+ * @brief qs8cx quantization of (n,k) RHS matrix in nxk format
+ * qs8cx refers to quantized symmetric 8-bit per-channel quantization.
+ * Note that the output is stored as signed int8.
+ *
+ * @param[in] n N length of the matrix
+ * @param[in] k K length of the matrix
+ * @param[in] rhs_f32 matrix data before quantization
+ * @param[out] rhs_qs8cx matrix data in nxk format after quantization
+ * @param[out] rhs_scales_f32 matrix quant scale after quantization
+ */
+void __fallback_quant_nxk_qs8cx_f32(size_t n, size_t k, const float *rhs_f32,
+                                    int8_t *rhs_qs8cx, float *rhs_scales_f32);
+
+/**
  * @brief qa8dx quantization of (m,k) LHS matrix. qa8dx refer to quantized
  * asymmetric 8-bit per-dimension quantization. Note that qparams are embedded
  * at the beginning of the output matrix.

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -559,6 +559,13 @@ void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
     (const float *)rhs_scales_f32, (float *)rhs_native_mtx_f32);
 }
 
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32) {
+  __fallback_quant_nxk_qs8cx_f32(n, k, (const float *)rhs_native_mtx_f32,
+                                 (int8_t *)rhs_native_mtx_qs8cx,
+                                 (float *)rhs_scales_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
   return __fallback_get_rhs_packed_size_qsi4cxp_qs4cxs1s0(n, k, idx_variant,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1322,6 +1322,27 @@ void dequantize_row_qs4cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs4cx,
                           void *rhs_scales_f32, void *rhs_native_mtx_f32);
 
 /**
+ * @brief qs8cx quantization of rhs matrix in nxk format. Typically a weight
+ * quantization, and the weight must be transposed in (N, K).
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ * Note that the output is stored as signed int8.
+ *
+ * @warning You should allocate memory for outputs before use:
+ *  - rhs_native_mtx_qs8cx
+ *    n * k * sizeof(int8_t)
+ *  - rhs_scales_f32
+ *    n * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_f32 matrix data before quantization
+ * @param[out] rhs_native_mtx_qs8cx quantized matrix data after quantization
+ * @param[out] rhs_scales_f32 matrix quant scale after quantization
+ */
+void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                     void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
+
+/**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
  * qsi4cxp
  * Note that nxk is the format of quantized rhs, not the shape of rhs

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -1140,6 +1140,46 @@ TEST(nntrainer_fallback_kleidiai, quant_kxn_qs4cx_f32_odd_n) {
   }
 }
 
+/**
+ * @brief test __fallback_quant_nxk_qs8cx_f32 with (n, k) shaped random input
+ */
+static void test_quant_nxk_qs8cx_f32(size_t n, size_t k) {
+  std::vector<float> rhs_f32 = generate_random_vector<float>(n * k);
+  std::vector<int8_t> rhs_qs8cx(n * k, 0);
+  std::vector<float> rhs_scales_f32(n, 0.0f);
+
+  nntrainer::__fallback_quant_nxk_qs8cx_f32(
+    n, k, rhs_f32.data(), rhs_qs8cx.data(), rhs_scales_f32.data());
+
+  // Verify scales are computed
+  for (size_t i = 0; i < n; ++i) {
+    float scale = rhs_scales_f32[i];
+    EXPECT_GT(scale, 0.0f);
+    for (size_t j = 0; j < k; ++j) {
+      int q = rhs_qs8cx[i * k + j];
+
+      float q_f = q * scale;
+      float ref = rhs_f32[i * k + j];
+
+      if (ref <= (float)INT8_MIN * scale) {
+        EXPECT_EQ(q, INT8_MIN);
+      } else if (ref >= (float)INT8_MAX * scale) {
+        EXPECT_EQ(q, INT8_MAX);
+      } else {
+        EXPECT_NEAR(q_f, ref, scale / 2);
+      }
+    }
+  }
+}
+
+TEST(nntrainer_fallback_kleidiai, quant_nxk_qs8cx_f32_n1_k128) {
+  test_quant_nxk_qs8cx_f32(1, 128);
+}
+
+TEST(nntrainer_fallback_kleidiai, quant_nxk_qs8cx_f32_n32_k128) {
+  test_quant_nxk_qs8cx_f32(32, 128);
+}
+
 TEST(nntrainer_fallback_kleidiai, quant_qa8dx_zero) {
   const size_t m = 2;
   const size_t k = 8;


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[cpu_backend] Add QS8CX quantization</summary><br />

- Add fallback implementation
  - only nxk format is implemented
- Add arm, x86, fallback implementation
- Add unittest

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
This PR adds QS8CX quantization in the same meaning of QS4CX.
Note that only nxk format is going to be supported because it is enough to use a single format.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
