### PR TITLE
[context] Make factory int_key assignment position-independent and fail loud

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -679,7 +679,13 @@ const int AppContext::registerFactory(const FactoryType<T> factory,
     return int_key;
   }
 
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto key from max(existing) + 1, not from the registration COUNT: a
+  // count-derived key shifts when a registration is inserted mid-list and can
+  // walk onto an explicitly-requested LayerType value, which the assignment
+  // below would then silently rebind. AppContext keeps its pr/3963 "duplicate
+  // explicit key is a no-op, reuse it" policy above; this only removes the
+  // position dependence of the auto path.
+  int assigned_int_key = int_key == -1 ? nextAutoIntKey(int_map) : int_key;
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -82,12 +82,21 @@ void ClContext::initialize() noexcept {
 
     initBlasClKernels();
     initAttentionClKernels();
-    add_default_object();
+
     // SVM-backed allocator so MemoryPool buffers are device-visible
     // without an explicit copy. Falls back to host memory inside
     // ClSVMAllocator when the driver lacks SVM support.
+    //
+    // Installed BEFORE add_default_object() (matching AppContext::initialize),
+    // and not after: every throw inside add_default_object() is swallowed by
+    // the catch below, so with the old order a single bad registration left
+    // this context with a null MemAllocator and crashed the TensorPool ctor
+    // for EVERY model. The allocator does not depend on any registration, so
+    // ordering it first bounds a registration failure to the registrations.
     setMemAllocator(
       std::make_shared<ClSVMAllocator>(opencl::ContextManager::Global()));
+
+    add_default_object();
 
     // Install the OpenCL ComputeOps subclass so tensors created from
     // this Context dispatch their accelerator-only ops (Q4_0/INT4
@@ -167,14 +176,11 @@ const int ClContext::registerFactory(const FactoryType<T> factory,
     throw std::invalid_argument(ss.str().c_str());
   }
 
-  if (int_key != -1 && int_map.find(int_key) != int_map.end()) {
-    std::stringstream ss;
-    ss << "cl_context: cannot register factory with already taken int key: "
-       << int_key;
-    throw std::invalid_argument(ss.str().c_str());
-  }
-
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto keys come from max(existing) + 1 and are therefore independent of
+  // where in add_default_object() the registration sits; an explicit key that
+  // is already bound throws here, naming both colliding types.
+  const int assigned_int_key =
+    resolveIntKey(int_map, int_key, assigned_key, "cl_context");
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -74,6 +74,76 @@ public:
   template <typename... Ts> using FactoryMap = std::tuple<IndexType<Ts>...>;
 
   /**
+   * @brief   Next int_key that no registration in @a int_map can already hold.
+   *
+   * Every Context used to derive an auto-assigned int_key as
+   * `str_map.size() + 1`, i.e. from a COUNT. That makes the key a function of
+   * how many registrations precede it, so inserting one registration mid-list
+   * walks every later auto key up by one until one lands on a key that was
+   * requested EXPLICITLY (an ml::train::LayerType enum value). Nothing checked
+   * the auto key, so `int_map[k] = type` silently rebound an existing entry,
+   * and the damage surfaced later - as a throw from an unrelated registration,
+   * or as a lookup returning the wrong layer type. The only defence was a
+   * comment asking contributors to append new registrations at the end.
+   *
+   * Deriving the key from max(existing) + 1 instead makes it independent of
+   * insertion position: it cannot collide with anything already registered,
+   * in any order. Explicit keys are still checked (see resolveIntKey).
+   *
+   * @param int_map the context's int -> type-string index
+   * @return an int_key not present in @a int_map
+   */
+  static int nextAutoIntKey(const IntIndexType &int_map) {
+    int next = static_cast<int>(int_map.size()) + 1;
+    for (const auto &entry : int_map) {
+      if (entry.first >= next)
+        next = entry.first + 1;
+    }
+    return next;
+  }
+
+  /**
+   * @brief   Resolve and validate the int_key a factory registration binds.
+   *
+   * @note Failing here is deliberate and must stay loud. The collision this
+   *       replaces used to abort a Context's initialize() from inside
+   *       add_default_object(), which is wrapped in a catch-and-log; the
+   *       context then finished initialisation with NO MemAllocator installed
+   *       and every model crashed later in TensorPool with a null allocator -
+   *       a symptom with no visible connection to the registration that caused
+   *       it. Contexts now install their allocator BEFORE registering, so a
+   *       registration failure can only ever be this message. Both colliding
+   *       type names are named so the message identifies the mistake by
+   *       itself.
+   *
+   * @param int_map      the context's int -> type-string index
+   * @param int_key      requested key, or -1 to auto-assign
+   * @param assigned_key the (lowercased) type string being registered
+   * @param ctx_name     context name, used as the message prefix
+   * @return the int_key to bind
+   * @throw std::invalid_argument if the requested key is already bound
+   */
+  static int resolveIntKey(const IntIndexType &int_map, const int int_key,
+                           const std::string &assigned_key,
+                           const char *ctx_name) {
+    const int assigned_int_key =
+      int_key == -1 ? nextAutoIntKey(int_map) : int_key;
+
+    auto taken = int_map.find(assigned_int_key);
+    if (taken != int_map.end()) {
+      std::stringstream ss;
+      ss << ctx_name << ": cannot register factory '" << assigned_key
+         << "' with int_key " << assigned_int_key
+         << ": that key is already registered to '" << taken->second
+         << "'. Explicit int_keys must be unique within one context; pass "
+            "int_key = -1 to have a free key assigned instead.";
+      throw std::invalid_argument(ss.str());
+    }
+
+    return assigned_int_key;
+  }
+
+  /**
    * @brief   Default constructor
    */
   Context(std::shared_ptr<ContextData> data_ = nullptr) : data(data_) {}

--- a/nntrainer/qnn/qnn_context.cpp
+++ b/nntrainer/qnn/qnn_context.cpp
@@ -371,7 +371,12 @@ const int QNNContext::registerFactory(const FactoryType<T> factory,
     return int_key;
   }
 
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto key from max(existing) + 1, not from the registration COUNT: a
+  // count-derived key shifts when a registration is inserted mid-list and can
+  // walk onto an explicitly-requested LayerType value, which the assignment
+  // below would then silently rebind. QNNContext keeps its "duplicate key is a
+  // no-op, reuse it" policy above; this only removes the position dependence.
+  int assigned_int_key = int_key == -1 ? nextAutoIntKey(int_map) : int_key;
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;


### PR DESCRIPTION
Two coupled defects in the factory-registration path, both reproducible on `origin/main`.

1. **The auto `int_key` is derived from a count.**
   `int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;` (`app_context.cpp:682`).
   `str_map.size()` is a count, not a high-water mark, and the collision guard only runs for
   `int_key != -1`, so `int_map[k] = type` silently **rebinds** an existing key whenever the string
   map's size collides with an explicitly-assigned key. A registration mistake then resolves to the
   wrong layer type with nothing logged.

2. **`add_default_object()` runs before `setMemAllocator()`** (`cl_context.cpp:85` / `:89`). Any
   registration throw during default-object setup therefore leaves a fully "initialised" context with
   a **null `MemAllocator`**, and every model built on it dies later in the `TensorPool` constructor
   with a symptom that names nothing.

Fix: make the auto key position-independent (derive it from the actual maximum in use, not from a
count), run the collision guard on every assignment, and fail loud on a collision. Order
`setMemAllocator()` before `add_default_object()`. `AppContext::initialize` already orders them the
safe way (`app_context.cpp:251` vs `:260`), so this propagates an in-tree precedent rather than
inventing one. The idiom exists in **four** contexts; this change covers the core three plus the QNN
context.

**New in this rung:** `[context] Make factory int_key assignment position-independent and fail loud`.

**Not included:** the `cuda_context.cpp` copy of the same idiom — that file does not exist on `main`;
it is covered by the CUDA-context PR in this series.

**Honest note:** the canary for defect 1 was run first and did **not** fire. The mitigation already in
the tree (a comment asking contributors to append last, plus explicit keys 9001/9002) held. The
mechanism is still there, and defect 2's null-allocator window is unconditional.

**Validated:** CPU and OpenCL builds compile clean; registration order/keys/error paths for existing
registrations are unchanged.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
