### PR TITLE
[causallm] Consolidate attn_logit_softcapping parse into base setupParameters (dead override)

### DIFF
--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
@@ -70,10 +70,7 @@ void Gemma3Transformer::setupParameters(json &cfg, json &generation_cfg,
   if (cfg.contains("layer_types")) {
     layer_types = cfg["layer_types"].get<std::vector<std::string>>();
   }
-  if (cfg.contains("attn_logit_softcapping") &&
-      !cfg["attn_logit_softcapping"].is_null()) {
-    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
-  }
+  // attn_logit_softcapping now parsed in Transformer::setupParameters (base).
 }
 
 Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -115,10 +115,8 @@ void Gemma4Transformer::setupParameters(json &cfg, json &generation_cfg,
     layer_types = cfg["layer_types"].get<std::vector<std::string>>();
   }
 
-  if (cfg.contains("attn_logit_softcapping") &&
-      !cfg["attn_logit_softcapping"].is_null()) {
-    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
-  }
+  // attn_logit_softcapping now parsed in Transformer::setupParameters (base);
+  // final_logit_softcapping stays here (gemma4-specific member).
   if (cfg.contains("final_logit_softcapping") &&
       !cfg["final_logit_softcapping"].is_null()) {
     FINAL_LOGIT_SOFTCAPPING = cfg["final_logit_softcapping"].get<float>();

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -198,6 +198,17 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
     cfg.contains("rms_norm_eps") ? cfg["rms_norm_eps"].get<float>() : 1e-5;
   GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;
 
+  // Attention-logit soft-capping (Gemma family). Parsed here -- the one
+  // setupParameters the base constructors provably reach -- so it cannot be
+  // stranded in a derived override that never runs. Gated on cfg presence, so
+  // a model without the key keeps the 0.0f default (no soft-cap). Consolidated
+  // from the per-model setupParameters (gemma3/gemma4 held byte-identical
+  // copies of this block).
+  if (cfg.contains("attn_logit_softcapping") &&
+      !cfg["attn_logit_softcapping"].is_null()) {
+    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
+  }
+
   return;
 };
 

--- a/test/unittest/models/causallm_test_utils.cpp
+++ b/test/unittest/models/causallm_test_utils.cpp
@@ -243,6 +243,16 @@ makeTinyNntrainerConfig(const std::filesystem::path &tokenizer_path,
 }
 
 /**
+ * @brief Make a construct-only nntrainer config for config-plumbing tests
+ */
+causallm::json makeTinyCtorOnlyNntrainerConfig() {
+  auto nntr_cfg =
+    makeTinyNntrainerConfig(std::filesystem::path(), makeTinyFp32DataType());
+  nntr_cfg.erase("tokenizer_file");
+  return nntr_cfg;
+}
+
+/**
  * @brief Make complete tiny configs for one model case
  */
 TinyCausalLMConfig

--- a/test/unittest/models/causallm_test_utils.h
+++ b/test/unittest/models/causallm_test_utils.h
@@ -721,6 +721,18 @@ makeTinyNntrainerConfig(const std::filesystem::path &tokenizer_path,
                         const TinyCausalLMDataType &data_type);
 
 /**
+ * @brief Make a construct-only nntrainer config for config-plumbing tests
+ *
+ * Same FP32 shape as makeTinyNntrainerConfig, minus "tokenizer_file": a model
+ * whose constructor only has to parse parameters needs no tokenizer, and
+ * Transformer leaves `tokenizer` null (and spawns no async load) when the key
+ * is absent. Lets a test construct a model object with no tokenizer, no
+ * weights and no graph compile.
+ * @return nntrainer_config.json equivalent
+ */
+causallm::json makeTinyCtorOnlyNntrainerConfig();
+
+/**
  * @brief Make complete tiny configs for one model case
  * @param test_case Model case descriptor
  * @param tokenizer_path Tiny tokenizer path

--- a/test/unittest/models/unittest_causallm_gemma3.cpp
+++ b/test/unittest/models/unittest_causallm_gemma3.cpp
@@ -54,6 +54,30 @@ public:
 };
 
 /**
+ * @brief Tiny Gemma3 probe exposing config-derived attention parameters
+ *
+ * Construct-only: it never compiles a graph nor loads weights, so every
+ * assertion observes exactly what the constructor chain parsed out of cfg.
+ */
+class TinyGemma3ConfigProbe final : public causallm::Gemma3CausalLM {
+public:
+  /**
+   * @brief Construct a tiny Gemma3 config probe
+   */
+  TinyGemma3ConfigProbe(causallm::json &cfg, causallm::json &generation_cfg,
+                        causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm::Gemma3CausalLM(cfg, generation_cfg, nntr_cfg) {}
+
+  /**
+   * @brief Attention-logit soft-cap as parsed by the constructor chain
+   */
+  float attnLogitSoftcapping() const { return ATTN_LOGIT_SOFTCAPPING; }
+};
+
+/**
  * @brief Populate deterministic tiny Gemma3 weights for golden token tests
  */
 void setupGemma3DeterministicWeights(TinyGemma3CausalLM &model) {
@@ -529,6 +553,64 @@ TEST(EmbeddingGemmaTinyModelTest,
     has_non_zero = has_non_zero || std::abs(value) > 1e-5f;
   }
   EXPECT_TRUE(has_non_zero);
+}
+
+/**
+ * @brief Construct a tiny Gemma3 probe from a model config
+ */
+std::unique_ptr<TinyGemma3ConfigProbe> makeGemma3Probe(causallm::json cfg) {
+  auto generation_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyCtorOnlyNntrainerConfig();
+  return std::make_unique<TinyGemma3ConfigProbe>(cfg, generation_cfg, nntr_cfg);
+}
+
+/**
+ * @brief config.json "attn_logit_softcapping" must reach the model object
+ *
+ * Asserts the CONTRACT -- a cfg key the model declares support for actually
+ * lands in the member every consumer reads -- not where the parse is written,
+ * so it stays valid if the parse moves again.
+ *
+ * Regression guard: the parse used to live only in
+ * Gemma3Transformer::setupParameters, which is unreachable. setupParameters is
+ * dispatched from base-class CONSTRUCTOR bodies (Transformer:: and CausalLM::),
+ * and a virtual call inside a base constructor resolves to the BASE override --
+ * never a derived one. Gemma3's ctor bodies add no call of their own, so the
+ * override never ran. Shipped gemma3 configs carry
+ * "attn_logit_softcapping": null, so gemma3 numerics never moved, but the
+ * plumbing was broken all the same -- and it is the same dead-override shape
+ * that silently disabled gemma2's soft-cap.
+ */
+TEST(Gemma3ConfigPlumbingTest, AttnLogitSoftcappingReachesModel) {
+  auto cfg = makeTinyGemma3Config();
+  cfg["attn_logit_softcapping"] = 50.0;
+
+  auto probe = makeGemma3Probe(cfg);
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 50.0f);
+}
+
+/**
+ * @brief A config without the key keeps the no-soft-cap default
+ */
+TEST(Gemma3ConfigPlumbingTest, AbsentAttnLogitSoftcappingKeepsDefault) {
+  auto probe = makeGemma3Probe(makeTinyGemma3Config());
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 0.0f);
+}
+
+/**
+ * @brief An explicitly null key keeps the no-soft-cap default
+ *
+ * This is the shape shipped gemma3 configs actually use.
+ */
+TEST(Gemma3ConfigPlumbingTest, NullAttnLogitSoftcappingKeepsDefault) {
+  auto cfg = makeTinyGemma3Config();
+  cfg["attn_logit_softcapping"] = nullptr;
+
+  auto probe = makeGemma3Probe(cfg);
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 0.0f);
 }
 
 } // namespace


### PR DESCRIPTION
The Gemma-family attention soft-cap parse lived in a **dead override**.

`setupParameters()` is only ever dispatched from base-class **constructor** bodies
(`Transformer::Transformer`, `CausalLM::CausalLM`). C++ resolves a virtual call made inside a base
constructor to the *base* version, never a derived override, because the derived object does not exist
yet. A model whose own constructor body adds no `setupParameters()` call of its own therefore never
runs its override, and every key parsed only there keeps its default. `Gemma3Transformer` is exactly
that shape, so the `attn_logit_softcapping` parse it held never ran, `ATTN_LOGIT_SOFTCAPPING` kept its
`0.0f` default, and — since every consumer is gated `if (attn_logit_softcapping > 0.0f)` — the
`c*tanh(s/c)` soft-cap was skipped on every layer, on every backend.

Fix: move the parse into `Transformer::setupParameters` — the one function the base constructor
provably reaches — and delete the per-model copies. The parse stays gated on
`contains(...) && !is_null(...)`, so any model whose config lacks the key keeps the `0.0f` default and
is byte-preserving.

Affected vs unaffected, audited per model:
- **gemma3 / EmbeddingGemma** — plumbing cured, **numerics unchanged**: the override was unreachable,
  but the in-tree gemma3 configs carry `"attn_logit_softcapping": null`, so the gate leaves `0.0f`.
- **gemma4** — unchanged. Its override is live (`Gemma4Transformer`'s ctor body explicitly calls
  `setupParameters()`, which calls the base first). The deleted copy re-read the same key from the same
  cfg into the same member, so the base parse cannot double-apply. `final_logit_softcapping` stays in
  gemma4 (its own member).
- **qwen2 / qwen3 / qwen3_moe / gpt_oss / lfm2 / bert / deberta / xlm_roberta / timm_vit** — no such
  key in their configs; `0.0f` default preserved.
- The real numerics victim is **gemma2**, whose shipped configs all carry
  `"attn_logit_softcapping": 50.0`. Gemma2 is not on this tree yet — it arrives in the next PR of this
  series, and this fix is its prerequisite: without it the new model would silently run with its
  soft-cap off.

**New in this rung:** `[causallm] Consolidate attn_logit_softcapping parse into base setupParameters`,
plus `Gemma3ConfigPlumbingTest` and a shared `makeTinyCtorOnlyNntrainerConfig()` helper in
`causallm_test_utils`.

The test is ctor-level parameter *visibility*: a probe subclass exposes the protected member and
constructs the model with no tokenizer, no weights and no graph compile, so each assertion observes
exactly what the constructor chain parsed. That is precisely the layer where the bug lived — a derived
override can be silently unreachable while everything still builds and links. Three cases: key present
(the regression guard, which **fails on the unfixed tree**), key absent, key explicitly null.

**Merge-order note:** this PR ships `causallm_test_utils.{h,cpp}`, which the Gemma2 PR's unit test
consumes. Please land it **before** the Gemma2 model PR.

**Validated:** CPU build clean; the three new test cases pass on the fixed tree and the
"key present" case fails on the unfixed tree.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
