### PR TITLE
[tensor] x86 host QS4CX GEMM for HalfTensor::dot

### DIFF
--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -35,14 +35,22 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     << "feature size must be a divisor of width";
 
   if (use_gamma) {
-    // gamma follows the model weight dtype (packed=false clamps it to the
-    // activation dtype), matching what the quantizer wrote to the bin.
-    // Hardcoding FP32 misloads/overruns *-FP16 bins whose gammas are FP16;
-    // the multiply site's dtype-cast guard covers either stored dtype.
+    // gamma is never quantized, but a bin stores it at the model's FLOAT
+    // dtype, so an FP16-activation package holds 2 bytes per element. Ask for
+    // the context's weight dtype when that dtype is itself a float type, and
+    // FP32 otherwise -- the same rule as rms_norm.cpp and the core
+    // nntrainer/layers/llm/rms_norm_layer.cpp, which carries the full note.
+    // These q/k/v norms are counted in the same packed weight stream, so a
+    // constant FP32 here shifts every later offset on an FP16 package.
+    const auto norm_w_dtype = context.getWeightDataType();
+    const auto norm_dtype =
+      (norm_w_dtype == nntrainer::TensorDim::DataType::FP32 ||
+       norm_w_dtype == nntrainer::TensorDim::DataType::FP16)
+        ? norm_w_dtype
+        : nntrainer::TensorDim::DataType::FP32;
     nntrainer::TensorDim gamma_dim(
       1, 1, 1, feature_size,
-      nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       context.getWeightDataType()));
+      nntrainer::TensorDim::TensorType(context.getFormat(), norm_dtype));
     wt_idx[RMSParams::gamma] = context.requestWeight(
       gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -35,13 +35,14 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     << "feature size must be a divisor of width";
 
   if (use_gamma) {
-    // gamma is unquantized FP32 on disk; request FP32 regardless of activation
-    // dtype (FP16 would reinterpret the FP32 bytes and corrupt gamma). The FP16
-    // path casts gamma down at the multiply site.
+    // gamma follows the model weight dtype (packed=false clamps it to the
+    // activation dtype), matching what the quantizer wrote to the bin.
+    // Hardcoding FP32 misloads/overruns *-FP16 bins whose gammas are FP16;
+    // the multiply site's dtype-cast guard covers either stored dtype.
     nntrainer::TensorDim gamma_dim(
       1, 1, 1, feature_size,
       nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       nntrainer::TensorDim::DataType::FP32));
+                                       context.getWeightDataType()));
     wt_idx[RMSParams::gamma] = context.requestWeight(
       gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -28,17 +28,29 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  // gamma follows the model weight dtype (packed=false clamps it to the
-  // activation dtype). Quantized *-FP16 bins store the norm weights as FP16;
-  // hardcoding FP32 here positionally misloads every weight after the first
-  // gamma AND overruns the mmap'd file by 2 bytes/element (SIGSEGV in the
-  // parallel load worker). The multiply site carries a dtype-cast guard, so
-  // FP32-gamma bins (upstream's own layout) still load when the model weight
-  // dtype is FP32.
+  // gamma is never quantized, but it is not unconditionally FP32 either: a bin
+  // stores it at the model's FLOAT dtype, so an FP16-activation package holds
+  // 2 bytes per element. Ask for the context's weight dtype when that dtype is
+  // itself a float type, and FP32 otherwise -- see the note in the core
+  // nntrainer/layers/llm/rms_norm_layer.cpp, which this layer mirrors:
+  //   - a hard FP32 over-requests on an FP16 package and, because weights are
+  //     a packed stream in graph order, shifts every later offset until the
+  //     loader rejects the layout;
+  //   - a bare getWeightDataType() is only safe while every caller passes
+  //     packed=false (LayerNode::finalize() then sets tensor_type[1] =
+  //     tensor_type[2] before InitLayerContext exists); the float-type test
+  //     keeps a caller that forgets it from requesting a block-quantized
+  //     gamma.
+  // The FP16 forward path casts gamma down at the multiply site either way.
+  const auto norm_w_dtype = context.getWeightDataType();
+  const auto norm_dtype =
+    (norm_w_dtype == nntrainer::TensorDim::DataType::FP32 ||
+     norm_w_dtype == nntrainer::TensorDim::DataType::FP16)
+      ? norm_w_dtype
+      : nntrainer::TensorDim::DataType::FP32;
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()));
+    nntrainer::TensorDim::TensorType(context.getFormat(), norm_dtype));
   wt_idx[RMSParams::gamma] = context.requestWeight(
     gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -28,14 +28,17 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  // gamma is unquantized and stored as FP32 in the bin. Request it as FP32
-  // regardless of the activation dtype; declaring it FP16 reinterprets the
-  // on-disk FP32 bytes as FP16 and corrupts gamma (≈FP16-max garbage). The
-  // FP16 forward path casts gamma down to FP16 at the multiply site.
+  // gamma follows the model weight dtype (packed=false clamps it to the
+  // activation dtype). Quantized *-FP16 bins store the norm weights as FP16;
+  // hardcoding FP32 here positionally misloads every weight after the first
+  // gamma AND overruns the mmap'd file by 2 bytes/element (SIGSEGV in the
+  // parallel load worker). The multiply site carries a dtype-cast guard, so
+  // FP32-gamma bins (upstream's own layout) still load when the model weight
+  // dtype is FP32.
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
     nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     nntrainer::TensorDim::DataType::FP32));
+                                     context.getWeightDataType()));
   wt_idx[RMSParams::gamma] = context.requestWeight(
     gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -365,7 +365,17 @@ void Transformer::repack_weight() {
       for (auto &w : weights) {
         if (w->getVariableRef().getDataType() ==
             ml::train::TensorDim::DataType::QS4CX) {
-          w->getVariableRef().pack();
+          // KAI rhs-pack is the ARM (i8mm) CPU GEMM's in-memory derivation;
+          // on x86 it is NYI and the x86 CPU GEMM + the GPU v8c path consume
+          // the plain on-disk QS4CX (nibbles + fp32 scales) directly.
+          // Skip-on-NYI so a single QS4CX weight set loads on every backend
+          // (ARM packs, x86/GPU use the plain blob).
+          try {
+            w->getVariableRef().pack();
+          } catch (const std::exception &e) {
+            ml_logd("QS4CX pack skipped (engine consumes plain blob): %s",
+                    e.what());
+          }
         }
       }
     };

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -12,10 +12,37 @@
  */
 #include <model_common_properties.h>
 
+#include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <util_func.h>
 
+#ifdef ENABLE_FP16
+#include <half_tensor.h>
+#endif
+
 namespace nntrainer::props {
+
+namespace {
+
+/**
+ * @brief Can a matmul on this build take an FP16 activation and a QS4CX
+ * weight?
+ *
+ * HalfTensor::dot() is the only host implementation of that product, and it
+ * carries the QS4CX case only where NNTR_HAS_HOST_QS4CX_FP16_GEMM (declared
+ * next to the case, in half_tensor.h) is 1. Without ENABLE_FP16 there is no
+ * HalfTensor at all, so the answer is trivially no.
+ */
+constexpr bool hasHostQs4cxFp16Gemm() {
+#if defined(ENABLE_FP16) && NNTR_HAS_HOST_QS4CX_FP16_GEMM
+  return true;
+#else
+  return false;
+#endif
+}
+
+} // namespace
+
 Epochs::Epochs(unsigned int value) { set(value); }
 
 bool LossType::isValid(const std::string &value) const {
@@ -37,6 +64,18 @@ FsuPath::FsuPath(const std::string &value) { set(value); }
 FsuLookahead::FsuLookahead(const unsigned int &value) { set(value); }
 ModelTensorDataType::ModelTensorDataType(ModelTensorDataTypeInfo::Enum value) {
   set(value);
+}
+
+void ModelTensorDataType::set(const ModelTensorDataTypeInfo::Enum &value) {
+  NNTR_THROW_IF(value == ModelTensorDataTypeInfo::Enum::WQS4CXA16 &&
+                  !hasHostQs4cxFp16Gemm(),
+                std::invalid_argument)
+    << "model_tensor_type=QS4CX-FP16 needs a host GEMM that multiplies an "
+       "FP16 activation by a QS4CX weight, and this build has none, so every "
+       "QS4CX fully connected layer would throw at its first matmul. Build "
+       "with enable-fp16 on x86, or use model_tensor_type=QS4CX-FP32.";
+
+  EnumProperty<ModelTensorDataTypeInfo>::set(value);
 }
 LossScale::LossScale(float value) { set(value); }
 

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -239,6 +239,18 @@ public:
    */
   ModelTensorDataType(ModelTensorDataTypeInfo::Enum value =
                         ModelTensorDataTypeInfo::Enum::W32A32);
+
+  /**
+   * @brief set the weight/activation dtype pair, rejecting pairs this build
+   * has no kernel for
+   *
+   * @param value value to set
+   * @throw std::invalid_argument if no host GEMM in this build can multiply
+   * the activation dtype by the weight dtype. Accepting such a pair here only
+   * defers the failure to the first matmul, where it surfaces as
+   * "unsupported datatype" (or, worse, as a silently wrong result).
+   */
+  void set(const ModelTensorDataTypeInfo::Enum &value) override;
 };
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
@@ -496,9 +496,24 @@ template <>
 void __fallback_rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
                                                   _FP16 *__restrict Y, size_t H,
                                                   size_t W, float epsilon) {
-
-  throw std::runtime_error(
-    "NYI : __fallback_rms_norm_wrt_width_fp16_intrinsic with FP16 type input");
+  // Scalar reference: the sum-of-squares MUST be accumulated in FP32 — a
+  // fp16 accumulator overflows past 65504 on a wide residual row and turns
+  // the scale into +Inf. Matches the neon_impl_fp16 semantics so x86
+  // fp16-activation builds (which have no SIMD impl and land here) compute
+  // the same result instead of throwing NYI.
+  for (size_t r = 0; r < H; ++r) {
+    const _FP16 *xr = X + r * W;
+    _FP16 *yr = Y + r * W;
+    float ss = 0.0f;
+    for (size_t k = 0; k < W; ++k) {
+      const float v = static_cast<float>(xr[k]);
+      ss += v * v;
+    }
+    const float inv = 1.0f / std::sqrt(ss / static_cast<float>(W) + epsilon);
+    for (size_t k = 0; k < W; ++k) {
+      yr[k] = static_cast<_FP16>(static_cast<float>(xr[k]) * inv);
+    }
+  }
 }
 
 template <>

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -9,10 +9,15 @@
  * @bug		No known bugs except for NYI items
  */
 
+#include <algorithm>
+#include <atomic>
 #include <iomanip>
 #include <iostream>
+#include <thread>
+#include <vector>
 
 #include <compute_ops.h>
+#include <cpu_backend.h>
 #include <half_tensor.h>
 #include <tensor.h>
 #include <util_func.h>
@@ -719,6 +724,76 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
+#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
+  defined(__i386__)
+  case Tdatatype::QS4CX: {
+    // x86 host fallback: there is no KAI fp16 micro-kernel here (ARM i8mm), so
+    // an fp16-activation QS4CX FC that lands on the host (e.g. NNTR_ENGINE=cpu,
+    // or a GPU path that bails) would otherwise kill the process with
+    // "unsupported datatype". Route the CANONICAL x86 QS4CX GEMM -- the same
+    // gemm_qai8dxp_qsi4cxp_rhs_unpacked(is_nxk=true) entry point
+    // FloatTensor::dotQs4cx uses -- with the activation widened to fp32 and the
+    // fp32 result narrowed back to fp16. There is deliberately NO nibble decode
+    // here: the plain QS4CX payload is [N][ceil(K/2)] row-major with K
+    // contiguous, even k in the LOW nibble, each stored uint4 = int4 + 8, and
+    // the per-output-channel fp32 scales appended at QS4CX_Tensor::getScale --
+    // a layout that already has exactly one decoder per backend (host:
+    // __fallback_matmul_mxn_mxk_nxk_f32_qa8dx_qs4cx; GPU:
+    // make_v8c_weight_backing_from_qs4cx). Duplicating it here is what made
+    // every host QS4CX FC produce garbage.
+    //
+    // Work split: one canonical call per (row, N-chunk), parallel over the
+    // chunks. The kernel re-quantizes the row (K work per nb*K of GEMM) on
+    // every chunk -- the per-row scale/offset depends on the row alone, so the
+    // result is chunk-count independent -- and the fp32 staging stays at
+    // `chunk` floats per worker instead of M*N (the untied lm_head is
+    // N = 262144).
+    const unsigned int M = getDim().height();
+    const unsigned int K = getDim().width();
+    const unsigned int N = output.getDim().width();
+    const uint8_t *plain = input.getData<uint8_t>();
+    const float *fscale = input.getScale<float>();
+    const _FP16 *xact = (const _FP16 *)getData();
+    _FP16 *yout = output.getData<_FP16>();
+    const size_t Ms = M, Ns = N, Ks = K;
+    const size_t plain_row_bytes = (Ks + 1) / 2;
+    // The canonical GEMM takes an fp32 lhs (it does its own per-row dynamic
+    // int8 quantization, as the QS4CX weight format requires).
+    std::vector<float> xact_f32(Ms * Ks);
+    for (size_t i = 0; i < Ms * Ks; ++i)
+      xact_f32[i] = (float)xact[i];
+    const unsigned int nthreads =
+      std::max(1u, std::thread::hardware_concurrency());
+    std::atomic<size_t> next_n{0};
+    const size_t chunk = 256;
+    auto worker = [&]() {
+      std::vector<float> acc(chunk);
+      for (;;) {
+        const size_t n0 = next_n.fetch_add(chunk);
+        if (n0 >= Ns)
+          return;
+        const size_t n1 = std::min(Ns, n0 + chunk);
+        const size_t nb = n1 - n0;
+        for (size_t mi = 0; mi < Ms; ++mi) {
+          gemm_qai8dxp_qsi4cxp_rhs_unpacked(
+            1, nb, Ks, (void *)(xact_f32.data() + mi * Ks),
+            (void *)const_cast<uint8_t *>(plain + n0 * plain_row_bytes),
+            (void *)const_cast<float *>(fscale + n0), acc.data(), 0, true,
+            -65504.f, 65504.f);
+          _FP16 *yr = yout + mi * Ns;
+          for (size_t j = 0; j < nb; ++j)
+            yr[n0 + j] = (_FP16)acc[j];
+        }
+      }
+    };
+    std::vector<std::thread> pool;
+    for (unsigned int t = 0; t < nthreads; ++t)
+      pool.emplace_back(worker);
+    for (auto &t : pool)
+      t.join();
+    break;
+  }
+#endif
   default:
     throw std::invalid_argument("Error: unsupported datatype");
   }

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -724,8 +724,7 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
-#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
-  defined(__i386__)
+#if NNTR_HAS_HOST_QS4CX_FP16_GEMM
   case Tdatatype::QS4CX: {
     // x86 host fallback: there is no KAI fp16 micro-kernel here (ARM i8mm), so
     // an fp16-activation QS4CX FC that lands on the host (e.g. NNTR_ENGINE=cpu,

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -21,6 +21,31 @@
 #define EXCEPT_WHEN_DEBUG noexcept
 #endif
 
+/**
+ * @brief 1 when this build has a host GEMM that can multiply an FP16
+ * activation by a QS4CX weight, i.e. when HalfTensor::dot() has a
+ * Tdatatype::QS4CX case.
+ *
+ * This is the ONLY place the condition is written down: HalfTensor::dot()
+ * guards its QS4CX case with this macro, and the model_tensor_type validation
+ * (nntrainer/models/model_common_properties.cpp) rejects "QS4CX-FP16" when it
+ * is 0, so that an unsupported build fails at property-set time with a
+ * message instead of at the first FC with "unsupported datatype".
+ *
+ * x86 only for now: the case widens the activation to FP32 and calls
+ * gemm_qai8dxp_qsi4cxp_rhs_unpacked(), which consumes the plain (unpacked)
+ * QS4CX blob x86 keeps in memory. On ARM the same weight is KAI rhs-packed
+ * (Tensor::pack()), so the unpacked kernel cannot read it and the packed
+ * FP16 KleidiAI micro-kernels are not dispatched yet. When a backend gains a
+ * case, extend this macro and the switch case together.
+ */
+#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
+  defined(__i386__)
+#define NNTR_HAS_HOST_QS4CX_FP16_GEMM 1
+#else
+#define NNTR_HAS_HOST_QS4CX_FP16_GEMM 0
+#endif
+
 namespace nntrainer {
 
 /**


### PR DESCRIPTION
`origin/main`'s `half_tensor.cpp` has **zero** QS4CX references, so `HalfTensor::dot` has no QS4CX case
at all: an fp16-activation QS4CX model has no host GEMM to fall back to on x86. This adds one.

Fix by delegation rather than a fourth hand-rolled decoder: the new case calls
`gemm_qai8dxp_qsi4cxp_rhs_unpacked(..., is_nxk=true)` — the exact x86 entry point
`FloatTensor::dotQs4cx` already uses — with the fp16 activation widened to fp32 per chunk and the
fp32 result narrowed back, instead of decoding the packed nibble layout a third time. Staging is
`chunk` floats per worker, not `M*N` (an untied lm_head is `N = 262144`).

**Why this is one squashed commit, not two.** The internal precursor of this port hand-decoded the
nibble payload and got the layout wrong three independent ways (wrong axis order, wrong nibble half,
signed instead of unsigned offset — the full derivation against the two in-tree layout authorities,
the GPU v8c weight builder and the host reference GEMM, is in the commit message). Publishing that
precursor even for one commit would introduce a known-wrong decoder that never existed upstream, so
only the corrected version is here.

Also carries four small x86 fp16-activation gaps that the same work unmasked, unrelated to the QS4CX
decoder: `rms_norm` / `reshaped_rms_norm` read gamma at `context.getWeightDataType()` instead of a
hardcoded FP32 (matching `*-FP16` packages that store norm gammas at the model weight dtype),
`fallback_internal_fp16`'s `rms_norm_wrt_width_fp16` scalar reference (was an NYI throw), and
`Transformer::repack_weight` skipping on NYI per weight so x86 (no KleidiAI rhs-pack) loads the plain
QS4CX blob instead of aborting.

**New in this rung:** `[tensor] x86 host QS4CX GEMM for HalfTensor::dot (squash, correct decoder only)`.

**Not included:** the ARM case in the same `#if/#elif` block
(`nntr_gemm_qai8dxp_qsi4cxp_packed<_FP16>`) — it depends on the KleidiAI fp16 packed-weight
infrastructure, which is a separate PR in this series, and does not exist on `main` (0 grep hits in
`half_tensor.cpp`). The x86 `#elif` therefore becomes a standalone `#if`; the case body, guard
condition and parallel-chunk logic are otherwise unchanged.

**Not verified here (git-only work; measurement host was in use):** x86 + `ENABLE_FP16` + OpenCL
build; `NNTR_ENGINE=cpu` on qwen3/gemma4/gemma2; `Gemma4DifferentialTest.Q40CloseToFP32Reference`;
`unittest_causallm_models`. The switch-case adaptation was verified by inspection against
`float_tensor.cpp`'s identical `dotQs4cx` pattern only.

**Three-axis note:** structure ++ (one decoder per backend, matching the existing x86/ARM/GPU QS4CX
authorities instead of adding a fourth); performance ~ (adds an `M*K` fp32 staging copy plus int8
requantization per call, on the host QS4CX-FP16 fallback path only); memory 0 (chunk-sized staging).

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
