### PR TITLE
[tensor] Fix uninitialized-memory NaN comparison in the fp16 tensor pool test

### DIFF
--- a/test/unittest/unittest_nntrainer_tensor_pool_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool_fp16.cpp
@@ -2057,6 +2057,12 @@ TEST(TensorPool, createOrExtend_p) {
   EXPECT_EQ(t1, t2);
   pool.finalize(nntrainer::BasicPlanner(), 0, 2);
   pool.allocate();
+  /// t1 and t2 alias the same pool memory, which pool.allocate() leaves
+  /// uninitialized. Give it a deterministic, non-NaN value before comparing
+  /// contents: HalfTensor::operator== treats NaN as always-unequal (even to
+  /// itself), so comparing raw uninitialized memory is flaky depending on
+  /// what garbage bytes happen to land in the fp16 exponent field.
+  t1->setZero();
   EXPECT_EQ(*t1, *t2);
   pool.deallocate();
 }


### PR DESCRIPTION
TensorPool.createOrExtend_p compares `*t1 == *t2` on freshly-allocated, never-written pool memory. Both pointers alias the same tensor over the same pool bytes, and HalfTensor::operator== treats NaN as unequal even to itself — so whenever meson's MALLOC_PERTURB_ poison byte lands in fp16's NaN/Inf exponent range (top byte 0x7C-0x7F / 0xFC-0xFF, a far wider slice of the byte space than fp32's equivalent), the self-comparison spuriously fails. That's why only the fp16 variant of this test flakes: reproduced the exact CI signatures locally at MALLOC_PERTURB_=2 (the #4100 ubuntu-22.04 failure) and =130 (the #4104 ubuntu-24.04 failure), both operands printing `-nan` at the same address.

Fix is test-only: give the shared memory a deterministic value (`t1->setZero()`) before the content-equality check, matching the pattern validate_memory_01_p already uses (write known content before comparing freshly-allocated pool memory).

Verification: the failing case + the full 96-test fp16 suite green under plain, =2, =130, and 20-value random MALLOC_PERTURB_ sweeps; 8 repeated meson-test invocations green; fp32 unittest_nntrainer_tensor_pool unaffected (48 green).

This is the pre-existing red on #4100/#4104's fp16 cells (their diffs are unrelated).


Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>