### PR TITLE
[ci] check_review: authenticate the reviews API call and stop crashing on rate-limit

### DIFF
--- a/.github/workflows/check_count.yml
+++ b/.github/workflows/check_count.yml
@@ -20,9 +20,16 @@ jobs:
           IS_CONTAIN: ${{ contains(github.event.pull_request.labels.*.name, 'Need Review') }}
         id: review_count
         run: |
-          review=$(curl -s -H "Accept: application/vnd.github.black-cat-preview+json" \
-          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-          | jq '[ .[] | select(.state=="APPROVED") | .user.login ] | unique | length')
+          # Authenticated call: the unauthenticated limit (60/hr, shared per
+          # runner IP) intermittently returns a rate-limit error object, which
+          # crashed the old jq filter (exit 5) and failed this check regardless
+          # of the PR's actual review state.
+          review=$(curl -s \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
+          | jq 'if type=="array" then [ .[] | select(.state=="APPROVED") | .user.login ] | unique | length else 0 end' \
+          || echo 0)
           echo "Number of approved review_count: $review"
           echo "CONTAIN=$IS_CONTAIN"
 


### PR DESCRIPTION
check_review's review_count step calls the reviews API with an unauthenticated curl. The anonymous quota (60/hr) is shared across every workflow on the runner's IP, so the call intermittently returns a rate-limit error object instead of an array — and the jq filter then crashes (`jq: error: Cannot index string with string "state"`, exit 5), failing the check regardless of the PR's real review state. That's why fresh PRs show a red check_review while others stay green with the same (zero) review count: it's the runner IP's rate limit, not reviews. Observed today on #4141/#4143/#4144/#4145 (log: exit code 5 with the jq index error).

Fix: authenticate with the workflow's own `GITHUB_TOKEN` (per-repo quota, available read-only on fork PRs), use the stable `application/vnd.github+json` media type instead of the retired black-cat-preview, request `per_page=100`, and make the jq filter total — a non-array response counts as 0 approvals instead of crashing. The recorded artifact semantics (unique approver count in `pr/`) are unchanged.


Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>