### PR TITLE
[meson] Fix CI failure on x86 configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -131,10 +131,10 @@ elif arch == 'x86' or arch == 'x86_64'
   if cxx_compiler_id == 'msvc'
     add_project_arguments(['/arch:AVX2'], language: ['c','cpp'])
     # Note: C runtime library (/MT or /MD) is controlled by b_vscrt option
+    message('/arch:AVX2 added for AVX hardware acceleration.')
   else
-    add_project_arguments(['-march=native'], language: ['c','cpp'])
-    add_project_arguments(['-mavx2', '-mfma'], language: ['c','cpp'])
-    message('-march=native added for AVX hardware acceleration.')
+    add_project_arguments(['-mavx2', '-mfma', '-mf16c'], language: ['c','cpp'])
+    message('-mavx2, -mfma, -mf16c added for AVX hardware acceleration.')
   endif
 endif
 


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[meson] Fix CI failure on x86 configuration</summary><br />

This commit removes redundant -march=native flag which confilcts with
following -mavx2 -mfma at CI runs.
Since -march=native enables every available extensions, let's remove
this line and keep necessary flags only.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR fixes the CI failure caused by `-march=native` which enables every available CPU extensions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>