### PR TITLE
[init-latency] Stop double zero-filling QS4CX weight payloads

### DIFF
--- a/nntrainer/tensor/qs4cx_tensor.cpp
+++ b/nntrainer/tensor/qs4cx_tensor.cpp
@@ -9,10 +9,60 @@
  */
 
 #include <cpu_backend.h>
+#include <cstdlib>
 #include <qs4cx_tensor.h>
 #include <tensor.h>
 
 namespace nntrainer {
+
+namespace {
+/**
+ * @brief VALUE-checked env truthiness: set, non-empty, and not starting with
+ *   '0', so that NNTR_QS4CX_ALLOC_ZERO=0 really is "off" rather than "present,
+ *   therefore on". Kept file-local on purpose: this translation unit must
+ *   compile against a tree that ships no shared env helper, and a header that
+ *   only this file would consume does not belong in the public include set.
+ */
+bool envOn(const char *name) {
+  const char *e = std::getenv(name);
+  return e != nullptr && e[0] != '\0' && e[0] != '0';
+}
+
+/**
+ * @brief [init-latency L1] Is this process's QS4CX payload allocation
+ *   load-destined, i.e. may allocate() hand back UNINITIALIZED memory?
+ *
+ * NNTR_QS4CX_HEAP_BYPASS is exactly the "self-owned weight payload about to be
+ * filled from the model file" signal: Manager::requestWeights only takes the
+ * bypass branch (weight_pool.request(UNMANAGED) + var->allocate()) under it,
+ * and every QS4CX tensor reached that way is a weight (the only other producer
+ * is the offline quantize tool, which never sets this env). Both zero passes
+ * that allocate() used to do -- `new uint8_t[size()]{}` and
+ * initialize()->setZero() -- are dead stores there: the payload is
+ * subsequently overwritten IN FULL, either by TensorBase::read (bytes() ==
+ * size() for QS4CX, since its data-type size is 1 and size() is overridden to
+ * the packed nibble+scale byte count) or by copy_qs4cx (scopy over size()).
+ *
+ * TRIPWIRE FOR FUTURE READERS. "Uninitialized is safe" holds only while EVERY
+ * reader of this payload writes all size() bytes. It is true of every reader in
+ * this tree today (TensorBase::read and copy_qs4cx, both above). It is NOT
+ * automatically true of a partial writer, and one such reader exists in the
+ * sibling trees: the legacy on-disk QINT4 -> QS4CX transcode. There, for even
+ * K, the QS4CX scale offset is `N*(K+1)/2` evaluated left-to-right
+ * (= N*K/2 + N/2) while the nibble region is only N*(K/2) bytes, so an
+ * N/2-byte gap sits between them that the transcode never touches; it used to
+ * be zero purely by virtue of the allocation. If that read path (or any other
+ * partial writer) is ever added here, it MUST call setZero() before
+ * transcoding, or the gap becomes uninitialized heap.
+ *
+ * Escape hatch: NNTR_QS4CX_ALLOC_ZERO=1 restores the old double zero-fill.
+ */
+bool qs4cxAllocUninitialized() {
+  static const bool v =
+    envOn("NNTR_QS4CX_HEAP_BYPASS") && !envOn("NNTR_QS4CX_ALLOC_ZERO");
+  return v;
+}
+} // namespace
 
 QS4CX_Tensor::QS4CX_Tensor(std::string name_, Tformat fm) :
   TensorBase(name_, fm) {
@@ -47,14 +97,23 @@ void QS4CX_Tensor::allocate() {
   } else {
     MemoryData *mem_data;
 
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
+    // [init-latency L1] Load-destined payload: allocate UNINITIALIZED and skip
+    // initialize(). See qs4cxAllocUninitialized() for why both zero passes are
+    // dead stores. The page faults are NOT saved -- they move to the read()
+    // that fills the buffer -- but the two full-arena writes are.
+    const bool uninit = qs4cxAllocUninitialized();
+    mem_data = new MemoryData(uninit ? (void *)(new uint8_t[size()])
+                                     : (void *)(new uint8_t[size()]{}));
     data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
       delete[] mem_data->template getAddr<uint8_t>();
       delete mem_data;
     });
 
     offset = 0;
-    initialize();
+    if (uninit)
+      putData();
+    else
+      initialize();
   }
 }
 


### PR DESCRIPTION
`QS4CX_Tensor::allocate()` zeroed its payload **twice** — `new uint8_t[size()]{}` and then
`initialize() -> setZero()` — and on the only path that reaches it in an inference process both
passes are dead stores: the weight's self-owned heap payload is overwritten in full by
`NeuralNetwork::load` (`TensorBase::read` writes `bytes()`, which for QS4CX equals `size()`;
`copy_qs4cx` scopy's `size()`). The zeroing was pure init latency.

This allocates uninitialized and skips `initialize()` on that path (`putData()` is still called, so
the `MemoryData` invalidate hook fires exactly as before). Page faults are **not** saved — they move
to the `read()` that fills the buffer — but the two full-arena writes are.

The argument is only as strong as the claim "every reader writes all `size()` bytes", so that was
audited on this tree and the audit is in the commit message: `TensorBase::read(std::ifstream)` /
`read(ReadSource)` write `bytes() == size()`; `copy_qs4cx` covers `size()`; `readFSU` is a no-op and
the path is gated `!enable_fsu`. There is no other reader — `QS4CX_Tensor` has no `read()` override
here. A tripwire is recorded in the `qs4cxAllocUninitialized()` doc comment for the one known partial
writer that does **not** exist in this tree (a legacy on-disk QINT4 → QS4CX transcode leaves an
N/2-byte hole between the nibble and scale regions for even K), so whoever ports that read path in
cannot miss the requirement.

Escape hatch: `NNTR_QS4CX_ALLOC_ZERO=1` restores the old double zero-fill — which is also the bisect
handle for any init-latency claim built on this rung.

Measured on a prior device session (35-layer sliding-window QS4CX-FP16 model, Intel Xe3, OpenCL,
warm, 3 runs each): `model_graph.initialize` **731.8 ms → 8.3 ms**, whole init **1593/1572/1514 ms →
893/979/947 ms**, peak RSS ~3.15 GB → ~1.7–2.0 GB, loader-join time +81 ms (the faults that moved),
generated text byte-identical to baseline.

**New in this rung:** `[init-latency] L1: stop double zero-filling QS4CX weight payloads`.

**Not included:** the Windows `VirtualAlloc` bypass branch (this tree's `allocate()` has only the CRT
heap branch), and the legacy QINT4 transcode guard (nothing to guard here — recorded as a tripwire
instead of a stub).

**Not verified on this tree:** golden-text identity with the lever on, and the hatch control
(`NNTR_QS4CX_ALLOC_ZERO=1`) reproducing the pre-port `init_ms`. The numbers above are from the prior
device session, not from this branch.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
