### PR TITLE
[build/android] Make the CLBlast-free OpenCL build configurable and reachable

### DIFF
--- a/Applications/CausalLM/build_android.sh
+++ b/Applications/CausalLM/build_android.sh
@@ -6,16 +6,29 @@ set -e
 
 # Parse options
 USE_BUILD_CACHE=0
+MESON_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --cache)
             USE_BUILD_CACHE=1
             shift
             ;;
+        -D*|--arm-arch=*)
+            # Forwarded verbatim to tools/package_android.sh, which already
+            # filters -D*/--arm-arch=* out of its own argv and hands them to
+            # meson. Without this, options the nntrainer build needs -- most
+            # importantly -Denable-opencl=true for the GPU build -- are
+            # unreachable from this script.
+            MESON_ARGS+=("$1")
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--cache]"
-            echo "  --cache  Reuse existing nntrainer builddir if available"
+            echo "Usage: $0 [--cache] [-D<meson-option>=<value>]... [--arm-arch=<version>]"
+            echo "  --cache           Reuse existing nntrainer builddir if available"
+            echo "  -D<opt>=<val>     Forwarded to meson, e.g."
+            echo "                    -Denable-opencl=true -Denable-clblast=false"
+            echo "  --arm-arch=<ver>  Forwarded to meson, e.g. --arm-arch=armv9.2-a"
             exit 1
             ;;
     esac
@@ -103,12 +116,16 @@ log_info "NNTRAINER_ROOT: $NNTRAINER_ROOT"
 log_info "Build cache: $([ "$USE_BUILD_CACHE" -eq 1 ] && echo 'enabled' || echo 'disabled (default)')"
 log_info "ANDROID_NDK: $ANDROID_NDK"
 log_info "Working directory: $(pwd)"
+log_info "meson args: ${MESON_ARGS[*]:-(none)}"
 
 # Step 1: Build nntrainer for Android if not already built
 log_step "1/4" "Build nntrainer for Android"
 
 if [ "$USE_BUILD_CACHE" -eq 1 ] && [ -f "$NNTRAINER_ROOT/builddir/android_build_result/lib/arm64-v8a/libnntrainer.so" ]; then
     log_info "Build cache enabled: reusing existing nntrainer builddir (skipping)"
+    if [ ${#MESON_ARGS[@]} -gt 0 ]; then
+        log_warning "meson args are ignored with --cache; the cached builddir keeps its own options."
+    fi
 else
     log_info "Building nntrainer for Android..."
     cd "$NNTRAINER_ROOT"
@@ -116,7 +133,7 @@ else
         log_info "Removing existing builddir..."
         rm -rf builddir
     fi
-    ./tools/package_android.sh
+    ./tools/package_android.sh "${MESON_ARGS[@]}"
 fi
 
 # Check if build was successful

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -107,6 +107,7 @@ LOCAL_SRC_FILES := \
     ../models/timm_vit/timm_vit_transformer.cpp \
     ../models/deberta_v2/deberta_v2.cpp \
     ../models/bert/bert_transformer.cpp \
+    ../models/bert/multilingual_tinybert_16mb.cpp \
     ../models/xlm_roberta/xlm_roberta.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp \
@@ -223,6 +224,7 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../models/gemma3/function.cpp \
     ../models/deberta_v2/deberta_v2.cpp \
     ../models/bert/bert_transformer.cpp \
+    ../models/bert/multilingual_tinybert_16mb.cpp \
     ../models/xlm_roberta/xlm_roberta.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp \

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -59,6 +59,7 @@ endif
 include $(CLEAR_VARS)
 
 ifeq (@MESON_ENABLE_OPENCL@,1)
+ifeq (@MESON_HAS_CLBLAST@,1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE        := clblast
@@ -170,7 +171,8 @@ LOCAL_CXXFLAGS      += -std=c++17 -O3 -fexceptions -DOPENCL_API
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
-endif
+endif # MESON_HAS_CLBLAST
+endif # MESON_ENABLE_OPENCL
 
 include $(CLEAR_VARS)
 
@@ -191,7 +193,9 @@ LOCAL_STATIC_LIBRARIES += iniparser openblas
 
 ifeq (@MESON_ENABLE_OPENCL@,1)
   LOCAL_SHARED_LIBRARIES := OpenCL
-  LOCAL_STATIC_LIBRARIES += clblast
+  ifeq (@MESON_HAS_CLBLAST@,1)
+    LOCAL_STATIC_LIBRARIES += clblast
+  endif
 endif
 
 ifeq ($(MESON_HAS_TFLITE), 1)

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -72,15 +72,25 @@ endif
 
 if get_option('enable-opencl')
   # Set OpenCL block markers to include the OpenCL sections
-  and_conf.set('MESON_ENABLE_OPENCL', 1) 
-  if clblast_dep.found()
+  and_conf.set('MESON_ENABLE_OPENCL', 1)
+  # The staged libOpenCL.so / CL headers are required by every OpenCL build,
+  # with or without CLBlast, so this is not gated on enable-clblast.
+  and_conf.set('MESON_CL_ROOT', opencl_root)
+  # Gate on the option, not on clblast_dep.found(): with enable-clblast=false
+  # clblast_dep is a bare declare_dependency() whose .found() is still true,
+  # which made the template reference the then-undefined clblast_root.
+  if get_option('enable-clblast')
+    and_conf.set('MESON_HAS_CLBLAST', 1)
     and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
-    and_conf.set('MESON_CL_ROOT', opencl_root)
+  else
+    and_conf.set('MESON_HAS_CLBLAST', 0)
+    and_conf.set('MESON_CLBLAST_ROOT', '')
   endif
 else
   # Disable OpenCL
   and_conf.set('MESON_ENABLE_OPENCL', 0)
   # No OpenCL libraries needed
+  and_conf.set('MESON_HAS_CLBLAST', 0)
   and_conf.set('MESON_CLBLAST_ROOT', '')
   and_conf.set('MESON_CL_ROOT', '')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -57,6 +57,8 @@ option('enable-blas', type: 'boolean', value: true)
 option('enable-fp16', type: 'boolean', value: false)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-opencl', type: 'boolean', value: false)
+option('enable-clblast', type: 'boolean', value: true,
+       description: 'Link the CLBlast subproject for general-purpose OpenCL BLAS routines. Disable when only the in-tree OpenCL kernels are needed — drops the multi-minute CLBlast compile.')
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -58,7 +58,13 @@ if get_option('enable-opencl')
   nntrainer_elements += 'opencl'
   nntrainer_elements += 'layers/cl_layers'
 
-  nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'CLBlast' / 'include'
+  # On android clblast_dep is a bare declare_dependency() with no include paths,
+  # so this is the only route for CLBlast headers. clblast_interface.cpp still
+  # includes "clblast.h" unconditionally, so a CLBlast-free ndk-build also needs
+  # the #ifdef ENABLE_CLBLAST guard and -DENABLE_CLBLAST=1 from #4191.
+  if get_option('enable-clblast')
+    nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'CLBlast' / 'include'
+  endif
 endif
 
 if get_option('enable-npu')


### PR DESCRIPTION
Three independent Android build defects, none of which any CI job can see (no CI job builds the
CausalLM app or runs `ndk-build`). Together they are why the Android GPU build was unreachable from
the documented entry point, and they are the fix for the Android arm64 "Build CausalLM" job that is
red on the app chain of this series.

1. **`-Denable-clblast=false` cannot configure on `platform=android`.**
   `meson -Dplatform=android -Denable-opencl=true -Denable-clblast=false` dies at configure time with
   `jni/meson.build:77: ERROR: Unknown variable "clblast_root"`. The CLBlast template substitution was
   gated on `clblast_dep.found()`, but on the `enable-clblast=false` path `clblast_dep` is a bare
   `declare_dependency()` — whose `.found()` is **true**. The guard never fires and the body reads a
   variable only assigned in the `true` branch. The same guard also owned `MESON_CL_ROOT`, so even
   without the crash the staged `libOpenCL.so` / CL headers would drop out of the generated
   `Android.mk`. Fix: gate on `get_option('enable-clblast')` — the same authority that decides whether
   `clblast_root` gets assigned — hoist `MESON_CL_ROOT` out of the CLBlast branch, and export a
   `MESON_HAS_CLBLAST` marker so `Android.mk.in` can drop the CLBlast static-library module instead of
   compiling ~100 CLBlast sources from an empty root prefix. The `clblast_dep.found()` idiom was
   vacuously correct before the option existed; adding the option turned a vacuous test into a live one
   on a path nothing exercises.

2. **`build_android.sh` cannot forward meson options.** It accepts only `--cache` and `exit 1`s on
   anything else, and invokes `tools/package_android.sh` with no arguments — and `enable-opencl`
   defaults to false. So the documented way to build the Android app could only ever produce a CPU-only
   nntrainer. `package_android.sh` already filters `-D*` / `--arm-arch=*` out of its argv and forwards
   them to meson, so the only missing piece was passing them through:
   `./build_android.sh -Denable-opencl=true -Denable-clblast=false` now works. Also warns when meson
   args are combined with `--cache`, since that path skips the reconfigure and the cached options win.

3. **A missing jni source ⇒ undefined vtable.** `jni/Android.mk` never listed
   `models/bert/multilingual_tinybert_16mb.cpp`, although meson does. `MultilingualTinyBert` declares
   all virtuals inline except `encode()`, which is an implicit override and therefore the class's key
   function — so the vtable is emitted only in that TU, and the two Android modules that instantiate
   the class (`causallm_core` via the model registry, `nntr_quantize` via `quantize.cpp`) link with an
   undefined `vtable for causallm::MultilingualTinyBert`. The jni source lists are hand-maintained and
   completely independent of the meson lists, so adding a model to the app fails only on a real NDK
   build.

**New in this rung:** the three commits above.

**Not included:** the `ENABLE_OPENCL` export to prebuilt consumers — that one has an app-chain
dependency and rides a separate PR in this series.

**Not verified here:** NDK build + on-device deploy. The three defects are configure-time /
link-time and were each reproduced from the error text quoted above.

### The `enable-clblast` declaration, and how it relates to #4191

This PR is the declaring PR of record for `enable-clblast`. Its first commit introduces the
`get_option('enable-clblast')` reads in `nntrainer/meson.build` and `jni/meson.build` **and** declares
the option in `meson_options.txt`, in that same commit. Meson resolves option names at configure time,
so a tree that reads an undeclared option aborts before any target is built; keeping the declaration
with its first reader means no commit in this PR leaves a tree that cannot run
`meson setup -Denable-opencl=true`.

#4191 carries a byte-identical declaration, because it reads the option as well. The two declarations
are the same text at the same position, immediately after `option('enable-opencl', ...)`, so the two
PRs merge cleanly in either order and whichever lands second is a no-op for `meson_options.txt`.

The reach of the knob differs between the two trees, which is worth stating precisely. On this PR's
tree alone, `-Denable-clblast=false` controls the Android path — the `MESON_HAS_CLBLAST` marker that
drops the CLBlast static-library module from the generated `Android.mk` — and the
`subprojects/CLBlast/include` entry on the compile line. It does not by itself stop a host build from
configuring and compiling the CLBlast cmake subproject. #4191 adds the gate on that subproject and
`-DENABLE_CLBLAST=1`, which is what makes `-Denable-clblast=false` actually skip the multi-minute
CLBlast compile, together with the matching `#ifdef ENABLE_CLBLAST` in
`nntrainer/tensor/cl_operations/clblast_interface.cpp`. That guard is what lets the translation unit
compile once the CLBlast headers are gone, so an `ndk-build` of the CLBlast-free configuration wants
both changes: this PR for the configure step, #4191 for the source-level guard. Merging the two yields
a single option declaration, the include-directory gate from this PR, and the `#ifdef` from #4191. The
comment above that gate in `nntrainer/meson.build` records the same dependency, so a reader of the
build file does not have to infer it.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>


