### PR TITLE
[layers] Fix 2x output-buffer overflow in ActiFunc::gelu/tanhGelu under FP16 activations

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -19,10 +19,8 @@
 #include <common_properties.h>
 #include <cpu_backend.h>
 
-#if defined(_WIN32)
-#define _USE_MATH_DEFINES
-#include <math.h>
-#endif
+#include <cmath>
+#include <type_traits>
 
 namespace nntrainer {
 
@@ -36,6 +34,19 @@ class ActiFunc {
 
 public:
   constexpr static inline float NEGATIVE_SLOPE = 0.01f;
+
+  /**
+   * @brief pi, as a plain constant of this header.
+   * @note  M_PI is not standard C++. The MSVC CRT only defines it when
+   *        _USE_MATH_DEFINES is defined *before* the first math header of the
+   *        translation unit is pulled in, and a header cannot guarantee that
+   *        for its consumers: <cmath> (here, or in any .cpp that includes this
+   *        file earlier) already brought in the include-guarded CRT math
+   *        header, so a later _USE_MATH_DEFINES has no effect. Carrying the
+   *        value here makes this header independent of include order. The
+   *        value is the same as the CRT/glibc M_PI, so results are unchanged.
+   */
+  constexpr static inline double PI = 3.14159265358979323846;
 
   /**
    * @brief     Constructor of ActiFunc
@@ -436,8 +447,24 @@ public:
    */
   template <typename T = float>
   static Tensor &gelu(Tensor const &t_in, Tensor &t_out) {
-    nntrainer::gelu_v2(t_in.size(), t_in.getData<float>(),
-                       t_out.getData<float>());
+    if constexpr (std::is_same_v<T, float>) {
+      nntrainer::gelu_v2(t_in.size(), t_in.getData<float>(),
+                         t_out.getData<float>());
+    } else {
+      /// @note cpu_backend exposes gelu_v2 for fp32 only, and getData<float>()
+      /// is an unchecked cast -- calling it for a non-fp32 activation would
+      /// read/write t_in.size() floats out of a buffer holding t_in.size()
+      /// T-sized elements. apply<T> walks the tensor with the correct element
+      /// type (and validates the output dtype). The accumulation is done in
+      /// float to match __fallback_gelu_v2's fp16 reference exactly.
+      t_in.apply<T>(
+        [](T x) {
+          const float xf = static_cast<float>(x);
+          return static_cast<T>(0.5f * xf *
+                                (1.0f + std::erf(xf * 0.7071067811f)));
+        },
+        t_out);
+    }
     return t_out;
   }
 
@@ -461,7 +488,7 @@ public:
       [&](T x) {
         return static_cast<T>(
           0.5 * (1 + erf(x * tmp) +
-                 x * ((2 / sqrt(M_PI)) * exp(-pow(x * tmp, 2))) * tmp));
+                 x * ((2 / sqrt(PI)) * exp(-pow(x * tmp, 2))) * tmp));
       },
       outgoing_derivative);
 
@@ -477,8 +504,23 @@ public:
    */
   template <typename T = float>
   static Tensor &tanhGelu(Tensor const &t_in, Tensor &t_out) {
-    nntrainer::tanh_gelu(t_in.size(), t_in.getData<float>(),
-                         t_out.getData<float>());
+    if constexpr (std::is_same_v<T, float>) {
+      nntrainer::tanh_gelu(t_in.size(), t_in.getData<float>(),
+                           t_out.getData<float>());
+    } else {
+      /// @note see gelu() above: cpu_backend's tanh_gelu declaration is fp32
+      /// only, so a non-fp32 activation must not go through getData<float>().
+      /// Accumulated in float to match __fallback_tanh_gelu's fp16 reference.
+      t_in.apply<T>(
+        [](T x) {
+          const float xf = static_cast<float>(x);
+          return static_cast<T>(
+            0.5f * xf *
+            (1.0f +
+             std::tanh(0.7978845608f * (xf + 0.044715f * xf * xf * xf))));
+        },
+        t_out);
+    }
     return t_out;
   }
 


### PR DESCRIPTION
`ActiFunc::gelu` and `ActiFunc::tanhGelu` are templates on the activation element type `T`, but their
bodies hardcode `getData<float>()` on an **element** count. `Tensor::getData<T>()` is an unchecked
cast that does not consult the tensor's real data type, so with `T = _FP16` the call hands a buffer of
N 2-byte elements to a routine that reads N 4-byte floats and writes N 4-byte floats: it reads 2x past
the end of the input and **overflows the output buffer by 2x**. Heap corruption, not merely wrong
numerics.

This is reachable. `ActivationLayer::finalize` really does select the `_FP16` instantiation when
`getActivationDataType() == FP16`, and ten of the `ModelTensorDataTypeInfo` strings are `*-FP16`.
In-tree consumers of the two affected activation nodes: `gelu` in the BERT, TIMM-ViT and DeBERTa-v2
CausalLM models, `tanh_gelu` in Gemma3. Any of those loaded with an `*-FP16` `model_tensor_type`
corrupts the heap in its MLP activation. It went unnoticed because every `model_tensor_type` committed
to this tree is `FP32-FP32` or `Q4_0-FP32`, so CI only ever instantiates `T = float`, where the cast
happens to be correct.

Fix keeps the accelerated fp32 path (`gelu_v2` / `tanh_gelu` are AVX2- and NEON-vectorized;
de-SIMDing fp32 would be a real regression) behind an `if constexpr (std::is_same_v<T, float>)` and
routes every other `T` through `Tensor::apply<T>()`, which walks the tensor with the correct element
type and additionally throws if the output dtype disagrees — exactly what the neighbouring
`sigmoidGelu` already does. The lambdas accumulate in float and cast back to `T`, reproducing the
existing `__fallback_gelu_v2` / `__fallback_tanh_gelu` fp16 references bit for bit.

**New in this rung:** `[layers] Fix 2x output-buffer overflow in ActiFunc::gelu/tanhGelu under FP16
activations`.

**Not included:** no new activation kernels, no dispatch changes.

**Validated:** CPU build (`-Denable-opencl=false -Denable-cuda=false -Denable-fp16=false`) and an
fp16-enabled build compile clean; the fp32 path is unchanged by construction.
**Honest empty cell:** there is **no in-tree `*-FP16` activation fixture**, so this cannot be closed
by a committed regression test today. Closing it needs either a committed FP16-activation reference
config or an ASAN build over one of the four affected models.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
