### PR TITLE
[CausalLM] Compact CachedSlim MoE expert outputs

### DIFF
--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -244,6 +244,7 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
 
     // reshape output: [B,1,S,H] -> [B*S,1,1,H]
     output.reshape({total_tokens, 1, 1, hidden_size});
+    output.setZero();
 
     // routing
     nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
@@ -285,19 +286,9 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
       }
     }
 
-    // Parallel processing for multiple tokens with many active experts
     std::vector<nntrainer::Tensor> expert_outputs(num_experts);
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-          if (!expert_assignments[expert_idx].empty()) {
-            expert_outputs[expert_idx] = nntrainer::Tensor(
-              total_tokens, 1, 1, hidden_size, output.getTensorType());
-          }
-        });
-    }
     std::vector<int> target_idx_vector;
+    target_idx_vector.reserve(num_experts);
 
     for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
          ++expert_idx) {
@@ -306,6 +297,9 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
         continue;
 
       target_idx_vector.push_back(expert_idx);
+      expert_outputs[expert_idx] =
+        nntrainer::Tensor(static_cast<unsigned int>(assignments.size()), 1, 1,
+                          hidden_size, output.getTensorType());
     }
 
 #ifdef DEBUG
@@ -419,13 +413,17 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
 #endif
 
     // Combine expert outputs
-    int init = 0;
+    nntrainer::TensorDim token_step_dim({1, 1, 1, hidden_size},
+                                        output.getTensorType());
     for (int expert_idx : target_idx_vector) {
-      if (!init) {
-        output.copyData(expert_outputs[expert_idx]);
-        ++init;
-      } else {
-        output.add_i(expert_outputs[expert_idx]);
+      const auto &assignments = expert_assignments[expert_idx];
+      for (size_t i = 0; i < assignments.size(); ++i) {
+        nntrainer::Tensor token_output = output.getSharedDataTensor(
+          token_step_dim, assignments[i].first * hidden_size, true);
+        nntrainer::Tensor expert_token_output =
+          expert_outputs[expert_idx].getSharedDataTensor(token_step_dim,
+                                                         i * hidden_size, true);
+        token_output.add_i(expert_token_output);
       }
     }
 
@@ -473,22 +471,14 @@ inline void CachedSlimGptOssMoELayer::compute_expert_forward(
                                        input.getTensorType());
   nntrainer::TensorDim intermediate_dim({1, 1, num_tokens, intermediate_size},
                                         input.getTensorType());
-  nntrainer::TensorDim token_output_dim({1, 1, num_tokens, hidden_size},
-                                        input.getTensorType());
   nntrainer::TensorDim out_step_dim({1, 1, 1, hidden_size},
                                     input.getTensorType());
-  nntrainer::TensorDim step_dim({1, 1, 1, intermediate_size},
-                                input.getTensorType());
   // Create intermediate tensors for this token
   nntrainer::Tensor gate_out(intermediate_dim);
   nntrainer::Tensor acti_out(intermediate_dim);
   nntrainer::Tensor up_out(intermediate_dim);
   nntrainer::Tensor token_input(token_input_dim);
-  // Down projection using optimized dot operation
-  nntrainer::Tensor token_expert_output(token_output_dim);
-
-  unsigned token_idx = token_assignments[0].first;
-  float weight = token_assignments[0].second;
+  const unsigned token_idx = token_assignments[0].first;
 
   if (num_tokens > 1) {
     /** if prefill, copy data to make a batch */
@@ -544,23 +534,16 @@ inline void CachedSlimGptOssMoELayer::compute_expert_forward(
     });
   }
 
-  // Down projection using optimized dot operation
-  acti_out.dot(down_proj, token_expert_output);
-  token_expert_output.add_i(down_bias);
+  acti_out.dot(down_proj, expert_output);
+  expert_output.add_i(down_bias);
 
-  // accumulate to output
+  // Apply routing weights to the compact expert output.
   {
     auto &tm = nntrainer::ThreadManager::Global();
     tm.parallel_for(0, static_cast<size_t>(num_tokens), [&](size_t i) {
-      unsigned t_idx = token_assignments[i].first;
-      float w = token_assignments[i].second;
-      size_t output_offset = t_idx * hidden_size;
-      nntrainer::Tensor token_output =
-        expert_output.getSharedDataTensor(out_step_dim, output_offset, true);
-      nntrainer::Tensor target = token_expert_output.getSharedDataTensor(
-        out_step_dim, i * hidden_size, true);
-      target.multiply_i(w);
-      token_output.add(target, token_output);
+      nntrainer::Tensor expert_token_output =
+        expert_output.getSharedDataTensor(out_step_dim, i * hidden_size, true);
+      expert_token_output.multiply_i(token_assignments[i].second);
     });
   }
 }

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -188,22 +188,14 @@ inline void CachedSlimMoELayer::compute_expert_forward(
                                        input.getTensorType());
   nntrainer::TensorDim intermediate_dim({1, 1, num_tokens, intermediate_size},
                                         input.getTensorType());
-  nntrainer::TensorDim token_output_dim({1, 1, num_tokens, hidden_size},
-                                        input.getTensorType());
   nntrainer::TensorDim out_step_dim({1, 1, 1, hidden_size},
                                     input.getTensorType());
-  nntrainer::TensorDim step_dim({1, 1, 1, intermediate_size},
-                                input.getTensorType());
   // Create intermediate tensors for this token
   nntrainer::Tensor gate_out(intermediate_dim);
   nntrainer::Tensor acti_out(intermediate_dim);
   nntrainer::Tensor up_out(intermediate_dim);
   nntrainer::Tensor token_input(token_input_dim);
-  // Down projection using optimized dot operation
-  nntrainer::Tensor token_expert_output(token_output_dim);
-
-  unsigned token_idx = token_assignments[0].first;
-  float weight = token_assignments[0].second;
+  const unsigned token_idx = token_assignments[0].first;
 
   if (num_tokens > 1) {
     /** if prefill, copy data to make a batch */
@@ -248,19 +240,13 @@ inline void CachedSlimMoELayer::compute_expert_forward(
     });
   }
 
-  acti_out.dot(down_proj, token_expert_output);
+  acti_out.dot(down_proj, output);
 
-  // accumulate to output
+  // Apply routing weights to the compact expert output.
   for (size_t i = 0; i < num_tokens; ++i) {
-    token_idx = token_assignments[i].first;
-    weight = token_assignments[i].second;
-    size_t output_offset = token_idx * hidden_size;
-    nntrainer::Tensor token_output =
-      output.getSharedDataTensor(out_step_dim, output_offset, true);
-    nntrainer::Tensor target = token_expert_output.getSharedDataTensor(
-      out_step_dim, i * hidden_size, true);
-    target.multiply_i(weight);
-    token_output.add(target, token_output);
+    nntrainer::Tensor expert_token_output =
+      output.getSharedDataTensor(out_step_dim, i * hidden_size, true);
+    expert_token_output.multiply_i(token_assignments[i].second);
   }
 }
 
@@ -349,19 +335,9 @@ void CachedSlimMoELayer::incremental_forwarding(
       }
     }
 
-    // Parallel processing for multiple tokens with many active experts
     std::vector<nntrainer::Tensor> expert_outputs(num_experts);
-    {
-      auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(
-        0, static_cast<size_t>(num_experts), [&](size_t expert_idx) {
-          if (!expert_assignments[expert_idx].empty()) {
-            expert_outputs[expert_idx] = nntrainer::Tensor(
-              total_tokens, 1, 1, hidden_size, output.getTensorType());
-          }
-        });
-    }
     std::vector<int> target_idx_vector;
+    target_idx_vector.reserve(num_experts);
 
     for (int expert_idx = 0; expert_idx < static_cast<int>(num_experts);
          ++expert_idx) {
@@ -370,6 +346,9 @@ void CachedSlimMoELayer::incremental_forwarding(
         continue;
 
       target_idx_vector.push_back(expert_idx);
+      expert_outputs[expert_idx] =
+        nntrainer::Tensor(static_cast<unsigned int>(assignments.size()), 1, 1,
+                          hidden_size, output.getTensorType());
     }
 
     int hit_count = 0;
@@ -470,13 +449,17 @@ void CachedSlimMoELayer::incremental_forwarding(
 #endif
 
     // Combine expert outputs
-    int init = 0;
+    nntrainer::TensorDim token_step_dim({1, 1, 1, hidden_size},
+                                        output.getTensorType());
     for (int expert_idx : target_idx_vector) {
-      if (!init) {
-        output.copyData(expert_outputs[expert_idx]);
-        ++init;
-      } else {
-        output.add_i(expert_outputs[expert_idx]);
+      const auto &assignments = expert_assignments[expert_idx];
+      for (size_t i = 0; i < assignments.size(); ++i) {
+        nntrainer::Tensor token_output = output.getSharedDataTensor(
+          token_step_dim, assignments[i].first * hidden_size, true);
+        nntrainer::Tensor expert_token_output =
+          expert_outputs[expert_idx].getSharedDataTensor(token_step_dim,
+                                                         i * hidden_size, true);
+        token_output.add_i(expert_token_output);
       }
     }
 


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Compact CachedSlim MoE expert outputs</summary><br />

CachedSlim previously allocated a full [total_tokens, hidden_size] output buffer for every active expert, although each expert processes only its assigned tokens.

Allocate each expert output using its routed token count instead.
Apply routing weights in the compact buffer and scatter-add each row back to its original token position.

This reduces expert output memory during prefill while preserving the existing expert cache loading behavior and numerical operation order.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped (clang-format 14, whitespace check, and target source syntax compilation)
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>



<details><summary>[CausalLM] Compact GptOss CachedSlim expert outputs</summary><br />

GptOss CachedSlim previously allocated a full [total_tokens, hidden_size] output buffer for every active expert, regardless of how many tokens were routed to it.

Allocate expert outputs using only the routed token count, apply the routing weights to the compact results, and scatter-add them back to the shared output tensor.

Preserve the GptOss gate, up, and down projection bias handling while removing full-token expert buffers and whole-tensor reductions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped (clang-format 14, whitespace check, and target source syntax compilation)
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Qwen3-30BA3B x86 Results

#### Before
```
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 9295 ms, 47.0145 TPS
generation: 409 tokens, 24246 ms, 16.8688 TPS
total: 33543 ms
peak memory: 5775996 KB
==========================================================
[e2e time]: 34152 ms 
Max Resident Set Size: 5775996 KB
```

#### After
```
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 6041 ms, 72.339 TPS
generation: 409 tokens, 24018 ms, 17.0289 TPS
total: 30062 ms
peak memory: 5464948 KB
==========================================================
[e2e time]: 30696 ms 
Max Resident Set Size: 5464948 KB
```


### Summary

- Reduce CachedSlim MoE expert output memory from full-token buffers to routed-token buffers.
- Replace whole-tensor reductions with weighted scatter-add for Qwen3 and GptOss CachedSlim paths.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
