### PR TITLE
[Tensor] Fix qs4cx size rounding bug

### DIFF
--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -418,11 +418,11 @@ public:
               ///@note The codelines below can be replaced with quantizer's
               /// quantize()
               TensorDim dim = weight.getDim();
-              unsigned int K = dim.height();
-              unsigned int N = dim.width();
+              size_t K = dim.height();
+              size_t N = dim.width();
               Tensor weight_t = weight.transpose("0:2:1");
 
-              size_t q_size = N * (K + 1) / 2;
+              size_t q_size = N * ((K + 1) / 2);
               size_t scale_size = N * sizeof(float);
 
               // allocate packed size, not an unpacked size

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1466,8 +1466,8 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
  *
  * @warning You should allocate memory for outputs before use:
  *  - rhs_native_mtx_qs4cx
- *    - is_nxk == true: n * (k + 1) / 2
- *    - is_nxk == false: k * (n + 1) / 2
+ *    - is_nxk == true: n * ((k + 1) / 2)
+ *    - is_nxk == false: k * ((n + 1) / 2)
  *  - rhs_scales_f32
  *    n * sizeof(float)
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1357,8 +1357,8 @@ namespace nnatrainer {
  *
  * @warning You should allocate memory for outputs before use:
  *  - rhs_native_mtx_qs4cx
- *    - is_nxk == true: n * (k + 1) / 2
- *    - is_nxk == false: k * (n + 1) / 2
+ *    - is_nxk == true: n * ((k + 1) / 2)
+ *    - is_nxk == false: k * ((n + 1) / 2)
  *  - rhs_scales_f32
  *    n * sizeof(float)
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1265,8 +1265,8 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
  *
  * @warning You should allocate memory for outputs before use:
  *  - rhs_native_mtx_qs4cx
- *    - is_nxk == true: n * (k + 1) / 2
- *    - is_nxk == false: k * (n + 1) / 2
+ *    - is_nxk == true: n * ((k + 1) / 2)
+ *    - is_nxk == false: k * ((n + 1) / 2)
  *  - rhs_scales_f32
  *    n * sizeof(float)
  *

--- a/nntrainer/tensor/qs4cx_tensor.cpp
+++ b/nntrainer/tensor/qs4cx_tensor.cpp
@@ -81,7 +81,7 @@ void QS4CX_Tensor::pack() {
 
   nntrainer::rhs_pack_qsi4cxp_qs4cxs1s0(
     N, K, packed_data.get(), getData(),
-    ((uint8_t *)getData()) + N * (K + 1) / 2, opt_kernel_idx, true);
+    ((uint8_t *)getData()) + N * ((K + 1) / 2), opt_kernel_idx, true);
 
   if (!packed_data) {
     throw std::runtime_error{"something wrong"};
@@ -99,7 +99,7 @@ void *QS4CX_Tensor::getPackedData() const {
 size_t QS4CX_Tensor::size() const {
   const size_t K = height();
   const size_t N = width();
-  return N * (K + 1) / 2 + N * sizeof(float);
+  return N * ((K + 1) / 2) + N * sizeof(float);
 }
 
 size_t QS4CX_Tensor::getMemoryBytes() const { return size() * sizeof(uint8_t); }
@@ -113,7 +113,7 @@ void *QS4CX_Tensor::getScale() const {
   const size_t K = height();
   const size_t N = width();
 
-  return ((int8_t *)getData()) + N * (K + 1) / 2;
+  return ((int8_t *)getData()) + N * ((K + 1) / 2);
 }
 
 void QS4CX_Tensor::copy_qs4cx(const void *buf) {

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -1248,7 +1248,7 @@ TEST(nntrainer_fallback_kleidiai, matmul_mxn_mxk_nxk_f32_qa8dx_qs4cx) {
   nntrainer::__fallback_quant_qa8dx_f32(m, k, lhs_f32.data(), lhs_qa8dx.data());
 
   // Quantize RHS
-  std::vector<uint8_t> rhs_qs4cx((n * (k + 1) / 2), 0);
+  std::vector<uint8_t> rhs_qs4cx((n * ((k + 1) / 2)), 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_nxk_qs4cx_f32(
     n, k, rhs_f32.data(), rhs_qs4cx.data(), rhs_scales_f32.data());
@@ -1297,7 +1297,7 @@ TEST(nntrainer_fallback_kleidiai, matmul_mxn_mxk_kxn_f32_qa8dx_qs4cx) {
   nntrainer::__fallback_quant_qa8dx_f32(m, k, lhs_f32.data(), lhs_qa8dx.data());
 
   // Quantize RHS
-  std::vector<uint8_t> rhs_qs4cx((k * (n + 1) / 2), 0);
+  std::vector<uint8_t> rhs_qs4cx((k * ((n + 1) / 2)), 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_kxn_qs4cx_f32(
     n, k, rhs_f32.data(), rhs_qs4cx.data(), rhs_scales_f32.data());
@@ -1355,7 +1355,7 @@ TEST(nntrainer_fallback_kleidiai,
   nntrainer::__fallback_quant_qa8dx_f32(m, k, lhs_f32.data(), lhs_qa8dx.data());
 
   // Quantize RHS
-  std::vector<uint8_t> rhs_qs4cx((n * (k + 1) / 2), 0);
+  std::vector<uint8_t> rhs_qs4cx((n * ((k + 1) / 2)), 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_nxk_qs4cx_f32(
     n, k, rhs_f32.data(), rhs_qs4cx.data(), rhs_scales_f32.data());
@@ -1419,7 +1419,7 @@ TEST(nntrainer_fallback_kleidiai,
   nntrainer::__fallback_quant_qa8dx_f32(m, k, lhs_f32.data(), lhs_qa8dx.data());
 
   // Quantize RHS
-  std::vector<uint8_t> rhs_qs4cx((k * (n + 1) / 2), 0);
+  std::vector<uint8_t> rhs_qs4cx((k * ((n + 1) / 2)), 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_kxn_qs4cx_f32(
     n, k, rhs_f32.data(), rhs_qs4cx.data(), rhs_scales_f32.data());
@@ -1477,7 +1477,7 @@ static void verify_dequant_nxk_qs4cx(size_t n, size_t k) {
   std::vector<float> rhs_f32 =
     generate_random_vector<float>(n * k, -10.0f, 10.0f);
 
-  const size_t rhs_qs4cx_size = n * (k + 1) / 2;
+  const size_t rhs_qs4cx_size = n * ((k + 1) / 2);
   std::vector<uint8_t> rhs_qs4cx(rhs_qs4cx_size, 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_nxk_qs4cx_f32(
@@ -1501,7 +1501,7 @@ static void verify_dequant_kxn_qs4cx(size_t n, size_t k) {
   std::vector<float> rhs_f32 =
     generate_random_vector<float>(n * k, -10.0f, 10.0f);
 
-  const size_t rhs_qs4cx_size = k * (n + 1) / 2;
+  const size_t rhs_qs4cx_size = k * ((n + 1) / 2);
   std::vector<uint8_t> rhs_qs4cx(rhs_qs4cx_size, 0);
   std::vector<float> rhs_scales_f32(n, 0.0f);
   nntrainer::__fallback_quant_kxn_qs4cx_f32(

--- a/test/unittest/unittest_nntrainer_kleidiai.cpp
+++ b/test/unittest/unittest_nntrainer_kleidiai.cpp
@@ -62,8 +62,8 @@ TEST_P(gemm_qai8dxp_qsi4cxp_rhs_unpacked, check_ukernels) {
 
   // quantize rhs weight
   const size_t rhs_native_size_qs4cx = is_nxk
-                                         ? N * (K + 1) / 2 * sizeof(uint8_t)
-                                         : K * (N + 1) / 2 * sizeof(uint8_t);
+                                         ? N * ((K + 1) / 2) * sizeof(uint8_t)
+                                         : K * ((N + 1) / 2) * sizeof(uint8_t);
   const size_t rhs_scales_size_f32 = N * sizeof(float);
 
   uint8_t *rhs_native_mtx_qs4cx = new uint8_t[rhs_native_size_qs4cx];
@@ -144,7 +144,7 @@ TEST_P(gemm_qai8dxp_qsi4cxp, check_ukernels) {
   std::vector<float> dst(M * N);
 
   // quantize rhs weight
-  const size_t rhs_native_size_qs4cx = N * (K + 1) / 2 * sizeof(uint8_t);
+  const size_t rhs_native_size_qs4cx = N * ((K + 1) / 2) * sizeof(uint8_t);
   const size_t rhs_scales_size_f32 = N * sizeof(float);
 
   uint8_t *rhs_native_mtx_qs4cx = new uint8_t[rhs_native_size_qs4cx];
@@ -227,7 +227,7 @@ void test_f16_qai8dxp_qsi4cxp_cosine_similarity(size_t M, size_t N, size_t K) {
   std::vector<__fp16> dst_f16(M * N);
   std::vector<float> dst(M * N);
 
-  const size_t rhs_native_size_qs4cx = N * (K + 1) / 2 * sizeof(uint8_t);
+  const size_t rhs_native_size_qs4cx = N * ((K + 1) / 2) * sizeof(uint8_t);
   const size_t rhs_scales_size_f32 = N * sizeof(float);
 
   uint8_t *rhs_native_mtx_qs4cx = new uint8_t[rhs_native_size_qs4cx];


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Tensor] Fix qs4cx size rounding bug</summary><br />

The size of int4 quantized weight has been evaluated as (N * (K + 1)) / 2
which is different from the intended value N * ceil(K/2).
This commit fixes this bug and reduce consumed memory.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR fixes bug from the QS4CX data size.
- intended size : `N * ceil(K/2)`
- wrong size : `N * (K + 1) / 2`
- proper size : `N * ( (K + 1) / 2 )`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
