### PR TITLE
[CausalLM] Fix parallel_for deadlock in MoE expert loops

### DIFF
--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
@@ -237,51 +237,22 @@ void GptOssMoELayer::forwarding(nntrainer::RunLayerContext &context,
     }
   }
 
-  // Adaptive optimization based on workload
-  const int active_experts =
-    std::count_if(expert_assignments.begin(), expert_assignments.end(),
-                  [](const auto &assignments) { return !assignments.empty(); });
+  // Serial outer loop: the expert GEMV/GEMM parallelizes internally via
+  // ThreadManager (dot() calls parallel_for), and nesting parallel_for
+  // deadlocks because ThreadManager::parallelize() uses a non-recursive
+  // execution_mutex_.
+  for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
+       ++expert_idx) {
+    const auto &assignments = expert_assignments[expert_idx];
+    if (assignments.empty())
+      continue;
 
-  // Calculate total work (sum of token assignments across all experts)
-  int total_work = 0;
-  for (const auto &assignments : expert_assignments) {
-    total_work += assignments.size();
-  }
-
-  // Use parallel processing only when it's beneficial
-  const bool use_parallel = (total_work > 4) && (active_experts > 1);
-
-  if (use_parallel) {
-    // Parallel processing for larger workloads
-    auto &tm = nntrainer::ThreadManager::Global();
-    tm.parallel_for(
-      0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-        const auto &assignments = expert_assignments[expert_idx];
-        if (assignments.empty())
-          return;
-
-        // Use optimized expert forward computation without memory copies
-        compute_expert_forward(
-          input, output, assignments,
-          context.getWeight(expert_gate_proj_indices[expert_idx]),
-          context.getWeight(expert_up_proj_indices[expert_idx]),
-          context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
-      });
-  } else {
-    // Sequential processing for smaller workloads
-    for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
-         ++expert_idx) {
-      const auto &assignments = expert_assignments[expert_idx];
-      if (assignments.empty())
-        continue;
-
-      // Use optimized expert forward computation without memory copies
-      compute_expert_forward(
-        input, output, assignments,
-        context.getWeight(expert_gate_proj_indices[expert_idx]),
-        context.getWeight(expert_up_proj_indices[expert_idx]),
-        context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
-    }
+    // Use optimized expert forward computation without memory copies
+    compute_expert_forward(
+      input, output, assignments,
+      context.getWeight(expert_gate_proj_indices[expert_idx]),
+      context.getWeight(expert_up_proj_indices[expert_idx]),
+      context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
   }
 
   // reshape output: [B*S,1,1,H] -> [B,1,S,H]

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -308,82 +308,79 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
       target_idx_vector.push_back(expert_idx);
     }
 
+#ifdef DEBUG
     int hit_count = 0;
     int miss_count = 0;
-
-#ifdef DEBUG
     auto t1_miss = high_resolution_clock::now();
     auto t2_miss = high_resolution_clock::now();
     auto t1_hit = high_resolution_clock::now();
     auto t2_hit = high_resolution_clock::now();
 #endif
 
-    /// @todo revisit multi thread design
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(target_idx_vector.size()), [&](size_t ti) {
-          int expert_idx = target_idx_vector[ti];
-          const auto &assignments = expert_assignments[expert_idx];
-          if (need_load[expert_idx]) {
+    // Serial outer loop: the expert GEMV/GEMM parallelizes internally via
+    // ThreadManager (dot() calls parallel_for), and nesting parallel_for
+    // deadlocks because ThreadManager::parallelize() uses a non-recursive
+    // execution_mutex_.
+    for (int expert_idx : target_idx_vector) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (need_load[expert_idx]) {
 
 #ifdef DEBUG
-            t1_miss = high_resolution_clock::now();
+        t1_miss = high_resolution_clock::now();
 #endif
 
-            context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
-            context.getWeight(expert_up_proj_indices[expert_idx]).activate();
-            context.getWeight(expert_down_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_up_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_down_proj_indices[expert_idx]).activate();
 
-            context.getWeight(expert_gate_bias_indices[expert_idx]).activate();
-            context.getWeight(expert_up_bias_indices[expert_idx]).activate();
-            context.getWeight(expert_down_bias_indices[expert_idx]).activate();
+        context.getWeight(expert_gate_bias_indices[expert_idx]).activate();
+        context.getWeight(expert_up_bias_indices[expert_idx]).activate();
+        context.getWeight(expert_down_bias_indices[expert_idx]).activate();
 
-            {
-              std::lock_guard<std::mutex> lock(cache_mutex);
-              loaded_expert_deque.push_back(expert_idx);
-              iteration_map[expert_idx] = --loaded_expert_deque.end();
-              need_load[expert_idx] = false;
-              miss_count += 1;
-            }
-
-            compute_expert_forward(
-              input, expert_outputs[expert_idx], assignments,
-              context.getWeight(expert_gate_proj_indices[expert_idx]),
-              context.getWeight(expert_up_proj_indices[expert_idx]),
-              context.getWeight(expert_down_proj_indices[expert_idx]),
-              context.getWeight(expert_gate_bias_indices[expert_idx]),
-              context.getWeight(expert_up_bias_indices[expert_idx]),
-              context.getWeight(expert_down_bias_indices[expert_idx]),
-              hidden_size);
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          loaded_expert_deque.push_back(expert_idx);
+          iteration_map[expert_idx] = --loaded_expert_deque.end();
+          need_load[expert_idx] = false;
 #ifdef DEBUG
-            t2_miss = high_resolution_clock::now();
+          miss_count += 1;
 #endif
-          } else {
+        }
 
+        compute_expert_forward(
+          input, expert_outputs[expert_idx], assignments,
+          context.getWeight(expert_gate_proj_indices[expert_idx]),
+          context.getWeight(expert_up_proj_indices[expert_idx]),
+          context.getWeight(expert_down_proj_indices[expert_idx]),
+          context.getWeight(expert_gate_bias_indices[expert_idx]),
+          context.getWeight(expert_up_bias_indices[expert_idx]),
+          context.getWeight(expert_down_bias_indices[expert_idx]), hidden_size);
 #ifdef DEBUG
-            t1_hit = high_resolution_clock::now();
+        t2_miss = high_resolution_clock::now();
 #endif
-            {
-              std::lock_guard<std::mutex> lock(cache_mutex);
-              hit_count += 1;
-            }
-
-            compute_expert_forward(
-              input, expert_outputs[expert_idx], assignments,
-              context.getWeight(expert_gate_proj_indices[expert_idx]),
-              context.getWeight(expert_up_proj_indices[expert_idx]),
-              context.getWeight(expert_down_proj_indices[expert_idx]),
-              context.getWeight(expert_gate_bias_indices[expert_idx]),
-              context.getWeight(expert_up_bias_indices[expert_idx]),
-              context.getWeight(expert_down_bias_indices[expert_idx]),
-              hidden_size);
+      } else {
 
 #ifdef DEBUG
-            t2_hit = high_resolution_clock::now();
+        t1_hit = high_resolution_clock::now();
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          hit_count += 1;
+        }
 #endif
-          }
-        });
+
+        compute_expert_forward(
+          input, expert_outputs[expert_idx], assignments,
+          context.getWeight(expert_gate_proj_indices[expert_idx]),
+          context.getWeight(expert_up_proj_indices[expert_idx]),
+          context.getWeight(expert_down_proj_indices[expert_idx]),
+          context.getWeight(expert_gate_bias_indices[expert_idx]),
+          context.getWeight(expert_up_bias_indices[expert_idx]),
+          context.getWeight(expert_down_bias_indices[expert_idx]), hidden_size);
+
+#ifdef DEBUG
+        t2_hit = high_resolution_clock::now();
+#endif
+      }
     }
 
     for (int i = extra_top_k.size() - 1; i >= 0; i--) {

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -382,62 +382,58 @@ void CachedSlimMoELayer::incremental_forwarding(
     auto t2_hit = t1_hit;
 #endif
 
-    /// @todo revisit multi thread design
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(target_idx_vector.size()), [&](size_t ti) {
-          int expert_idx = target_idx_vector[ti];
-          const auto &assignments = expert_assignments[expert_idx];
-          if (need_load[expert_idx]) {
+    // Serial outer loop: the expert GEMV/GEMM parallelizes internally via
+    // ThreadManager (dot() calls parallel_for), and nesting parallel_for
+    // deadlocks because ThreadManager::parallelize() uses a non-recursive
+    // execution_mutex_.
+    for (int expert_idx : target_idx_vector) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (need_load[expert_idx]) {
 
 #ifdef DEBUG
-            t1_miss = high_resolution_clock::now();
+        t1_miss = high_resolution_clock::now();
 #endif
 
-            context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
-            context.getWeight(expert_up_proj_indices[expert_idx]).activate();
-            context.getWeight(expert_down_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_up_proj_indices[expert_idx]).activate();
+        context.getWeight(expert_down_proj_indices[expert_idx]).activate();
 
-            {
-              std::lock_guard<std::mutex> lock(cache_mutex);
-              loaded_expert_deque.push_back(expert_idx);
-              iteration_map[expert_idx] = --loaded_expert_deque.end();
-              need_load[expert_idx] = false;
-              miss_count += 1;
-            }
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          loaded_expert_deque.push_back(expert_idx);
+          iteration_map[expert_idx] = --loaded_expert_deque.end();
+          need_load[expert_idx] = false;
+          miss_count += 1;
+        }
 
-            compute_expert_forward(
-              input, expert_outputs[expert_idx], assignments,
-              context.getWeight(expert_gate_proj_indices[expert_idx]),
-              context.getWeight(expert_up_proj_indices[expert_idx]),
-              context.getWeight(expert_down_proj_indices[expert_idx]),
-              hidden_size);
+        compute_expert_forward(
+          input, expert_outputs[expert_idx], assignments,
+          context.getWeight(expert_gate_proj_indices[expert_idx]),
+          context.getWeight(expert_up_proj_indices[expert_idx]),
+          context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
 #ifdef DEBUG
-            t2_miss = high_resolution_clock::now();
+        t2_miss = high_resolution_clock::now();
 #endif
-          } else {
-
-#ifdef DEBUG
-            t1_hit = high_resolution_clock::now();
-#endif
-            {
-              std::lock_guard<std::mutex> lock(cache_mutex);
-              hit_count += 1;
-            }
-
-            compute_expert_forward(
-              input, expert_outputs[expert_idx], assignments,
-              context.getWeight(expert_gate_proj_indices[expert_idx]),
-              context.getWeight(expert_up_proj_indices[expert_idx]),
-              context.getWeight(expert_down_proj_indices[expert_idx]),
-              hidden_size);
+      } else {
 
 #ifdef DEBUG
-            t2_hit = high_resolution_clock::now();
+        t1_hit = high_resolution_clock::now();
 #endif
-          }
-        });
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          hit_count += 1;
+        }
+
+        compute_expert_forward(
+          input, expert_outputs[expert_idx], assignments,
+          context.getWeight(expert_gate_proj_indices[expert_idx]),
+          context.getWeight(expert_up_proj_indices[expert_idx]),
+          context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
+
+#ifdef DEBUG
+        t2_hit = high_resolution_clock::now();
+#endif
+      }
     }
 
     for (int i = extra_top_k.size() - 1; i >= 0; i--) {

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
@@ -208,51 +208,22 @@ void MoELayer::forwarding(nntrainer::RunLayerContext &context, bool training) {
     }
   }
 
-  // Adaptive optimization based on workload
-  const int active_experts =
-    std::count_if(expert_assignments.begin(), expert_assignments.end(),
-                  [](const auto &assignments) { return !assignments.empty(); });
+  // Serial outer loop: the expert GEMV/GEMM parallelizes internally via
+  // ThreadManager (dot() calls parallel_for), and nesting parallel_for
+  // deadlocks because ThreadManager::parallelize() uses a non-recursive
+  // execution_mutex_.
+  for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
+       ++expert_idx) {
+    const auto &assignments = expert_assignments[expert_idx];
+    if (assignments.empty())
+      continue;
 
-  // Calculate total work (sum of token assignments across all experts)
-  int total_work = 0;
-  for (const auto &assignments : expert_assignments) {
-    total_work += assignments.size();
-  }
-
-  // Use parallel processing only when it's beneficial
-  const bool use_parallel = (total_work > 4) && (active_experts > 1);
-
-  if (use_parallel) {
-    // Parallel processing for larger workloads
-    auto &tm = nntrainer::ThreadManager::Global();
-    tm.parallel_for(
-      0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-        const auto &assignments = expert_assignments[expert_idx];
-        if (assignments.empty())
-          return;
-
-        // Use optimized expert forward computation without memory copies
-        compute_expert_forward(
-          input, output, assignments,
-          context.getWeight(expert_gate_proj_indices[expert_idx]),
-          context.getWeight(expert_up_proj_indices[expert_idx]),
-          context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
-      });
-  } else {
-    // Sequential processing for smaller workloads
-    for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
-         ++expert_idx) {
-      const auto &assignments = expert_assignments[expert_idx];
-      if (assignments.empty())
-        continue;
-
-      // Use optimized expert forward computation without memory copies
-      compute_expert_forward(
-        input, output, assignments,
-        context.getWeight(expert_gate_proj_indices[expert_idx]),
-        context.getWeight(expert_up_proj_indices[expert_idx]),
-        context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
-    }
+    // Use optimized expert forward computation without memory copies
+    compute_expert_forward(
+      input, output, assignments,
+      context.getWeight(expert_gate_proj_indices[expert_idx]),
+      context.getWeight(expert_up_proj_indices[expert_idx]),
+      context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
   }
 
   // reshape output: [B*S,1,1,H] -> [B,1,S,H]
@@ -465,7 +436,7 @@ void MoELayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       }
     }
 
-    // Parallel processing for multiple tokens with many active experts
+    // Allocate per-expert output tensors
     std::vector<nntrainer::Tensor> expert_outputs(num_experts);
     for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
          ++expert_idx) {
@@ -476,21 +447,17 @@ void MoELayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       }
     }
 
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-          const auto &assignments = expert_assignments[expert_idx];
-          if (assignments.empty())
-            return;
+    for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
+         ++expert_idx) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (assignments.empty())
+        continue;
 
-          compute_expert_forward_no_critical(
-            input, expert_outputs[expert_idx], assignments,
-            context.getWeight(expert_gate_proj_indices[expert_idx]),
-            context.getWeight(expert_up_proj_indices[expert_idx]),
-            context.getWeight(expert_down_proj_indices[expert_idx]),
-            hidden_size);
-        });
+      compute_expert_forward_no_critical(
+        input, expert_outputs[expert_idx], assignments,
+        context.getWeight(expert_gate_proj_indices[expert_idx]),
+        context.getWeight(expert_up_proj_indices[expert_idx]),
+        context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
     }
 
     // Combine expert outputs

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
@@ -454,37 +454,37 @@ void SlimMoELayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       }
     }
 
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-          const auto &assignments = expert_assignments[expert_idx];
-          if (assignments.empty())
-            return;
+    // Serial outer loop: the expert GEMV/GEMM parallelizes internally via
+    // ThreadManager (dot() calls parallel_for), and nesting parallel_for
+    // deadlocks because ThreadManager::parallelize() uses a non-recursive
+    // execution_mutex_.
+    for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
+         ++expert_idx) {
+      const auto &assignments = expert_assignments[expert_idx];
+      if (assignments.empty())
+        continue;
 
-          ///@note Please note that expert_gate_proj is virtual tensor,
-          ///      which is not allocated so far. It will be allocated when it
-          ///      is used. `activate(read=true)` will allocate its memory and
-          ///      will read from the original weight. activate is true by
-          ///      default. i.e., mmap
-          context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
-          context.getWeight(expert_up_proj_indices[expert_idx]).activate();
-          context.getWeight(expert_down_proj_indices[expert_idx]).activate();
+      ///@note Please note that expert_gate_proj is virtual tensor,
+      ///      which is not allocated so far. It will be allocated when it
+      ///      is used. `activate(read=true)` will allocate its memory and
+      ///      will read from the original weight. activate is true by
+      ///      default. i.e., mmap
+      context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
+      context.getWeight(expert_up_proj_indices[expert_idx]).activate();
+      context.getWeight(expert_down_proj_indices[expert_idx]).activate();
 
-          compute_expert_forward_no_critical(
-            input, expert_outputs[expert_idx], assignments,
-            context.getWeight(expert_gate_proj_indices[expert_idx]),
-            context.getWeight(expert_up_proj_indices[expert_idx]),
-            context.getWeight(expert_down_proj_indices[expert_idx]),
-            hidden_size);
+      compute_expert_forward_no_critical(
+        input, expert_outputs[expert_idx], assignments,
+        context.getWeight(expert_gate_proj_indices[expert_idx]),
+        context.getWeight(expert_up_proj_indices[expert_idx]),
+        context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
 
-          ////@note Please note that the virtual tensor is deactivated after
-          /// usage /      This will allocate and load data from the storage
-          /// on-the-fly /      i.e., unmap
-          context.getWeight(expert_gate_proj_indices[expert_idx]).deactivate();
-          context.getWeight(expert_up_proj_indices[expert_idx]).deactivate();
-          context.getWeight(expert_down_proj_indices[expert_idx]).deactivate();
-        });
+      ////@note Please note that the virtual tensor is deactivated after
+      /// usage This will allocate and load data from the storage on-the-fly
+      /// i.e., unmap
+      context.getWeight(expert_gate_proj_indices[expert_idx]).deactivate();
+      context.getWeight(expert_up_proj_indices[expert_idx]).deactivate();
+      context.getWeight(expert_down_proj_indices[expert_idx]).deactivate();
     }
 
     // Combine expert outputs


### PR DESCRIPTION
## Dependency of the PR

N/A

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Fix parallel_for deadlock in MoE expert loops</summary><br />

[CausalLM] Fix parallel_for deadlock in MoE expert loops

ThreadManager::parallelize() uses a non-recursive execution_mutex_,
so nesting parallel_for (outer expert loop) inside dot() (which also
calls parallel_for) causes deadlock. Replace the outer parallel_for
with a serial for loop across all three MoE layer variants
(qwen3_moe, qwen3_slim_moe, qwen3_cached_slim_moe). The internal
GEMV/GEMM parallelism in dot() is preserved.

Also remove unused variables (active_experts, total_work, use_parallel)
in forwarding() that would trigger -Wunused-but-set-variable, and fix
-Wsign-compare in incremental_forwarding().

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Replace the outer `parallel_for` with a serial `for` loop in all three MoE layer variants (qwen3_moe, qwen3_slim_moe, qwen3_cached_slim_moe) to resolve a deadlock caused by `ThreadManager::parallelize()` using a non-recursive `execution_mutex_` when nested inside `dot()`.
- Remove unused variables (`active_experts`, `total_work`, `use_parallel`) in `forwarding()` that would trigger `-Wunused-but-set-variable` build failure.
- Fix `-Wsign-compare` in `incremental_forwarding()` by casting `num_experts` to `int` for loop comparison.
- Internal GEMV/GEMM parallelism in `dot()` is preserved, minimizing performance impact.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>