### PR TITLE
[opencl/q4_0] Gate the CL q4_0 accel path on prepack shape eligibility

### DIFF
--- a/nntrainer/tensor/cl_operations/cl_compute_ops.cpp
+++ b/nntrainer/tensor/cl_operations/cl_compute_ops.cpp
@@ -26,17 +26,50 @@
 
 #include <blas_kernels.h>
 #include <compute_ops.h>
+#include <cpu_backend.h> // gemm_q4_0 (host route for CL-ineligible shapes)
 
 namespace nntrainer {
+
+namespace {
+/**
+ * @brief Whether one (N, K) Q4_0 weight can enter the CL accel route.
+ *
+ * Both CL entry points (gemm_q4_0_cl / gemm_q4_0_async_cl) prepack the
+ * Q4_0x8 weight on the host with unpack_q4_0x8_transpose16, whose x86
+ * implementation is an AVX2 256-wide K unroll asserting (K % 256) == 0 and
+ * (N % 8) == 0 (avx2_impl.cpp); the kernel's NDRange (N/4 columns) needs
+ * N % 4 == 0, subsumed by N % 8. Ineligible shapes (e.g. the hidden=64
+ * tiny test fixtures) take the host gemm_q4_0 below instead.
+ */
+bool cl_q4_0_shape_eligible(unsigned int N, unsigned int K) {
+  return (K % 256) == 0 && (N % 8) == 0;
+}
+} // namespace
 
 class ClComputeOps : public ComputeOps {
 public:
   // ── Accelerator-only Q4_0 / INT4 GEMM/GEMV ────────────────
+  // The Q4_0 supports_*() predicates are shape-blind, so the shape gate lives
+  // here in the CL wrappers: eligible shapes take the CL kernels unchanged,
+  // ineligible ones bounce to the host gemm_q4_0 — the same generic route the
+  // cpu engine's gemm_q4_0_fp32 uses (cpu_ops_table.h), on the same host/SVM
+  // pointers the caller handed us. That host bounce is deliberate, not hidden:
+  // there is no CL fallback kernel for these shapes.
   bool supports_gemm_q4_0_batch_fp32() const override { return true; }
   void gemm_q4_0_batch_fp32(std::vector<void *> matAdata, float *matBdata,
                             std::vector<float *> matCdata, unsigned int M,
                             std::vector<unsigned int> N,
                             unsigned int K) override {
+    bool eligible = true;
+    for (unsigned int n : N)
+      eligible = eligible && cl_q4_0_shape_eligible(n, K);
+    if (!eligible) {
+      // Whole batch on host (mirrors float_tensor.cpp's non-accel loop).
+      for (size_t i = 0; i < matAdata.size(); ++i)
+        nntrainer::gemm_q4_0(M, N[i], K, matBdata, K, matAdata[i], N[i],
+                             matCdata[i], N[i]);
+      return;
+    }
     nntrainer::gemm_q4_0_async_cl(matAdata, matBdata, matCdata, M, N, K);
   }
 
@@ -44,7 +77,24 @@ public:
   void gemm_q4_0_accel_fp32(void *matAdata, float *matBdata, float *matCdata,
                             unsigned int M, unsigned int N,
                             unsigned int K) override {
+    if (!cl_q4_0_shape_eligible(N, K)) {
+      nntrainer::gemm_q4_0(M, N, K, matBdata, K, matAdata, N, matCdata, N);
+      return;
+    }
     nntrainer::gemm_q4_0_cl(matAdata, matBdata, matCdata, M, N, K);
+  }
+
+  // Generic (non-accel) Q4_0 branch of float_tensor.cpp's dispatch — the
+  // M == 1 decode step and any caller that skips the accel predicates land
+  // here. Host GEMM, identical to CpuComputeOps::gemm_q4_0_fp32
+  // (cpu_ops_table.h); without this override the base class throws NI, which
+  // the Q4_0 GPU decode path would hit on its first token.
+  void gemm_q4_0_fp32(const unsigned int M, const unsigned int N,
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C,
+                      const unsigned int ldc) override {
+    nntrainer::gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
   }
 
   bool supports_gemv_int4_batch_fp32() const override { return true; }


### PR DESCRIPTION
`ClComputeOps::supports_gemm_q4_0_{batch,accel}_fp32()` return `true` **unconditionally**
(`cl_compute_ops.cpp:35`, `:43` on `origin/main`), so `float_tensor.cpp`'s Q4_0 dispatch sends every
`M > 1` GEMM into the CL prepack. Both CL entry points prepack the Q4_0x8 weight on the host with
`unpack_q4_0x8_transpose16`, whose x86 implementation is an AVX2 256-wide K unroll that asserts
`(K % 256) == 0` and `(N % 8) == 0` (`x86/avx2_impl.cpp:356-357`). Any Q4_0 weight with
`K % 256 != 0` therefore **aborts the process** on `engine=gpu`: the tiny CausalLM fixtures
(hidden_size = 64) crash **7 of the 10 `Q40CloseToFP32Reference` suites** this way, while the same
suites pass on `NNTR_ENGINE=cpu` (the host `gemm_q4_0` has no such constraint — `K % 256` is an
artifact of the AVX2 unroll). This reproduces on `origin/main`; it is a pre-existing upstream defect,
not something this series introduced.

Fix at the CL seam, not at the neutral dispatch site: the wrappers that claimed support now check
shape eligibility (`K % 256 == 0 && N % 8 == 0`; the kernel's own `N/4` NDRange need is subsumed by
`N % 8`) and route ineligible shapes to the host `gemm_q4_0` — the exact function the cpu engine's
`gemm_q4_0_fp32` uses, on the same host/SVM pointers. **That host bounce is NAMED in a code comment
rather than hidden.** Eligible shapes take the identical CL calls as before: zero behaviour change.

The same seam also needed the generic branch: the dispatch's `else` path (`M == 1`, i.e. every decode
step) calls `gemm_q4_0_fp32`, which `ClComputeOps` never overrode, so the base class threw "not
implemented by this backend" on the first generated token — a latent defect the prefill crash used to
mask. `ClComputeOps` now implements it with the same host GEMM.

Rejected alternatives, and why: a gate in `float_tensor.cpp` would stamp a CL-prepack/AVX2 constraint
into backend-neutral code and mis-gate any future backend whose q4_0 kernels accept arbitrary K; a
shape-aware `supports_*()` signature change is an unnecessary interface touch here.

**New in this rung:** `[opencl/q4_0] Gate the CL q4_0 accel path on prepack shape eligibility`.

**Not included / known NOT fixed:** the tiny-BERT Q4_0-on-gpu path completes after this change but
yields NaN embeddings from a **distinct** pre-existing gpu-engine Q4_0 weight-load defect that this
crash used to hide. Separate rung.

**Validated:** the 10 `Q40CloseToFP32Reference` suites on an OpenCL + fp32 build — 7 CRASH → PASS,
3 PASS-still. Highest value-per-line change in this series; recommended to land before any GPU-suite
CI run of the app chain, since without it every downstream PR inherits a red job it did not cause.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
