### PR TITLE
[CausalLM] Restrict weight repack on Fully Connected layer

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -361,6 +361,11 @@ void Transformer::repack_weight() {
   }
   std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
     fn = [](ml::train::Layer &l, nntrainer::RunLayerContext &context, void *) {
+      // repack FC layer only
+      if (l.getType() != "fully_connected" &&
+          l.getType() != "shared_fully_connected")
+        return;
+
       auto weights = context.getWeights();
       for (auto &w : weights) {
         if (w->getVariableRef().getDataType() ==


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR
<details><summary>[CausalLM] Restrict weight repack on Fully Connected layer</summary><br />

This commit applys repacking at FC layer only.
This change can prevent unintended change on other channel-wise int4
typed weight that should not be re-arranged.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>