### PR TITLE
[causallm] Persistent tokenizer snapshot cache: rebuild the BPE instead of re-parsing 32 MB of JSON

### DIFF
--- a/Applications/CausalLM/huggingface_tokenizer.cpp
+++ b/Applications/CausalLM/huggingface_tokenizer.cpp
@@ -129,4 +129,25 @@ Tokenizer::FromBlobByteLevelBPE(const std::string &vocab,
     vocab.data(), vocab.length(), merges.data(), merges.length(),
     added_tokens.data(), added_tokens.length()));
 }
+
+std::unique_ptr<Tokenizer> Tokenizer::FromSnapshot(const std::string &blob) {
+  TokenizerHandle handle =
+    tokenizers_new_from_snapshot(blob.data(), blob.length());
+  if (handle == nullptr) {
+    return nullptr; // caller falls back to the JSON parse path
+  }
+  return std::make_unique<HFTokenizer>(handle);
+}
+
+std::string Tokenizer::SnapshotFromJSON(const std::string &json) {
+  char *data = nullptr;
+  size_t len = 0;
+  tokenizers_snapshot_from_json(json.data(), json.length(), &data, &len);
+  if (data == nullptr || len == 0) {
+    return {};
+  }
+  std::string blob(data, len);
+  tokenizers_snapshot_free(data);
+  return blob;
+}
 } // namespace tokenizers

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -78,6 +78,7 @@ LOCAL_SRC_FILES := \
     ../models/gpt_oss/gptoss_causallm.cpp \
     ../models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.cpp \
     ../huggingface_tokenizer.cpp \
+    ../tokenizer_cache.cpp \
     ../llm_util.cpp \
     ../layers/embedding_layer.cpp \
     ../layers/embedding_pooling_layer.cpp \

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -1,6 +1,7 @@
 causallm_src = [
     meson.current_source_dir() / 'chat_template.cpp',
     meson.current_source_dir() / 'huggingface_tokenizer.cpp',
+    meson.current_source_dir() / 'tokenizer_cache.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
     meson.current_source_dir() / 'api' / 'callback_streamer.cpp',
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -18,6 +18,7 @@
 #include <model.h>
 
 #include <llm_util.hpp>
+#include <tokenizer_cache.h>
 #include <tokenizers_cpp.h>
 #include <transformer.h>
 
@@ -118,8 +119,14 @@ Transformer::Transformer(json &cfg, json &generation_cfg, json &nntr_cfg,
       nntr_cfg["tokenizer_file"].is_null()) {
     tokenizer = nullptr; // No tokenizer for this model
   } else {
-    tokenizer = tokenizers::Tokenizer::FromBlobJSON(
-      LoadBytesFromFile(nntr_cfg["tokenizer_file"]));
+    // Through the persistent snapshot cache (tokenizer_cache.cpp): a HIT
+    // rebuilds the BPE from the snapshot's vocab/merges tables instead of
+    // re-parsing ~32 MB of JSON; a miss / stale key / corrupt file parses
+    // exactly as before (same FromBlobJSON call, same bytes) and schedules a
+    // background, exit-joined rewrite. This parse is SYNCHRONOUS here, so
+    // everything it saves comes straight off time-to-first-token.
+    // NNTR_TOKENIZER_CACHE=0 opts out.
+    tokenizer = causallm::LoadTokenizerCached(nntr_cfg["tokenizer_file"]);
   }
 };
 

--- a/Applications/CausalLM/tokenizer_cache.cpp
+++ b/Applications/CausalLM/tokenizer_cache.cpp
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   tokenizer_cache.cpp
+ * @date   30 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Persistent post-parse tokenizer cache -- see tokenizer_cache.h.
+ */
+
+#include "tokenizer_cache.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+
+#include <nntrainer_log.h>
+
+namespace causallm {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+/**
+ * Cache file layout (little-endian, after which the Rust-side snapshot
+ * payload follows verbatim; the payload carries its own magic + version):
+ *
+ *   offset 0  : magic "NTKC"
+ *          4  : u32 header version (bump on ANY layout/semantic change)
+ *          8  : u64 source tokenizer.json size          } the (size, mtime,
+ *          16 : u64 source tokenizer.json mtime (raw)   } version) cache key
+ *          24 : u64 payload length
+ *          32 : u64 FNV-1a of the payload (bit-flip / truncation guard)
+ *          40 : payload
+ */
+constexpr char kMagic[4] = {'N', 'T', 'K', 'C'};
+constexpr uint32_t kHeaderVersion = 1;
+constexpr size_t kHeaderSize = 40;
+
+struct SourceKey {
+  uint64_t size;
+  uint64_t mtime;
+};
+
+uint64_t fnv1a(const void *data, size_t len) {
+  const auto *p = static_cast<const unsigned char *>(data);
+  uint64_t h = 1469598103934665603ULL;
+  for (size_t i = 0; i < len; ++i) {
+    h ^= p[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+double nowMs() {
+  return std::chrono::duration<double, std::milli>(
+           std::chrono::steady_clock::now().time_since_epoch())
+    .count();
+}
+
+bool cacheEnabled() {
+  const char *e = std::getenv("NNTR_TOKENIZER_CACHE");
+  return e == nullptr || e[0] != '0';
+}
+
+bool sourceKey(const std::string &path, SourceKey &out) {
+  std::error_code ec;
+  const auto size = fs::file_size(path, ec);
+  if (ec)
+    return false;
+  const auto mtime = fs::last_write_time(path, ec);
+  if (ec)
+    return false;
+  out.size = static_cast<uint64_t>(size);
+  out.mtime = static_cast<uint64_t>(mtime.time_since_epoch().count());
+  return true;
+}
+
+/** Primary cache location: next to the tokenizer file. */
+std::string primaryCachePath(const std::string &tok_path) {
+  return tok_path + ".ntkc";
+}
+
+/** Fallback: $XDG_CACHE_HOME/nntrainer/tokenizer (else ~/.cache/...). */
+std::string fallbackCachePath(const std::string &tok_path) {
+  std::string base;
+  if (const char *xdg = std::getenv("XDG_CACHE_HOME"); xdg && xdg[0])
+    base = xdg;
+  else if (const char *home = std::getenv("HOME"); home && home[0])
+    base = std::string(home) + "/.cache";
+  else
+    return {}; // no stable per-user location on this platform/environment
+  std::error_code ec;
+  fs::path abs = fs::absolute(tok_path, ec);
+  const std::string keysrc = ec ? tok_path : abs.string();
+  char name[32];
+  std::snprintf(
+    name, sizeof(name), "%016llx",
+    static_cast<unsigned long long>(fnv1a(keysrc.data(), keysrc.size())));
+  return base + "/nntrainer/tokenizer/" + name + ".ntkc";
+}
+
+/**
+ * Read + fully validate one candidate cache file against the current source
+ * key. Returns the payload, or empty on ANY mismatch/short-read/corruption.
+ */
+std::string readValidatedPayload(const std::string &cache_path,
+                                 const SourceKey &key) {
+  std::ifstream f(cache_path, std::ios::binary | std::ios::in);
+  if (!f.good())
+    return {};
+  char header[kHeaderSize];
+  if (!f.read(header, kHeaderSize))
+    return {};
+  if (std::memcmp(header, kMagic, 4) != 0)
+    return {};
+  auto rd_u32 = [&header](size_t off) {
+    uint32_t v;
+    std::memcpy(&v, header + off, sizeof(v));
+    return v;
+  };
+  auto rd_u64 = [&header](size_t off) {
+    uint64_t v;
+    std::memcpy(&v, header + off, sizeof(v));
+    return v;
+  };
+  if (rd_u32(4) != kHeaderVersion)
+    return {};
+  if (rd_u64(8) != key.size || rd_u64(16) != key.mtime)
+    return {}; // stale key -> miss -> re-parse + rewrite
+  const uint64_t payload_len = rd_u64(24);
+  const uint64_t payload_fnv = rd_u64(32);
+  // Sanity bound: a payload larger than 1GB is not something we ever wrote.
+  if (payload_len == 0 || payload_len > (1ULL << 30))
+    return {};
+  std::string payload(static_cast<size_t>(payload_len), '\0');
+  if (!f.read(payload.data(), static_cast<std::streamsize>(payload_len)))
+    return {}; // truncated
+  // Trailing bytes after the payload => not a file this version wrote.
+  f.peek();
+  if (!f.eof())
+    return {};
+  if (fnv1a(payload.data(), payload.size()) != payload_fnv)
+    return {}; // bit-flip
+  return payload;
+}
+
+/** Atomic-ish write: temp file + rename. Returns true on success. */
+bool writeCacheFile(const std::string &cache_path, const SourceKey &key,
+                    const std::string &payload) {
+  std::error_code ec;
+  const fs::path dir = fs::path(cache_path).parent_path();
+  if (!dir.empty())
+    fs::create_directories(dir, ec); // best-effort; open below decides
+  const std::string tmp = cache_path + ".tmp";
+  {
+    std::ofstream f(tmp, std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!f.good())
+      return false;
+    char header[kHeaderSize];
+    std::memcpy(header, kMagic, 4);
+    auto wr_u32 = [&header](size_t off, uint32_t v) {
+      std::memcpy(header + off, &v, sizeof(v));
+    };
+    auto wr_u64 = [&header](size_t off, uint64_t v) {
+      std::memcpy(header + off, &v, sizeof(v));
+    };
+    wr_u32(4, kHeaderVersion);
+    wr_u64(8, key.size);
+    wr_u64(16, key.mtime);
+    wr_u64(24, static_cast<uint64_t>(payload.size()));
+    wr_u64(32, fnv1a(payload.data(), payload.size()));
+    f.write(header, kHeaderSize);
+    f.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+    if (!f.good()) {
+      f.close();
+      fs::remove(tmp, ec);
+      return false;
+    }
+  }
+  fs::rename(tmp, cache_path, ec);
+  if (ec) {
+    fs::remove(tmp, ec);
+    return false;
+  }
+  return true;
+}
+
+std::string loadFileBytes(const std::string &path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file.is_open()) {
+    // Same failure semantics as the parse path (LoadBytesFromFile).
+    throw std::runtime_error("Failed to open file: " + path);
+  }
+  const std::streamsize size = file.tellg();
+  file.seekg(0, std::ios::beg);
+  std::string buffer(static_cast<size_t>(size), ' ');
+  if (!file.read(buffer.data(), size)) {
+    throw std::runtime_error("Failed to read file: " + path);
+  }
+  return buffer;
+}
+
+/**
+ * Background cache (re)write. Runs on a side thread with the json bytes
+ * moved in, AFTER the parsed tokenizer has been handed to the caller -- a
+ * cache miss never adds to the critical path. A partial write is never
+ * visible (temp + rename), and even a corrupted rename result is caught by
+ * the FNV check on the next read.
+ *
+ * The worker is held in a function-static std::async future rather than
+ * detached: its destructor joins at process exit, so a short-lived process
+ * (CLI one-shot) still persists the cache instead of killing the writer
+ * mid-cycle (verified: a detached writer's rename never landed when main()
+ * returned first). Cost: at most one ~0.5-0.7s teardown wait, only on runs
+ * that actually re-wrote the cache.
+ */
+void scheduleCacheWrite(std::string json, const std::string &tok_path,
+                        const SourceKey &key) {
+  static std::mutex writer_mtx;
+  static std::future<void> writer; // joined on reassignment and at exit
+  auto task = [json = std::move(json), tok_path, key]() {
+    const double t0 = nowMs();
+    const std::string payload = tokenizers::Tokenizer::SnapshotFromJSON(json);
+    if (payload.empty()) {
+      ml_logd("tokenizer snapshot not cacheable (non-BPE or unknown shape); "
+              "parse path stays (%.1f ms spent probing)",
+              nowMs() - t0);
+      return;
+    }
+    std::string where = primaryCachePath(tok_path);
+    if (!writeCacheFile(where, key, payload)) {
+      where = fallbackCachePath(tok_path);
+      if (where.empty() || !writeCacheFile(where, key, payload))
+        where.clear();
+    }
+    if (!where.empty())
+      ml_logd("tokenizer snapshot written (background, %.1f ms)", nowMs() - t0);
+    else
+      ml_logd("tokenizer snapshot write failed everywhere (read-only?); "
+              "will re-parse next run (%.1f ms)",
+              nowMs() - t0);
+  };
+  std::lock_guard<std::mutex> lk(writer_mtx);
+  if (writer.valid())
+    writer.wait(); // at most one writer in flight (multi-model processes)
+  writer = std::async(std::launch::async, std::move(task));
+}
+
+} // namespace
+
+std::unique_ptr<tokenizers::Tokenizer>
+LoadTokenizerCached(const std::string &tok_path) {
+  SourceKey key{};
+  const bool use_cache = cacheEnabled() && sourceKey(tok_path, key);
+
+  if (use_cache) {
+    const double t0 = nowMs();
+    std::string payload = readValidatedPayload(primaryCachePath(tok_path), key);
+    if (payload.empty()) {
+      const std::string fb = fallbackCachePath(tok_path);
+      if (!fb.empty())
+        payload = readValidatedPayload(fb, key);
+    }
+    if (!payload.empty()) {
+      auto tok = tokenizers::Tokenizer::FromSnapshot(payload);
+      if (tok != nullptr) {
+        ml_logd("tokenizer snapshot HIT, load took %.1f ms (parse avoided)",
+                nowMs() - t0);
+        return tok;
+      }
+      ml_logd("tokenizer snapshot rejected by loader after %.1f ms; falling "
+              "back to parse",
+              nowMs() - t0);
+    }
+  }
+
+  // Parse path -- identical to the pre-cache behavior.
+  const double t0 = nowMs();
+  std::string json = loadFileBytes(tok_path);
+  auto tok = tokenizers::Tokenizer::FromBlobJSON(json);
+  ml_logd("tokenizer parse done, parse took %.1f ms", nowMs() - t0);
+  if (use_cache)
+    scheduleCacheWrite(std::move(json), tok_path, key);
+  return tok;
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/tokenizer_cache.h
+++ b/Applications/CausalLM/tokenizer_cache.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   tokenizer_cache.h
+ * @date   30 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Persistent post-parse tokenizer cache.
+ *
+ * Tokenizer::FromBlobJSON on a ~32MB BPE tokenizer.json costs ~600ms on an
+ * idle desktop host, and in a synchronous construction path every millisecond
+ * of it lands on time-to-first-token. This module caches the expensive part --
+ * the parsed vocab/merges tables plus the small component sections -- in a
+ * snapshot file so subsequent processes rebuild the tokenizer in ~1/3 the time
+ * (measured 597 -> 234 ms).
+ *
+ * Contract:
+ *  - Byte-identical tokenization: the snapshot reconstruction mirrors the
+ *    tokenizers crate's own deserialize order (model first, then components,
+ *    then added tokens); encode/decode of any prompt equals the parse path.
+ *  - Fail-safe: ANY key mismatch (size/mtime), short read, version bump,
+ *    checksum or deserialize failure falls back silently to the parse path
+ *    (debug log only) and rewrites the cache.
+ *  - NNTR_TOKENIZER_CACHE=0 opts out entirely (no read, no write).
+ *
+ * Cache location: "<tokenizer_file>.ntkc" next to the model; when that
+ * directory is not writable, "$XDG_CACHE_HOME/nntrainer/tokenizer/<hash>.ntkc"
+ * (fallback "~/.cache/..."). The write happens on a detached thread AFTER the
+ * parsed tokenizer has been handed to the caller, so a cache MISS never adds
+ * to the critical path.
+ */
+
+#ifndef __TOKENIZER_CACHE_H__
+#define __TOKENIZER_CACHE_H__
+
+#include <memory>
+#include <string>
+
+#include <tokenizers_cpp.h>
+
+namespace causallm {
+
+/**
+ * @brief Load a tokenizer through the persistent snapshot cache.
+ *
+ * On cache hit rebuilds from the snapshot; on miss/stale/corrupt parses the
+ * JSON (exactly like Tokenizer::FromBlobJSON) and schedules a background
+ * cache (re)write.
+ *
+ * @param tok_path path to tokenizer.json
+ * @return the tokenizer (same success/failure semantics as FromBlobJSON;
+ *         file-open failures throw just like the parse path did)
+ */
+std::unique_ptr<tokenizers::Tokenizer>
+LoadTokenizerCached(const std::string &tok_path);
+
+} // namespace causallm
+
+#endif // __TOKENIZER_CACHE_H__

--- a/Applications/CausalLM/tokenizers_c.h
+++ b/Applications/CausalLM/tokenizers_c.h
@@ -55,6 +55,20 @@ void tokenizers_token_to_id(TokenizerHandle handle, const char *token,
 
 void tokenizers_free(TokenizerHandle handle);
 
+// ---- tokenizer snapshot (persistent post-parse cache payload) ----
+// Build a snapshot payload from tokenizer.json bytes. On success *out_data
+// (malloc'd; free with tokenizers_snapshot_free) and *out_len are set; on ANY
+// failure (non-BPE model, unknown shape) both are zeroed.
+void tokenizers_snapshot_from_json(const char *json, size_t len,
+                                   char **out_data, size_t *out_len);
+
+void tokenizers_snapshot_free(char *data);
+
+// Rebuild a tokenizer from a snapshot payload. Returns NULL on ANY failure
+// (bad magic/version/bounds/deserialize) -- caller falls back to the JSON
+// parse path.
+TokenizerHandle tokenizers_new_from_snapshot(const char *data, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Applications/CausalLM/tokenizers_c_win/src/lib.rs
+++ b/Applications/CausalLM/tokenizers_c_win/src/lib.rs
@@ -350,3 +350,389 @@ pub unsafe extern "C" fn tokenizers_free(handle: TokenizerHandle) {
         drop(Box::from_raw(handle as *mut TokenizerState));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tokenizer snapshot: a persistent post-parse cache payload.
+//
+// Rationale: Tokenizer::from_bytes on a ~32MB BPE tokenizer.json costs
+// ~500-600ms per process on an idle desktop host (more under contention with
+// load workers), and the crate's own serde path cannot be made
+// faster by switching serde formats -- the cost is dominated by the internal
+// Content/Value buffering (ModelWrapper's untagged+flatten deserialize) and
+// by BPE construction, not by JSON text parsing. (Measured: a full-object
+// msgpack round-trip loads in ~505ms vs ~525ms JSON -- no win. Also, BPE's
+// custom Serialize declares 8 struct fields but writes 10, which truncates
+// vocab/merges in any length-prefixed format; only the JSON-object route is
+// safe.)
+//
+// The snapshot therefore bypasses serde for the heavy sections. Layout
+// (little-endian):
+//
+//   u32 magic 'NTKS' | u32 version
+//   u32 comp_len   | components JSON (verbatim copies of every non-model
+//                    section of tokenizer.json + the BPE option fields)
+//   u32 vocab_cnt  | vocab_cnt x { u32 id, u32 len, bytes }
+//   u32 merges_cnt | merges_cnt x { u32 len_a, bytes_a, u32 len_b, bytes_b }
+//
+// Reconstruction uses only public tokenizers API (BpeBuilder + component
+// deserializers + add_tokens in the same order as the crate's own
+// TokenizerVisitor), measured at ~175ms for the same file (~3x). Encode /
+// decode / vocab-size / id<->token identity against the parse path is the
+// caller's acceptance gate; ANY structural surprise here returns
+// null/failure so the caller can fall back to the parse path.
+//
+// Only BPE models are snapshotted (vocab/merges are the only heavy sections
+// worth bypassing); everything else returns failure => no cache.
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT_MAGIC: u32 = 0x4E544B53; // 'NTKS'
+const SNAPSHOT_VERSION: u32 = 1;
+
+fn put_u32(out: &mut Vec<u8>, v: u32) {
+    out.extend_from_slice(&v.to_le_bytes());
+}
+
+fn put_str(out: &mut Vec<u8>, s: &str) {
+    put_u32(out, s.len() as u32);
+    out.extend_from_slice(s.as_bytes());
+}
+
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn u32(&mut self) -> Option<u32> {
+        let end = self.pos.checked_add(4)?;
+        if end > self.buf.len() {
+            return None;
+        }
+        let v = u32::from_le_bytes(self.buf[self.pos..end].try_into().ok()?);
+        self.pos = end;
+        Some(v)
+    }
+    fn bytes(&mut self, len: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(len)?;
+        if end > self.buf.len() {
+            return None;
+        }
+        let b = &self.buf[self.pos..end];
+        self.pos = end;
+        Some(b)
+    }
+    fn str_field(&mut self) -> Option<&'a str> {
+        let len = self.u32()? as usize;
+        std::str::from_utf8(self.bytes(len)?).ok()
+    }
+}
+
+/// Build the snapshot payload from the ORIGINAL tokenizer.json bytes.
+/// Conservative: any shape this writer does not fully understand => None
+/// (the caller simply does not cache). The caller must only invoke this
+/// after the parse path succeeded on the same bytes, so the file is known
+/// to be loadable by the crate.
+fn snapshot_from_json_impl(json: &[u8]) -> Option<Vec<u8>> {
+    let v: serde_json::Value = serde_json::from_slice(json).ok()?;
+    let obj = v.as_object()?;
+
+    // The crate's TokenizerVisitor only accepts version "1.0"; mirror it.
+    if let Some(ver) = obj.get("version") {
+        if ver.as_str() != Some("1.0") {
+            return None;
+        }
+    }
+
+    let model = obj.get("model")?.as_object()?;
+    if model.get("type").and_then(|t| t.as_str()) != Some("BPE") {
+        return None; // only BPE is worth (and safe for) bypassing
+    }
+
+    // added_tokens: require the exact field set the reconstruction consumes,
+    // so a novel added-token shape falls back to the parse path instead of
+    // being silently mis-reconstructed.
+    if let Some(added) = obj.get("added_tokens") {
+        let arr = added.as_array()?;
+        for t in arr {
+            let o = t.as_object()?;
+            if !(o.get("content").map_or(false, |x| x.is_string())
+                && o.get("id").map_or(false, |x| x.is_u64())
+                && o.get("special").map_or(false, |x| x.is_boolean())
+                && o.get("single_word").map_or(false, |x| x.is_boolean())
+                && o.get("lstrip").map_or(false, |x| x.is_boolean())
+                && o.get("rstrip").map_or(false, |x| x.is_boolean())
+                && o.get("normalized").map_or(false, |x| x.is_boolean()))
+            {
+                return None;
+            }
+        }
+    }
+
+    // Components JSON: verbatim copies, so reconstruction feeds the exact
+    // same JSON values to the exact same component deserializers.
+    let mut comp = serde_json::Map::new();
+    for key in [
+        "normalizer",
+        "pre_tokenizer",
+        "post_processor",
+        "decoder",
+        "padding",
+        "truncation",
+        "added_tokens",
+    ] {
+        if let Some(val) = obj.get(key) {
+            comp.insert(key.to_string(), val.clone());
+        }
+    }
+    let mut bpe_opts = serde_json::Map::new();
+    for key in [
+        "dropout",
+        "unk_token",
+        "continuing_subword_prefix",
+        "end_of_word_suffix",
+        "fuse_unk",
+        "byte_fallback",
+        "ignore_merges",
+    ] {
+        if let Some(val) = model.get(key) {
+            bpe_opts.insert(key.to_string(), val.clone());
+        }
+    }
+    comp.insert("bpe".to_string(), serde_json::Value::Object(bpe_opts));
+    let comp_json = serde_json::to_string(&serde_json::Value::Object(comp)).ok()?;
+
+    let vocab = model.get("vocab")?.as_object()?;
+    let merges = model.get("merges")?.as_array()?;
+
+    let mut out = Vec::with_capacity(json.len() / 2 + comp_json.len() + 64);
+    put_u32(&mut out, SNAPSHOT_MAGIC);
+    put_u32(&mut out, SNAPSHOT_VERSION);
+    put_str(&mut out, &comp_json);
+
+    put_u32(&mut out, u32::try_from(vocab.len()).ok()?);
+    for (token, id) in vocab {
+        let id = u32::try_from(id.as_u64()?).ok()?;
+        put_u32(&mut out, id);
+        put_str(&mut out, token);
+    }
+
+    put_u32(&mut out, u32::try_from(merges.len()).ok()?);
+    for m in merges {
+        if let Some(pair) = m.as_array() {
+            if pair.len() != 2 {
+                return None;
+            }
+            put_str(&mut out, pair[0].as_str()?);
+            put_str(&mut out, pair[1].as_str()?);
+        } else {
+            // legacy "a b" string form
+            let s = m.as_str()?;
+            let mut it = s.splitn(2, ' ');
+            let a = it.next()?;
+            let b = it.next()?;
+            put_str(&mut out, a);
+            put_str(&mut out, b);
+        }
+    }
+    Some(out)
+}
+
+/// Rebuild the Tokenizer from a snapshot payload. Bounds-checked throughout;
+/// any inconsistency => None (caller falls back to the parse path). The
+/// assembly order mirrors the crate's own TokenizerVisitor: model FIRST,
+/// then components, then add_tokens against the fully-populated model so
+/// added-token id resolution is identical.
+fn tokenizer_from_snapshot_impl(blob: &[u8]) -> Option<Tokenizer> {
+    let mut cur = Cursor { buf: blob, pos: 0 };
+    if cur.u32()? != SNAPSHOT_MAGIC || cur.u32()? != SNAPSHOT_VERSION {
+        return None;
+    }
+    let comp_json = cur.str_field()?;
+    let comp: serde_json::Value = serde_json::from_str(comp_json).ok()?;
+    let comp = comp.as_object()?;
+
+    let vocab_cnt = cur.u32()? as usize;
+    // 8 bytes minimum per entry: reject counts the remaining bytes cannot hold.
+    if vocab_cnt > (blob.len() - cur.pos) / 8 {
+        return None;
+    }
+    let mut vocab = Vocab::with_capacity(vocab_cnt);
+    for _ in 0..vocab_cnt {
+        let id = cur.u32()?;
+        let token = cur.str_field()?;
+        vocab.insert(token.to_string(), id);
+    }
+
+    let merges_cnt = cur.u32()? as usize;
+    if merges_cnt > (blob.len() - cur.pos) / 8 {
+        return None;
+    }
+    let mut merges: Vec<(String, String)> = Vec::with_capacity(merges_cnt);
+    for _ in 0..merges_cnt {
+        let a = cur.str_field()?;
+        let b = cur.str_field()?;
+        merges.push((a.to_string(), b.to_string()));
+    }
+    if cur.pos != blob.len() {
+        return None; // trailing bytes => not something this version wrote
+    }
+
+    let empty = serde_json::Map::new();
+    let opts = comp
+        .get("bpe")
+        .and_then(|b| b.as_object())
+        .unwrap_or(&empty);
+    let mut b = BPE::builder().vocab_and_merges(vocab, merges);
+    // Mirrors BPEVisitor: absent or null => builder default, exactly like
+    // `if let Some(x) = map.next_value::<Option<_>>()`.
+    if let Some(d) = opts.get("dropout").and_then(|x| x.as_f64()) {
+        b = b.dropout(d as f32);
+    }
+    if let Some(u) = opts.get("unk_token").and_then(|x| x.as_str()) {
+        b = b.unk_token(u.to_string());
+    }
+    if let Some(p) = opts
+        .get("continuing_subword_prefix")
+        .and_then(|x| x.as_str())
+    {
+        b = b.continuing_subword_prefix(p.to_string());
+    }
+    if let Some(s) = opts.get("end_of_word_suffix").and_then(|x| x.as_str()) {
+        b = b.end_of_word_suffix(s.to_string());
+    }
+    if let Some(f) = opts.get("fuse_unk").and_then(|x| x.as_bool()) {
+        b = b.fuse_unk(f);
+    }
+    if let Some(f) = opts.get("byte_fallback").and_then(|x| x.as_bool()) {
+        b = b.byte_fallback(f);
+    }
+    if let Some(f) = opts.get("ignore_merges").and_then(|x| x.as_bool()) {
+        b = b.ignore_merges(f);
+    }
+    let bpe = b.build().ok()?;
+
+    let mut tk = Tokenizer::new(bpe);
+    if let Some(n) = comp.get("normalizer") {
+        if !n.is_null() {
+            tk.with_normalizer(Some(
+                serde_json::from_value::<tokenizers::NormalizerWrapper>(n.clone()).ok()?,
+            ));
+        }
+    }
+    if let Some(p) = comp.get("pre_tokenizer") {
+        if !p.is_null() {
+            tk.with_pre_tokenizer(Some(
+                serde_json::from_value::<tokenizers::PreTokenizerWrapper>(p.clone()).ok()?,
+            ));
+        }
+    }
+    if let Some(p) = comp.get("post_processor") {
+        if !p.is_null() {
+            tk.with_post_processor(Some(
+                serde_json::from_value::<tokenizers::PostProcessorWrapper>(p.clone()).ok()?,
+            ));
+        }
+    }
+    if let Some(d) = comp.get("decoder") {
+        if !d.is_null() {
+            tk.with_decoder(Some(
+                serde_json::from_value::<tokenizers::DecoderWrapper>(d.clone()).ok()?,
+            ));
+        }
+    }
+    if let Some(p) = comp.get("padding") {
+        if !p.is_null() {
+            tk.with_padding(Some(serde_json::from_value(p.clone()).ok()?));
+        }
+    }
+    if let Some(t) = comp.get("truncation") {
+        if !t.is_null() {
+            tk.with_truncation(Some(serde_json::from_value(t.clone()).ok()?))
+                .ok()?;
+        }
+    }
+    if let Some(a) = comp.get("added_tokens") {
+        let arr = a.as_array()?;
+        let mut toks: Vec<AddedToken> = Vec::with_capacity(arr.len());
+        for t in arr {
+            let o = t.as_object()?;
+            toks.push(
+                AddedToken::from(
+                    o.get("content")?.as_str()?.to_string(),
+                    o.get("special")?.as_bool()?,
+                )
+                .single_word(o.get("single_word")?.as_bool()?)
+                .lstrip(o.get("lstrip")?.as_bool()?)
+                .rstrip(o.get("rstrip")?.as_bool()?)
+                .normalized(o.get("normalized")?.as_bool()?),
+            );
+        }
+        tk.add_tokens(&toks);
+    }
+    Some(tk)
+}
+
+/// C ABI: build a snapshot payload from tokenizer.json bytes. On success
+/// *out_data (malloc'd, free with tokenizers_snapshot_free) and *out_len are
+/// set; on ANY failure both are zeroed. Never panics across the boundary.
+#[no_mangle]
+pub unsafe extern "C" fn tokenizers_snapshot_from_json(
+    json: *const c_char,
+    len: size_t,
+    out_data: *mut *mut c_char,
+    out_len: *mut size_t,
+) {
+    if out_data.is_null() || out_len.is_null() {
+        return;
+    }
+    *out_data = ptr::null_mut();
+    *out_len = 0;
+    let Some(bytes) = bytes_from_raw(json, len) else {
+        return;
+    };
+    let blob = std::panic::catch_unwind(|| snapshot_from_json_impl(bytes))
+        .ok()
+        .flatten();
+    let Some(blob) = blob else {
+        return;
+    };
+    let out = libc::malloc(blob.len()) as *mut u8;
+    if out.is_null() {
+        return;
+    }
+    ptr::copy_nonoverlapping(blob.as_ptr(), out, blob.len());
+    *out_data = out as *mut c_char;
+    *out_len = blob.len();
+}
+
+/// C ABI: free a buffer returned by tokenizers_snapshot_from_json.
+#[no_mangle]
+pub unsafe extern "C" fn tokenizers_snapshot_free(data: *mut c_char) {
+    if !data.is_null() {
+        libc::free(data as *mut c_void);
+    }
+}
+
+/// C ABI: rebuild a tokenizer from a snapshot payload. Returns NULL on ANY
+/// failure (bad magic/version/bounds/deserialize) -- the caller falls back
+/// to the JSON parse path. Never panics across the boundary.
+#[no_mangle]
+pub unsafe extern "C" fn tokenizers_new_from_snapshot(
+    data: *const c_char,
+    len: size_t,
+) -> TokenizerHandle {
+    let Some(bytes) = bytes_from_raw(data, len) else {
+        return ptr::null_mut();
+    };
+    let tok = std::panic::catch_unwind(|| tokenizer_from_snapshot_impl(bytes))
+        .ok()
+        .flatten();
+    match tok {
+        Some(tokenizer) => Box::into_raw(Box::new(TokenizerState {
+            tokenizer,
+            decoded: Vec::new(),
+            token: Vec::new(),
+        })) as TokenizerHandle,
+        None => ptr::null_mut(),
+    }
+}

--- a/Applications/CausalLM/tokenizers_cpp.h
+++ b/Applications/CausalLM/tokenizers_cpp.h
@@ -120,6 +120,30 @@ public:
    */
   static std::unique_ptr<Tokenizer>
   FromBlobRWKVWorld(const std::string &model_blob);
+
+  /**
+   * @brief Create HF tokenizer from a snapshot payload previously produced by
+   *        SnapshotFromJSON (persistent post-parse cache).
+   *
+   * Unlike FromBlobJSON this returns nullptr on ANY failure so the caller can
+   * fall back to the JSON parse path.
+   *
+   * @param blob The snapshot payload.
+   * @return The created tokenizer, or nullptr.
+   */
+  static std::unique_ptr<Tokenizer> FromSnapshot(const std::string &blob);
+
+  /**
+   * @brief Build a snapshot payload from tokenizer.json bytes.
+   *
+   * Only call after FromBlobJSON succeeded on the same bytes. Returns an
+   * empty string when the tokenizer shape cannot be snapshotted (non-BPE
+   * model, unknown fields) -- the caller then simply does not cache.
+   *
+   * @param json The tokenizer.json contents.
+   * @return The snapshot payload, or empty.
+   */
+  static std::string SnapshotFromJSON(const std::string &json);
 };
 
 } // namespace tokenizers


### PR DESCRIPTION
`Transformer`'s constructor parses the ~32 MB BPE `tokenizer.json` **synchronously**, before the
model factory and before any GPU bring-up, so all of it sits on the critical path — measured
**626 ms median, 19 % of a warm 3.3 s time-to-first-token** on the reference desktop package.

The cost is not JSON text parsing, so no parser swap removes it: it is dominated by the `tokenizers`
crate's untagged+flatten deserialize buffering plus BPE construction (a full msgpack round-trip
measured ~505 ms vs ~525 ms JSON — no win). So this caches the **result**, not the input: the parsed
vocab/merges tables plus the small component sections are written to a snapshot file, and later runs
rebuild the tokenizer from it.

## Safety contract — the reason this is acceptable on a correctness path

- **Byte-identical tokenization on a HIT.** The snapshot reconstruction mirrors the crate's own
  deserialize order (model, then components, then added tokens), so encode/decode of any prompt
  equals the parse path.
- **Silent fallback on key mismatch or corruption.** Source `(size, mtime)` mismatch, header version
  bump, short read, trailing bytes, FNV-1a payload checksum mismatch, or a loader rejection all fall
  back to the untouched `FromBlobJSON` path and schedule a rewrite. A failure is a debug log, never
  an error, and **never a different answer**.
- **Opt-out:** `NNTR_TOKENIZER_CACHE=0` disables it entirely — no read, no write.
- The (re)write runs on a background worker **after** the parsed tokenizer has been handed to the
  caller, so a MISS never adds to the critical path. The worker is a function-static `std::async`
  future rather than a detached thread, so its destructor joins at exit and a short-lived CLI process
  still persists the cache (a detached writer's rename was verified not to land when `main()`
  returned first).

Cache location: `<tokenizer_file>.ntkc` next to the model, falling back to
`$XDG_CACHE_HOME/nntrainer/tokenizer/<hash>.ntkc` when that directory is not writable.

## Measured

RTX 5060 Laptop desktop host, a 3.5B-class QS4CX package, quiet host, 4–5 runs per arm, snapshot HIT
vs `NNTR_TOKENIZER_CACHE=0`:

| arm | n | full-span TTFT | tokenizer lap | peak RSS |
|---|--:|--:|--:|--:|
| `NNTR_TOKENIZER_CACHE=0` (parse) | 4 | 2126 [2024–2147] | 597 [592–599] | 4366.2 MB |
| snapshot HIT (default) | 3 | **1713** [1709–1781] | **234** [226–240] | **4177.6 MB** |

**−413 ms full span, −363 ms on the lap, −189 MB peak RSS** — rebuilding from the snapshot's
vocab/merges records never materializes the 32 MB JSON document plus serde's transcode buffers.

Gates — each its own run, all with byte-identical golden output:

| gate | tokenizer lap | outcome |
|---|--:|---|
| HIT | 226–240 | as measured above |
| MISS (snapshot parked) | 591 | parse + background rewrite; the rewritten file is **md5-identical** to the original |
| post-rewrite HIT | 227–241 | the exit-joined writer landed |
| bit-flip inside the checksummed window | 625 | silent fallback to parse, correct output |
| truncation to 1/3 | 609 | silent fallback to parse, correct output |
| stale key (`touch tokenizer.json`) | 591 → 230 | invalidate, re-derive + rewrite, then HIT |
| `NNTR_TOKENIZER_CACHE=0` | 597 | pure parse path, no cache file touched |

A snapshot written on one host loaded unmodified on another — the point of keying it by content
(source size/mtime/version + payload checksum) rather than by build.

## What a reviewer should know before approving

- **`Applications/CausalLM/lib/libtokenizers_c.a` is regenerated** (36.1 → 40.2 MB) because the
  snapshot payload is produced/consumed inside the Rust wrapper: three new C entry points
  (`tokenizers_snapshot_from_json` / `tokenizers_snapshot_free` /
  `tokenizers_new_from_snapshot`). The Windows build compiles the same crate from source
  (`tokenizers_c_win`), which is why `src/lib.rs` carries the matching implementation. As with the
  prebuilt it replaces, the archive embeds cargo-registry paths from the machine that built it in
  Rust panic-location strings; removing those needs a rebuild with `--remap-path-prefix`.
- **The snapshot deliberately bypasses serde for the heavy sections.** BPE's custom `Serialize`
  declares 8 struct fields but writes 10, which truncates vocab/merges in any length-prefixed
  format, so only an explicit layout is safe. The payload carries its own magic + version.
- **One call site changes.** `FromBlobJSON(LoadBytesFromFile(...))` becomes
  `LoadTokenizerCached(...)`; the parse path itself is untouched and remains the fallback for every
  failure mode.

**Where this sits in the whole span, attributed honestly.** On this box the three *code* rungs of
this campaign — the i8 prewarm length gate (#4207), the symmetric engine-conditional bring-up
(#4214) and the tokenizer snapshot cache (#4215) — take a warm short turn from **3326 → 1777 ms
(−47 %)** and peak RSS from 4432 → 4080 MB. Reaching the campaign's headline **1504 ms / 2200 MB
(−55 % / −50 %)** additionally needs a **packaging** change with no code in it: moving the PLE and
embedding tables into mmap'd sidecar payloads (`ple_file_name` / `embedding_file_name` — runtime keys
already consumed) measured **−273 ms and −1978 MB peak RSS** (UVM plane 2696 → 1373 MiB), golden
identical to the canonical package. That is a recommendation for model packaging, **not part of this
or any other PR here**. Goldens are byte-identical across all 72 short-turn runs of the campaign,
which share one md5.

Applies to `main` directly — no dependency on the backend series.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
