### PR TITLE
[init-latency] Overlap the chat-template renderer warm-up with model load

### DIFF
--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
@@ -41,20 +42,29 @@ bool fileExists(const std::string &path) {
   return file.good();
 }
 
-std::string readTextFile(const std::string &path) {
+/**
+ * @brief Read a whole file, or nullopt when it cannot be opened.
+ *
+ * [init-latency] Load() used to probe each file with fileExists() and then
+ * open it a second time to read it -- three files, six opens. Only an OPEN
+ * failure yields nullopt; a malformed file still throws out of the parse,
+ * exactly as the fileExists()-guarded form did, so no error path changes.
+ */
+std::optional<std::string> tryReadTextFile(const std::string &path) {
   std::ifstream file(path, std::ios::binary);
   if (!file.is_open())
-    throw std::runtime_error("Failed to open file: " + path);
+    return std::nullopt;
 
   std::ostringstream buffer;
   buffer << file.rdbuf();
   return buffer.str();
 }
 
-nlohmann::json readJsonFile(const std::string &path) {
+/** @copydoc tryReadTextFile */
+std::optional<nlohmann::json> tryReadJsonFile(const std::string &path) {
   std::ifstream file(path);
   if (!file.is_open())
-    throw std::runtime_error("Failed to open file: " + path);
+    return std::nullopt;
 
   nlohmann::json data;
   file >> data;
@@ -514,15 +524,12 @@ bool ChatTemplate::Exists(const std::string &model_path) {
   if (fileExists(model_path + "/chat_template.jinja"))
     return true;
 
-  const std::string tokenizer_config_path =
-    model_path + "/tokenizer_config.json";
-  if (!fileExists(tokenizer_config_path))
-    return false;
-
   try {
-    nlohmann::json tokenizer_config = readJsonFile(tokenizer_config_path);
-    return tokenizer_config.contains("chat_template") &&
-           !tokenizer_config["chat_template"].is_null();
+    const auto tokenizer_config =
+      tryReadJsonFile(model_path + "/tokenizer_config.json");
+    return tokenizer_config.has_value() &&
+           tokenizer_config->contains("chat_template") &&
+           !(*tokenizer_config)["chat_template"].is_null();
   } catch (...) {
     return false;
   }
@@ -534,13 +541,13 @@ ChatTemplate ChatTemplate::Load(const std::string &model_path) {
 
   const std::string tokenizer_config_path =
     model_path + "/tokenizer_config.json";
-  if (fileExists(tokenizer_config_path))
-    impl->tokenizer_config = readJsonFile(tokenizer_config_path);
+  if (auto tokenizer_config = tryReadJsonFile(tokenizer_config_path))
+    impl->tokenizer_config = std::move(*tokenizer_config);
 
   const std::string special_tokens_path =
     model_path + "/special_tokens_map.json";
-  if (fileExists(special_tokens_path))
-    impl->special_tokens = readJsonFile(special_tokens_path);
+  if (auto special_tokens = tryReadJsonFile(special_tokens_path))
+    impl->special_tokens = std::move(*special_tokens);
 
   impl->bos_token =
     findToken(impl->tokenizer_config, impl->special_tokens, "bos_token");
@@ -548,9 +555,9 @@ ChatTemplate ChatTemplate::Load(const std::string &model_path) {
     findToken(impl->tokenizer_config, impl->special_tokens, "eos_token");
 
   const std::string template_file_path = model_path + "/chat_template.jinja";
-  if (fileExists(template_file_path)) {
+  if (auto template_source = tryReadTextFile(template_file_path)) {
     impl->source_path = template_file_path;
-    impl->template_source = readTextFile(template_file_path);
+    impl->template_source = std::move(*template_source);
     // [init-latency L3] Everything the renderer needs is final now.
     impl->startWarmup();
     return ChatTemplate(std::move(impl));

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -14,9 +14,13 @@
 
 #include <minja/chat-template.hpp>
 
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 
@@ -169,6 +173,108 @@ struct ChatTemplate::Impl {
     Options::DeveloperRolePolicy::MergeIntoSystem;
   mutable std::unordered_map<std::string, std::unique_ptr<minja::chat_template>>
     renderers;
+  /** [init-latency L3] renderers is now touched by the warm-up thread too. */
+  mutable std::mutex renderers_mtx;
+  mutable std::thread warm_thread;
+  /**
+   * @brief Serialises the warm-up join, and ONLY the join.
+   *
+   * It cannot be `renderers_mtx`: the warm thread takes that lock to publish
+   * its renderer, so joining while holding it deadlocks. That is why the join
+   * was originally left unsynchronised -- but then two concurrent apply()
+   * callers could both observe warm_thread.joinable() and both call join() on
+   * the same thread, which is undefined. It has never fired only because the
+   * SFlare path serialises apply() on its own run_mutex_, which is a property
+   * of one caller and not of this class.
+   *
+   * A dedicated mutex is used rather than a std::once_flag because once_flag
+   * would be consumed by a join attempt made BEFORE startWarmup() assigned the
+   * thread; the flag would then be spent and the thread never joined, which is
+   * std::terminate at destruction. The mutex has no such ordering trap: an
+   * early call simply finds nothing to join and a later one still joins.
+   * Losers block here until the winner's join returns, which is exactly the
+   * "nobody reads renderers until the warm thread is done" contract.
+   */
+  mutable std::mutex warm_join_mtx;
+
+  /**
+   * @brief Join the warm-up thread before anyone reads `renderers`.
+   *        Idempotent and safe to call concurrently.
+   */
+  void joinWarmup() const {
+    std::lock_guard<std::mutex> lk(warm_join_mtx);
+    if (warm_thread.joinable())
+      warm_thread.join();
+  }
+
+  ~Impl() {
+    // A destructor must not let an exception escape, and a std::thread that is
+    // still joinable when destroyed is an unconditional std::terminate --
+    // detaching is the only safe fallback if the join itself failed.
+    try {
+      joinWarmup();
+    } catch (...) {
+      if (warm_thread.joinable())
+        warm_thread.detach();
+    }
+  }
+
+  /**
+   * @brief [init-latency L3] Build the renderer we are almost certainly going
+   *   to need on a side thread, at template-LOAD time instead of at first
+   *   apply().
+   *
+   * minja::chat_template's constructor parses the Jinja source and (for the
+   * polyfill probe) renders it once with a synthetic message set; on the
+   * an 18 KB chat_template.jinja that measured ~170 ms, paid serially inside
+   * the first apply() -- i.e. straight onto the first-token latency, after the
+   * whole model was already loaded. It depends on nothing but the source and
+   * the bos/eos tokens, all of which are final by the end of Load(), so it
+   * overlaps the graph compile + weight load for free (same trick as the
+   * async tokenizer parse in Transformer's ctor).
+   *
+   * Only the key apply() will actually ask for is warmed: "__default__" for a
+   * single-source template (chat_template.jinja or a string chat_template),
+   * else the "default" entry of a template map. A tools/template_name request
+   * simply misses the cache and constructs lazily as before.
+   *
+   * Failures are swallowed: apply() then constructs on its own and raises the
+   * real error at the point the caller can attribute it.
+   * NNTR_CHAT_TEMPLATE_WARM=0 disables the warm-up.
+   */
+  void startWarmup() {
+    const char *e = std::getenv("NNTR_CHAT_TEMPLATE_WARM");
+    if (e != nullptr && e[0] == '0')
+      return;
+
+    std::string key;
+    std::string src;
+    if (!template_source.empty()) {
+      key = "__default__";
+      src = template_source;
+    } else if (template_map.contains("default") &&
+               template_map["default"].is_string()) {
+      key = "default";
+      src = template_map["default"].get<std::string>();
+    } else {
+      return;
+    }
+
+    warm_thread = std::thread([this, key, src]() {
+      try {
+        auto renderer =
+          std::make_unique<minja::chat_template>(src, bos_token, eos_token);
+        std::lock_guard<std::mutex> lk(renderers_mtx);
+        renderers.emplace(key, std::move(renderer));
+      } catch (...) {
+        // Leave the cache empty; apply() will construct and throw properly.
+      }
+      if (std::getenv("NNTR_INIT_TRACE")) {
+        std::fprintf(stderr, "[init-trace] chat-template renderer warm done\n");
+        std::fflush(stderr);
+      }
+    });
+  }
 
   const std::string &selectTemplate(bool has_tools, const Options &options,
                                     std::string &cache_key) const {
@@ -211,6 +317,15 @@ struct ChatTemplate::Impl {
 
   const minja::chat_template &rendererFor(const std::string &key,
                                           const std::string &source) const {
+    // [init-latency L3] The warm-up thread may still be inserting; join it
+    // before the lookup, then take renderers_mtx for the map itself (a later
+    // apply() with a different key can race a concurrent caller on it).
+    // Lock ORDER matters and is enforced by construction: joinWarmup() takes
+    // and releases warm_join_mtx and returns before renderers_mtx is acquired
+    // here, so the two are never held at once -- which is what keeps the join
+    // from deadlocking against the warm thread's own renderers_mtx.
+    joinWarmup();
+    std::lock_guard<std::mutex> lk(renderers_mtx);
     auto it = renderers.find(key);
     if (it != renderers.end())
       return *it->second;
@@ -436,6 +551,8 @@ ChatTemplate ChatTemplate::Load(const std::string &model_path) {
   if (fileExists(template_file_path)) {
     impl->source_path = template_file_path;
     impl->template_source = readTextFile(template_file_path);
+    // [init-latency L3] Everything the renderer needs is final now.
+    impl->startWarmup();
     return ChatTemplate(std::move(impl));
   }
 
@@ -455,6 +572,8 @@ ChatTemplate ChatTemplate::Load(const std::string &model_path) {
                              "object");
   }
 
+  // [init-latency L3] Everything the renderer needs is final now.
+  impl->startWarmup();
   return ChatTemplate(std::move(impl));
 }
 

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -393,15 +393,31 @@ int main(int argc, char *argv[]) {
       chat_template.emplace(causallm::ChatTemplate::Load(model_path));
     }
 
-    // Determine input text
+    // [init-latency] Decide WHICH input we will use here, but defer the chat
+    // template RENDER to just before run().
+    //
+    // L3 (a3495fdbd) warms the minja renderer on a side thread inside
+    // ChatTemplate::Load(), and apply() joins that thread. Rendering nine
+    // lines after Load() gave the warm thread nothing to overlap, so the CLI
+    // still paid the full ~170-190 ms construction serially -- and paid it
+    // AHEAD of initialize(), i.e. squarely on the path to the first token.
+    // Deferring the render past repack_weight() hands it the same window the
+    // SFlare path already gets for free (create + initialize + load_weight +
+    // repack), where the measured overlap is total.
+    //
+    // Config-shape errors are still raised HERE, before ~800 ms of model load:
+    // the deferred branch is taken only when chat_input exists AND a template
+    // loaded, and both are decided now. The 'sample_input' lookups (which
+    // throw when the key is missing) also stay on this side. Only a template
+    // RENDER failure moves later, and that is not discoverable without
+    // rendering.
+    bool render_chat_input = false;
     if (argc >= 3) {
       input_text = argv[2];
     } else {
       if (nntr_cfg.contains("chat_input")) {
         if (chat_template.has_value()) {
-          input_text = chat_template->apply(nntr_cfg["chat_input"]);
-          system_head_prompt.clear();
-          system_tail_prompt.clear();
+          render_chat_input = true;
         } else {
           std::cerr << "[Warning] 'chat_input' is set but support for model "
                        "architecture '"
@@ -427,6 +443,18 @@ int main(int argc, char *argv[]) {
     model->initialize();
     model->load_weight(weight_file);
     model->repack_weight();
+
+    // [init-latency] The deferred chat-template render. By now L3's warm
+    // thread has had the whole create/initialize/load/repack window to finish,
+    // so this joins an already-completed renderer instead of constructing one.
+    // Clearing the system prompts is part of the contract of using a chat
+    // template (the template carries its own system turn) and must still
+    // happen before run() -- it does, run() is below.
+    if (render_chat_input) {
+      input_text = chat_template->apply(nntr_cfg["chat_input"]);
+      system_head_prompt.clear();
+      system_tail_prompt.clear();
+    }
 
     bool do_sample = generation_cfg.value("do_sample", false);
 


### PR DESCRIPTION
Two commits that take the ~170–190 ms `minja` chat-template renderer construction off the path to the
first token.

1. **Warm the renderer off-thread, race-safe.** `ChatTemplate::Load()` starts a side thread that
   builds the renderer; the first `apply()` joins it. On a caller that does
   create → initialize → load_weight → repack between `Load()` and `apply()`, the overlap is total.
   The join is guarded (the naive `if (warm_thread.joinable()) warm_thread.join();` outside a lock lets
   two concurrent `apply()` callers both see `joinable()` and both join — the fix for that is folded
   into this commit, not left as a follow-up).

2. **Make the CLI actually overlap.** On the app's own CLI path the first commit bought nothing:
   `Load()` and `apply()` were nine lines apart, before the model object even existed, so the warm
   thread was joined almost immediately and the construction was still paid serially — and *ahead* of
   `initialize()`, squarely on the path to the first token. This splits the decision from the render:
   *which* input to use is still resolved in place, only the render moves to just after
   `repack_weight()`, handing the warm thread the same window a create/initialize/load/repack caller
   already gets.

Error timing is deliberately preserved: the deferred branch is taken only when a chat input exists
**and** a template loaded, and both are decided at the original point — as are the `sample_input`
lookups that throw when the key is missing. A malformed config still fails before model load.

**New in this rung:** the two commits above.

**Not included:** no change to template semantics, rendering output, or the tokenizer path.

**Validated:** CPU build clean; the double-join race is closed by construction (single guarded join
under the lock). Generated text is unaffected — this moves *when* the renderer is built, not what it
produces.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends
and levers are gated so existing builds and the default execution path stay byte-identical unless a
feature is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
