### PR TITLE
[cpu_backend] Add QS8CX dequantization

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -657,6 +657,23 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                                  (float *)rhs_scales_f32);
 }
 
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  __fallback_dequant_nxk_qs8cx_f32(n, k, (const int8_t *)rhs_native_mtx_qs8cx,
+                                   (const float *)rhs_scales_f32,
+                                   (float *)rhs_native_mtx_f32);
+}
+
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  // qs8cx dequantization is a memory-bound int8->f32 widening. The compiler
+  // auto-vectorizes the scalar fallback into NEON at -O2/-O3, so a hand-written
+  // NEON kernel offered no speedup over the fallback and was dropped.
+  __fallback_dequantize_row_qs8cx_f32(
+    n_idx, k, (const int8_t *)rhs_native_mtx_qs8cx,
+    (const float *)rhs_scales_f32, (float *)rhs_native_mtx_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
 #ifndef ARMV7

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1544,6 +1544,44 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                      void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
 
 /**
+ * @brief qs8cx dequantization of rhs matrix in nxk format. Inverse of
+ * quant_qs8cx_f32. Converts quantized int8 back to float32 using per-channel
+ * scales. qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    n * k * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_qs8cx quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized matrix data in float32
+ */
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
+ * @brief qs8cx dequantization of a single channel (row) in nxk format.
+ * Reads the n_idx-th row from the full nxk quantized buffers and converts it
+ * back to float32 using its per-channel scale. The result is written compactly
+ * to the first k floats of rhs_native_mtx_f32.
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    k * sizeof(float)
+ *
+ * @param[in] n_idx channel (row) index to dequantize
+ * @param[in] k K length of the row (channel)
+ * @param[in] rhs_native_mtx_qs8cx full nxk quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized row data in float32 (k floats)
+ */
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
  * qsi4cxp
  * Note that nxk is the format of quantized rhs, not the shape of rhs

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -434,6 +434,20 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                                  (float *)rhs_scales_f32);
 }
 
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  __fallback_dequant_nxk_qs8cx_f32(n, k, (const int8_t *)rhs_native_mtx_qs8cx,
+                                   (const float *)rhs_scales_f32,
+                                   (float *)rhs_native_mtx_f32);
+}
+
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  __fallback_dequantize_row_qs8cx_f32(
+    n_idx, k, (const int8_t *)rhs_native_mtx_qs8cx,
+    (const float *)rhs_scales_f32, (float *)rhs_native_mtx_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
   return __fallback_get_rhs_packed_size_qsi4cxp_qs4cxs1s0(n, k, idx_variant,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1433,6 +1433,44 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                      void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
 
 /**
+ * @brief qs8cx dequantization of rhs matrix in nxk format. Inverse of
+ * quant_qs8cx_f32. Converts quantized int8 back to float32 using per-channel
+ * scales. qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    n * k * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_qs8cx quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized matrix data in float32
+ */
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
+ * @brief qs8cx dequantization of a single channel (row) in nxk format.
+ * Reads the n_idx-th row from the full nxk quantized buffers and converts it
+ * back to float32 using its per-channel scale. The result is written compactly
+ * to the first k floats of rhs_native_mtx_f32.
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    k * sizeof(float)
+ *
+ * @param[in] n_idx channel (row) index to dequantize
+ * @param[in] k K length of the row (channel)
+ * @param[in] rhs_native_mtx_qs8cx full nxk quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized row data in float32 (k floats)
+ */
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
  * qsi4cxp
  * Note that nxk is the format of quantized rhs, not the shape of rhs

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -956,6 +956,35 @@ void __fallback_quant_nxk_qs8cx_f32(size_t n, size_t k, const float *rhs_f32,
   }
 }
 
+void __fallback_dequantize_row_qs8cx_f32(size_t n_idx, size_t k,
+                                         const int8_t *rhs_qs8cx,
+                                         const float *rhs_scales_f32,
+                                         float *rhs_f32) {
+  const int8_t *src_ptr = rhs_qs8cx + n_idx * k;
+  const float recip_scale = rhs_scales_f32[n_idx];
+
+  for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+    const int32_t v_s32 = (int32_t)src_ptr[k_idx];
+    rhs_f32[k_idx] = (float)v_s32 * recip_scale;
+  }
+}
+
+void __fallback_dequant_nxk_qs8cx_f32(size_t n, size_t k,
+                                      const int8_t *rhs_qs8cx,
+                                      const float *rhs_scales_f32,
+                                      float *rhs_f32) {
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    const int8_t *src_ptr = rhs_qs8cx + n_idx * k;
+    float *dst_ptr = rhs_f32 + n_idx * k;
+    const float recip_scale = rhs_scales_f32[n_idx];
+
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const int32_t v_s32 = (int32_t)src_ptr[k_idx];
+      dst_ptr[k_idx] = (float)v_s32 * recip_scale;
+    }
+  }
+}
+
 void __fallback_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
                                 int8_t *lhs_qa8dx) {
   const size_t dst_stride =

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1367,6 +1367,37 @@ void __fallback_quant_nxk_qs8cx_f32(size_t n, size_t k, const float *rhs_f32,
                                     int8_t *rhs_qs8cx, float *rhs_scales_f32);
 
 /**
+ * @brief qs8cx dequantization of a single channel (row) in nxk format
+ * @note a row holds k contiguous int8 codes sharing one per-channel scale. The
+ * n_idx-th row is read from the full nxk buffers and written compactly to the
+ * first k floats of rhs_f32.
+ *
+ * @param[in] n_idx channel (row) index to dequantize
+ * @param[in] k K length of the row
+ * @param[in] rhs_qs8cx full nxk quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_f32 dequantized row data (k floats)
+ */
+void __fallback_dequantize_row_qs8cx_f32(size_t n_idx, size_t k,
+                                         const int8_t *rhs_qs8cx,
+                                         const float *rhs_scales_f32,
+                                         float *rhs_f32);
+
+/**
+ * @brief qs8cx dequantization of (n,k) RHS matrix in nxk format
+ *
+ * @param[in] n N length of the matrix
+ * @param[in] k K length of the matrix
+ * @param[in] rhs_qs8cx quantized matrix data in nxk format
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_f32 dequantized matrix data after dequantization
+ */
+void __fallback_dequant_nxk_qs8cx_f32(size_t n, size_t k,
+                                      const int8_t *rhs_qs8cx,
+                                      const float *rhs_scales_f32,
+                                      float *rhs_f32);
+
+/**
  * @brief qa8dx quantization of (m,k) LHS matrix. qa8dx refer to quantized
  * asymmetric 8-bit per-dimension quantization. Note that qparams are embedded
  * at the beginning of the output matrix.

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -566,6 +566,20 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                                  (float *)rhs_scales_f32);
 }
 
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  __fallback_dequant_nxk_qs8cx_f32(n, k, (const int8_t *)rhs_native_mtx_qs8cx,
+                                   (const float *)rhs_scales_f32,
+                                   (float *)rhs_native_mtx_f32);
+}
+
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32) {
+  __fallback_dequantize_row_qs8cx_f32(
+    n_idx, k, (const int8_t *)rhs_native_mtx_qs8cx,
+    (const float *)rhs_scales_f32, (float *)rhs_native_mtx_f32);
+}
+
 size_t get_rhs_packed_size_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
                                              size_t idx_variant, bool is_nxk) {
   return __fallback_get_rhs_packed_size_qsi4cxp_qs4cxs1s0(n, k, idx_variant,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1343,6 +1343,44 @@ void quant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
                      void *rhs_native_mtx_qs8cx, void *rhs_scales_f32);
 
 /**
+ * @brief qs8cx dequantization of rhs matrix in nxk format. Inverse of
+ * quant_qs8cx_f32. Converts quantized int8 back to float32 using per-channel
+ * scales. qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    n * k * sizeof(float)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] rhs_native_mtx_qs8cx quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized matrix data in float32
+ */
+void dequant_qs8cx_f32(size_t n, size_t k, void *rhs_native_mtx_qs8cx,
+                       void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
+ * @brief qs8cx dequantization of a single channel (row) in nxk format.
+ * Reads the n_idx-th row from the full nxk quantized buffers and converts it
+ * back to float32 using its per-channel scale. The result is written compactly
+ * to the first k floats of rhs_native_mtx_f32.
+ * qs8cx refers to quantized symmetric 8-bit channel-wise quantization.
+ *
+ * @warning You should allocate memory for output before use:
+ *  - rhs_native_mtx_f32
+ *    k * sizeof(float)
+ *
+ * @param[in] n_idx channel (row) index to dequantize
+ * @param[in] k K length of the row (channel)
+ * @param[in] rhs_native_mtx_qs8cx full nxk quantized matrix data
+ * @param[in] rhs_scales_f32 per-channel quantization scales
+ * @param[out] rhs_native_mtx_f32 dequantized row data in float32 (k floats)
+ */
+void dequantize_row_qs8cx(size_t n_idx, size_t k, void *rhs_native_mtx_qs8cx,
+                          void *rhs_scales_f32, void *rhs_native_mtx_f32);
+
+/**
  * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
  * qsi4cxp
  * Note that nxk is the format of quantized rhs, not the shape of rhs

--- a/test/unittest/unittest_nntrainer_fallback.cpp
+++ b/test/unittest/unittest_nntrainer_fallback.cpp
@@ -1615,6 +1615,75 @@ TEST(nntrainer_fallback, dequantize_row_qs4cx_f32_odd_k) {
 }
 
 //==============================================================================
+// Tests for qs8cx dequantization
+//==============================================================================
+
+static void verify_dequant_nxk_qs8cx(size_t n, size_t k) {
+  std::vector<float> rhs_f32 =
+    generate_random_vector<float>(n * k, -10.0f, 10.0f);
+
+  std::vector<int8_t> rhs_qs8cx(n * k, 0);
+  std::vector<float> rhs_scales_f32(n, 0.0f);
+  nntrainer::__fallback_quant_nxk_qs8cx_f32(
+    n, k, rhs_f32.data(), rhs_qs8cx.data(), rhs_scales_f32.data());
+
+  std::vector<float> reconstructed(n * k, 0.0f);
+  nntrainer::__fallback_dequant_nxk_qs8cx_f32(
+    n, k, rhs_qs8cx.data(), rhs_scales_f32.data(), reconstructed.data());
+
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const int code = (int)rhs_qs8cx[n_idx * k + k_idx];
+      const float expected = (float)code * rhs_scales_f32[n_idx];
+      EXPECT_FLOAT_EQ(reconstructed[n_idx * k + k_idx], expected);
+    }
+  }
+}
+
+TEST(nntrainer_fallback, dequant_nxk_qs8cx_f32) {
+  verify_dequant_nxk_qs8cx(/*n=*/4, /*k=*/8);
+}
+
+TEST(nntrainer_fallback, dequant_nxk_qs8cx_f32_odd_k) {
+  verify_dequant_nxk_qs8cx(/*n=*/4, /*k=*/7);
+}
+
+static void verify_dequantize_row_qs8cx(size_t n, size_t k) {
+  std::vector<float> rhs_f32 =
+    generate_random_vector<float>(n * k, -10.0f, 10.0f);
+
+  std::vector<int8_t> rhs_qs8cx(n * k, 0);
+  std::vector<float> rhs_scales_f32(n, 0.0f);
+  nntrainer::__fallback_quant_nxk_qs8cx_f32(
+    n, k, rhs_f32.data(), rhs_qs8cx.data(), rhs_scales_f32.data());
+
+  std::vector<float> tensor_ref(n * k, 0.0f);
+  nntrainer::__fallback_dequant_nxk_qs8cx_f32(
+    n, k, rhs_qs8cx.data(), rhs_scales_f32.data(), tensor_ref.data());
+
+  std::vector<float> row_out(k, 0.0f);
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    nntrainer::__fallback_dequantize_row_qs8cx_f32(
+      n_idx, k, rhs_qs8cx.data(), rhs_scales_f32.data(), row_out.data());
+
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const int code = (int)rhs_qs8cx[n_idx * k + k_idx];
+      const float expected = (float)code * rhs_scales_f32[n_idx];
+      EXPECT_FLOAT_EQ(row_out[k_idx], expected);
+      EXPECT_FLOAT_EQ(row_out[k_idx], tensor_ref[n_idx * k + k_idx]);
+    }
+  }
+}
+
+TEST(nntrainer_fallback, dequantize_row_qs8cx_f32) {
+  verify_dequantize_row_qs8cx(/*n=*/4, /*k=*/8);
+}
+
+TEST(nntrainer_fallback, dequantize_row_qs8cx_f32_odd_k) {
+  verify_dequantize_row_qs8cx(/*n=*/4, /*k=*/7);
+}
+
+//==============================================================================
 // Main function
 //==============================================================================
 


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[cpu_backend] Add QS8CX dequantization</summary><br />

- Add dequant_qs8cx_f32 and dequantize_row_qs8cx for arm, x86, fallback
  - only nxk format is implemented
- Add unittest for fallback correctness

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR updates dequantization for `QS8CX` type matrix and row.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
