### PR TITLE
[CausalLM] Use SIMD SwiGLU in Qwen3 MoE layers

### DIFF
--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -234,10 +234,8 @@ inline void CachedSlimMoELayer::compute_expert_forward(
   token_input.dot(up_proj, up_out);
 
   if (num_tokens == 1) {
-    // Apply activation (silu)
-    acti_func.run_fn(gate_out, acti_out);
-    // Element-wise multiply: silu(gate_out) * up_out
-    acti_out.multiply_i(up_out);
+    nntrainer::swiglu(acti_out.width(), acti_out.getData<float>(),
+                      gate_out.getData<float>(), up_out.getData<float>());
   } else {
     auto &tm = nntrainer::ThreadManager::Global();
     tm.parallel_for(0, static_cast<size_t>(num_tokens), [&](size_t i) {

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
@@ -274,14 +274,11 @@ inline void MoELayer::compute_expert_forward(
     // Gate projection using optimized dot operation
     token_input.dot(gate_proj, gate_out);
 
-    // Apply activation (silu)
-    acti_func.run_fn(gate_out, acti_out);
-
     // Up projection using optimized dot operation
     token_input.dot(up_proj, up_out);
 
-    // Element-wise multiply: silu(gate_out) * up_out
-    acti_out.multiply_i(up_out);
+    nntrainer::swiglu(acti_out.width(), acti_out.getData<float>(),
+                      gate_out.getData<float>(), up_out.getData<float>());
 
     // Down projection using optimized dot operation
     nntrainer::Tensor token_expert_output(token_output_dim);
@@ -339,14 +336,11 @@ inline void MoELayer::compute_expert_forward_no_critical(
     // Gate projection using optimized dot operation
     token_input.dot(gate_proj, gate_out);
 
-    // Apply activation (silu)
-    acti_func.run_fn(gate_out, acti_out);
-
     // Up projection using optimized dot operation
     token_input.dot(up_proj, up_out);
 
-    // Element-wise multiply: silu(gate_out) * up_out
-    acti_out.multiply_i(up_out);
+    nntrainer::swiglu(acti_out.width(), acti_out.getData<float>(),
+                      gate_out.getData<float>(), up_out.getData<float>());
 
     // Down projection using optimized dot operation
     nntrainer::Tensor token_expert_output(token_output_dim);

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
@@ -291,14 +291,11 @@ inline void SlimMoELayer::compute_expert_forward(
     // Gate projection using optimized dot operation
     token_input.dot(gate_proj, gate_out);
 
-    // Apply activation (silu)
-    acti_func.run_fn(gate_out, acti_out);
-
     // Up projection using optimized dot operation
     token_input.dot(up_proj, up_out);
 
-    // Element-wise multiply: silu(gate_out) * up_out
-    acti_out.multiply_i(up_out);
+    nntrainer::swiglu(acti_out.width(), acti_out.getData<float>(),
+                      gate_out.getData<float>(), up_out.getData<float>());
 
     // Down projection using optimized dot operation
     nntrainer::Tensor token_expert_output(token_output_dim);
@@ -356,14 +353,11 @@ inline void SlimMoELayer::compute_expert_forward_no_critical(
     // Gate projection using optimized dot operation
     token_input.dot(gate_proj, gate_out);
 
-    // Apply activation (silu)
-    acti_func.run_fn(gate_out, acti_out);
-
     // Up projection using optimized dot operation
     token_input.dot(up_proj, up_out);
 
-    // Element-wise multiply: silu(gate_out) * up_out
-    acti_out.multiply_i(up_out);
+    nntrainer::swiglu(acti_out.width(), acti_out.getData<float>(),
+                      gate_out.getData<float>(), up_out.getData<float>());
 
     // Down projection using optimized dot operation
     nntrainer::Tensor token_expert_output(token_output_dim);


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Use SIMD SwiGLU in Qwen3 MoE layers</summary><br />

Qwen3 MoE implementations applied SiLU and the element-wise up projection multiplication in separate tensor passes for per-token expert outputs. This left the existing fused SwiGLU backend unused on decode and token-at-a-time expert paths.

Call `nntrainer::swiglu()` directly in the regular MoE, FSU Slim MoE, and CachedSlim single-token paths. CachedSlim prefill already uses the same fused kernel.

This combines activation and multiplication into one backend dispatch, enabling the ARM SIMD implementation while retaining the portable fallback on other platforms.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped (clang-format 14, whitespace check, and target source compilation)
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Qwen3-30BA3B x86 Results
```
#### Before
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 9295 ms, 47.0145 TPS
generation: 409 tokens, 24246 ms, 16.8688 TPS
total: 33543 ms
peak memory: 5775996 KB
==========================================================
[e2e time]: 34152 ms 
Max Resident Set Size: 5775996 KB
```
```
#### After
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 9286 ms, 47.0601 TPS
generation: 401 tokens, 23091 ms, 17.3661 TPS
total: 32379 ms
peak memory: 5775096 KB
==========================================================
[e2e time]: 33005 ms 
Max Resident Set Size: 5775096 KB
```


### Summary

- Use the fused SIMD SwiGLU backend in every Qwen3 MoE expert path.
- Keep GptOss unchanged because its regular and CachedSlim layers already use fused SwiGLU.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
