### PR TITLE
[ci] Fix uncatched whitespace errors

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: check whitespace errors on changed lines
+        run: |
+          echo "Checking whitespace errors on changed lines"
+          git diff --check ${{ github.event.pull_request.base.sha }}...HEAD \
+            -- . ':(exclude).github' ':(exclude)Applications/CausalLM/third_party'
       - name: install dev packages
         run: |
           echo "Install mandatory dev packages to avoid false-positive reports from cpp-linter"


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[ci] Fix uncatched whitespace errors</summary><br />

- Add an explicit git diff --check for whitespace

cpp-linter runs with lines-changed-only, so it only reports clang-format
replacements whose start line falls inside the PR diff. When a changed
line is a blank line carrying trailing whitespace, clang-format emits a
single replacement that begins at the newline terminating the previous
line (the offset lands on the preceding, unchanged line). cpp-linter
attributes that fix to the previous line, which is not in the changed-line
set, and drops it -- so trailing whitespace introduced on such lines slips
through the format check.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
`clang-format-14` with `lines-changed-only` option which used in nntrainer's CI
can't detect some unformatted white spaces.
This PR introduces a explicit `git diff --check` which checks white space errors.

You can find the example at https://github.com/nntrainer/nntrainer/pull/4159.

### To do
* Introduce pre-commit hook
  * Remove white space check if matters

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
