### PR TITLE
[causallm] Honor nntr_config lmhead_untie: untied FC lm_head in the generic and Gemma4 graphs

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -220,26 +220,43 @@ void CausalLM::advanceKVCachePosition(unsigned int step_size) {
   kv_cache.advance(step_size);
 }
 
-std::pair<Tensor, Tensor> CausalLM::constructModel() {
-
-  // base transformer (input, output_norm)
-  auto [x, h] = Transformer::constructModel();
-
+/**
+ * [lmhead-untie] When nntr_config.json sets lmhead_untie, build
+ * output_of_causallm as an independent fully_connected layer with its own
+ * weight even for a tied-embedding model, so the lm_head can carry a
+ * different dtype than the embedding (untied-serialized packages such as
+ * gemma4_qs4cx_fp16 ship a separate transposed [hidden, vocab] head record
+ * that a tied graph cannot load). Untie is the config flag, NOT derived from
+ * LMHEAD_DTYPE: a quantizer constructs this same untied graph from the FP32
+ * source and quantizes output_of_causallm via the dtype map on save.
+ * skip_prefill keeps the FC lm_head decode-only, the same contract the tied
+ * lm_head types implement internally. Flag off = byte-identical graph.
+ */
+Tensor CausalLM::buildLmHeadOutput(Tensor h, bool add_skip_prefill) {
+  const bool lmhead_untied = LMHEAD_UNTIE;
   const std::string lmhead_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head";
-
+    lmhead_untied ? "fully_connected"
+                  : (TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head");
   std::vector<std::string> lmhead_prop = {
     withKey("name", "output_of_causallm"),
     withKey("unit", NUM_VOCAB),
     withKey("disable_bias", "true"),
     withKey("weight_dtype", LMHEAD_DTYPE),
   };
-
-  if (TIE_WORD_EMBEDDINGS)
+  if (add_skip_prefill)
+    lmhead_prop.emplace_back(withKey("skip_prefill", "true"));
+  if (TIE_WORD_EMBEDDINGS && !lmhead_untied)
     lmhead_prop.emplace_back(withKey("shared_from", "embedding0"));
-
   LayerHandle lmhead(createLayer(lmhead_type, lmhead_prop));
-  Tensor y = lmhead(h);
+  return lmhead(h);
+}
+
+std::pair<Tensor, Tensor> CausalLM::constructModel() {
+
+  // base transformer (input, output_norm)
+  auto [x, h] = Transformer::constructModel();
+
+  Tensor y = buildLmHeadOutput(h, LMHEAD_UNTIE && SKIP_PREFILL);
 
   return {x, y};
 }

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -139,6 +139,15 @@ protected:
   virtual std::pair<Tensor, Tensor> constructModel() override;
 
   /**
+   * @brief Build the output_of_causallm lm_head from the transformer hidden
+   *        state @p h. Shared by the generic and the model-override
+   *        constructModel paths. The skip_prefill decision differs per path
+   *        (generic gates on SKIP_PREFILL; Gemma4 on ENABLE_SKIP_PREFILL_OPT),
+   *        so it is passed in rather than recomputed here.
+   */
+  Tensor buildLmHeadOutput(Tensor h, bool add_skip_prefill);
+
+  /**
    * @brief register Outputs
    */
   virtual void

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -249,10 +249,16 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
   Tensor x =
     Tensor({1, 1, 1, static_cast<unsigned int>(INIT_SEQ_LEN)}, "input0");
 
+  // TieWordEmbedding exists to share the table with a tied lm_head. With
+  // LMHEAD_UNTIE the head is a separate FC, so embedding0 is a plain
+  // embedding_layer — lookup-identical (same weight record) and it unlocks
+  // the mmap'd sidecar (embedding_file_name) that TieWordEmbedding
+  // structurally lacks.
+  const bool embedding_tied = TIE_WORD_EMBEDDINGS && !LMHEAD_UNTIE;
   const std::string embedding_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "embedding_layer";
+    embedding_tied ? "tie_word_embeddings" : "embedding_layer";
 
-  NNTR_THROW_IF(TIE_WORD_EMBEDDINGS && !EMBEDDING_FILE_NAME.empty(),
+  NNTR_THROW_IF(embedding_tied && !EMBEDDING_FILE_NAME.empty(),
                 std::invalid_argument)
     << "embedding_file_name requires untied embedding_layer";
   LayerHandle embedding(createLayer(
@@ -810,24 +816,11 @@ void Gemma4CausalLM::registerCustomLayers() {
 std::pair<Tensor, Tensor> Gemma4CausalLM::constructModel() {
   auto [x, h] = Gemma4Transformer::constructModel();
 
-  // create lm_head layer (using fully_connected option)
-  const std::string lmhead_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head";
-
-  // add lmhead
-  std::vector<std::string> lmhead_prop = {
-    withKey("name", "output_of_causallm"),
-    withKey("unit", NUM_VOCAB),
-    withKey("disable_bias", "true"),
-    withKey("weight_dtype", LMHEAD_DTYPE),
-  };
-  appendSkipPrefillIfNeeded(lmhead_prop, true);
-
-  if (TIE_WORD_EMBEDDINGS)
-    lmhead_prop.emplace_back(withKey("shared_from", "embedding0"));
-
-  LayerHandle lmhead(createLayer(lmhead_type, lmhead_prop));
-  Tensor y = lmhead(h);
+  // lm_head: shares CausalLM::buildLmHeadOutput, which honors LMHEAD_UNTIE
+  // (untied FC head with its own weight record — the layout the
+  // gemma4_qs4cx_fp16 packagings serialize). skip_prefill gates on
+  // ENABLE_SKIP_PREFILL_OPT here, matching every other Gemma4 layer.
+  Tensor y = buildLmHeadOutput(h, ENABLE_SKIP_PREFILL_OPT);
 
   if (FINAL_LOGIT_SOFTCAPPING > 0.0f) {
     std::vector<std::string> final_softcap_props = {

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -144,6 +144,8 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
   FC_LAYER_DTYPE = nntr_cfg["fc_layer_dtype"];
   EMBEDDING_FILE_NAME = nntr_cfg.value("embedding_file_name", std::string());
   PLE_FILE_NAME = nntr_cfg.value("ple_file_name", std::string());
+  LMHEAD_UNTIE =
+    nntr_cfg.contains("lmhead_untie") && nntr_cfg["lmhead_untie"].get<bool>();
 
   if (cfg.contains("is_causal")) {
     IS_CAUSAL = cfg["is_causal"].get<bool>();

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -375,6 +375,15 @@ protected:
   std::string EMBEDDING_FILE_NAME;
   std::string PLE_FILE_NAME;
 
+  /** untie lm_head from the input embedding (separate FC weight, not shared
+   *  with the embedding table). Lives here (not CausalLM) because embedding0's
+   *  layer-type choice — tied TieWordEmbedding vs untied embedding_layer —
+   *  happens in <model>Transformer::constructModel scope. A dedicated flag
+   *  (not derived from LMHEAD_DTYPE) so a quantizer can build the same untied
+   *  graph from FP32 source weights while the dtype map quantizes
+   *  output_of_causallm on save. */
+  bool LMHEAD_UNTIE = false;
+
   unsigned int SLIDING_WINDOW = UINT_MAX;
   unsigned int SLIDING_WINDOW_PATTERN = 5;
   unsigned int ROPE_THETA = 10000; /**< RoPE theta value */


### PR DESCRIPTION
The app only read `config.json`'s `tie_word_embeddings` when choosing the lm_head layer type;
`nntr_config.json`'s `lmhead_untie` key was ignored entirely. Untied-serialized packages (tied HF
config plus a separate transposed `[hidden, vocab]` head record appended to the bin) therefore built a
**tied** graph against an **untied** bin. That used to misload silently; with the loader tripwire in
this series it now fails fast with a model-layout mismatch — either way the package is unusable.

- `Transformer::setupParameters` parses `lmhead_untie` into a new `LMHEAD_UNTIE` member. It lives on
  `Transformer`, not `CausalLM`, because `embedding0`'s layer-type choice happens in
  `<model>Transformer::constructModel` scope, which does not see `CausalLM` members in the diamond
  hierarchy.
- New `CausalLM::buildLmHeadOutput(h, add_skip_prefill)`: untied ⇒ an independent
  `fully_connected` output with its own weight (`weight_dtype = LMHEAD_DTYPE`, optional
  `skip_prefill` so the head stays decode-only); tied ⇒ the existing
  `tie_word_embeddings` / `lm_head` choice with `shared_from`, unchanged. Shared by the generic path
  and by Gemma4, each keeping the exact skip-prefill gate its inline copy had.
- `Gemma4Transformer::constructModel` gates `embedding0` on
  `TIE_WORD_EMBEDDINGS && !LMHEAD_UNTIE`: with an untied head there is nothing to share, so
  `embedding0` becomes a plain `embedding_layer` (lookup-identical, same weight record), which also
  makes the `embedding_file_name` sidecar legal for it.

Byte-preserving for every package without the key: `LMHEAD_UNTIE` defaults false, the emitted property
strings and their order are unchanged, and no `skip_prefill` is added on paths that did not add it
before. The generic base `constructModel` intentionally keeps a `tie_word_embeddings`-typed
`embedding0` even when untied, because a standalone `TieWordEmbedding` is a plain lookup.

**New in this rung:** `[causallm] Honor nntr_config lmhead_untie: untied FC lm_head in the generic and
Gemma4 graphs`.

**Not included:** no change to the tied path's numerics, no new kernels, no loader changes (the
tripwire that makes a mismatch diagnosable is a separate PR in this series).

**Not verified here:** tied goldens (qwen3 / gemma2 / gemma4 packagings) byte-identical, and an
untied-serialized gemma4 package passing the load tripwire and producing coherent output. Both are
pending build-host time; the change is byte-preserving by construction for every package that does not
set the key.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
