### PR TITLE
[ci] enable failed test error log

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -65,6 +65,6 @@ jobs:
             build
       - run: ninja -C build
       - name: run App Tests
-        run: meson test -C build --no-suite unittests
+        run: meson test -C build --no-suite unittests --print-errorlogs
       - name: run Unittests
-        run: meson test -C build --suite unittests
+        run: meson test -C build --suite unittests --print-errorlogs

--- a/.github/workflows/daily_build_windows_arm.yml
+++ b/.github/workflows/daily_build_windows_arm.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite
-        run: meson test -C builddir
+        run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/daily_build_windows_x86_64.yml
+++ b/.github/workflows/daily_build_windows_x86_64.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite
-        run: meson test -C builddir
+        run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -91,6 +91,6 @@ jobs:
         PY
     - run: ninja -C build
     - name: run App Tests
-      run: meson test -C build --no-suite unittests
+      run: meson test -C build --no-suite unittests --print-errorlogs
     - name: run Unittests
-      run: meson test -C build --suite unittests
+      run: meson test -C build --suite unittests --print-errorlogs

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Run Build
       run: meson compile -C builddir
     - name: Run Test Suite
-      run: meson test -C builddir
+      run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite
-        run: meson test -C builddir
+        run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/windows_arm_clang.yml
+++ b/.github/workflows/windows_arm_clang.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite
-        run: meson test -C builddir
+        run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/windows_cross_compile.yml
+++ b/.github/workflows/windows_cross_compile.yml
@@ -97,4 +97,4 @@ jobs:
         run: Get-ChildItem -Path build_cross\test\unittest -Recurse
 
       - name: Run Test Suite
-        run: meson test -C build_cross --no-rebuild
+        run: meson test -C build_cross --no-rebuild --print-errorlogs


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[ci] enable failed test</summary><br />

As of now, there's no way to figure out the log when meson test fails on CI.
This commit adds --print-errorlogs to see the failed test log on CI.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
Let's print test failure log for CI.

You can find the difference from the #4165 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
