### PR TITLE
[loader] Fail loud on a weight-name miss and on a model-layout mismatch

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1255,8 +1255,18 @@ void NeuralNetwork::load(const std::string &file_path,
           continue;
         const std::string &name = weight->getName();
         auto it = name_offset_map.find(name);
-        if (it == name_offset_map.end())
+        if (it == name_offset_map.end()) {
+          // A name miss used to be a SILENT wrong-data path: file_offset keeps
+          // its default of 0, so the weight is later read from byte 0 of the
+          // file -- the 8-byte header length plus the ASCII JSON header, whose
+          // byte pairs decode as fp16 5.3e4..6.1e4. That is indistinguishable
+          // from a plausible-but-wrong weight downstream, and the EOF tripwire
+          // cannot catch it because offset 0 never overruns. Say so.
+          ml_logw("safetensors: no record named '%s' in %s; this weight keeps "
+                  "file offset 0 and will read the container header as data",
+                  name.c_str(), f_path.c_str());
           continue;
+        }
         const size_t file_off = data_base + it->second.first;
         weight->getVariableRef().setFileOffset(file_off);
       }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -995,6 +995,24 @@ void NeuralNetwork::load(const std::string &file_path,
     auto model_file =
       checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
 
+    // Layout tripwire: the per-tensor file offsets computed above are trusted
+    // blindly by the (parallel, mmap-backed) reader below — if the graph's
+    // idea of a weight's on-disk size disagrees with what the file actually
+    // contains (e.g. a dtype mismatch between the requested weight and the
+    // stored record), every later tensor is positionally misloaded and the
+    // final reads run PAST THE END of the mapping (SIGSEGV in a load worker,
+    // far from the actual bug). Fail fast with an actionable message instead.
+    {
+      model_file.seekg(0, std::ios::end);
+      const auto f_bytes = static_cast<size_t>(model_file.tellg());
+      model_file.seekg(0, std::ios::beg);
+      NNTR_THROW_IF(start_from > f_bytes, std::runtime_error)
+        << "Model layout mismatch: graph expects " << start_from
+        << " bytes of weights but file '" << f_path << "' has only " << f_bytes
+        << " bytes. A weight's requested dtype/size disagrees with the stored "
+           "record (offsets would run past EOF).";
+    }
+
 #if defined(_WIN32)
     HANDLE hFile, hMap;
 #endif


### PR DESCRIPTION
Two silent-wrong-data / late-crash paths in the model loader, both hardening, no behaviour change on
a well-formed package.

1. **Name-miss reads the container header as weight data.** `NeuralNetwork::load`'s safetensors path
   assigns each weight its file offset **by name**; on a miss it just `continue`d, leaving
   `file_offset` at its default `0`. The weight is then read from byte 0 of the file: the 8-byte
   header length followed by the ASCII JSON header. Those byte pairs decode as fp16 5.3e4…6.1e4 —
   large-but-finite values indistinguishable from a plausible weight to everything downstream, and
   the EOF tripwire cannot catch it because offset 0 never overruns. Now logs the tensor name and the
   file. Warning, not a throw: a genuinely optional record is a legitimate miss, and turning this
   into a hard error needs a per-model audit this change is not making.

2. **Layout mismatch SIGSEGVs on a loader thread.** The per-tensor offsets are trusted blindly by the
   parallel mmap reader, so any graph-vs-file size disagreement surfaces as a `memcpy` past the end
   of the mapping — a crash on a worker thread, far from the actual bug. This compares the computed
   layout total against the real file size up front and throws with both numbers. Demonstrated on a
   QINT4-FP16 qwen3 package where the graph sizes QINT4 records by
   `Int4QTensor::getMemoryBytes()` while the container on disk stores the plain PR#3978 layout
   (graph expects 375,483,784 vs 348,646,792 on disk): that package now errors with an actionable
   message instead of crashing.

**New in this rung:** `[loader] Warn instead of silently reading the container header as weight data`
and `union-fixup: fail fast on model-layout mismatch instead of SIGSEGV in a load worker`.

**Not included:** the read-time QINT4 → QS4CX transcode that would make the mismatched package
actually load. That is a separate loader rung; this change only makes its absence diagnosable.

**Validated:** silent on all four target packages (a 35-layer sliding-window QS4CX-FP16 model,
gemma4, qwen3, gemma2 — 0 warnings each; they load through the positional `.bin` path, not this one),
so neither message is the cause of any current defect.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
