### PR TITLE
[causallm] Pass max_position_embeddings to base Transformer's and Gem…

### DIFF
--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
@@ -201,6 +201,7 @@ Tensor Gemma3Transformer::createAttention(const int layer_id, int seq_len,
      withKey("max_timestep", std::to_string(MAX_SEQ_LEN)),
      withKey("sliding_window", window_size),
      withKey("rope_theta", std::to_string(rope_theta)),
+     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
      withKey("max_new_tokens", std::to_string(NUM_TO_GENERATE)),
      withKey("attn_logit_softcapping", std::to_string(ATTN_LOGIT_SOFTCAPPING)),
      withKey("is_causal", IS_CAUSAL ? "true" : "false")}));

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -512,6 +512,7 @@ Tensor Transformer::createAttention(const int layer_id, int seq_len,
                                  ? SLIDING_WINDOW
                                  : UINT_MAX),
      withKey("rope_theta", ROPE_THETA),
+     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
      withKey("max_new_tokens", std::to_string(NUM_TO_GENERATE)),
      withKey("is_causal", IS_CAUSAL ? "true" : "false")}));
   Tensor a = mha({q, k, v, cache_k, cache_v});


### PR DESCRIPTION
### Summary                                                                                                
- Base Transformer's and Gemma3's MHA creation didn't pass `max_position_embeddings`, so both fell back to mha_core's 40,960-entry default RoPE tabreal config value.
- Pass `MAX_POSITION_EMBEDDINGS` through in both, matching how Qwen2/3, LFM2, Gemma4 and GPT-OSS already do it.
- Inspired by #4144 (clamps max_seq_len/init_seq_len to max_position_embeddings).


Signed-off-by: jayden0701 <jrock.oh@samsung.com>