### PR TITLE
[causallm] One prompt-preparation seam for the chat template

### DIFF
--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -498,4 +498,57 @@ const std::string &ChatTemplate::sourcePath() const {
   return impl_->source_path;
 }
 
+nlohmann::json chatTemplateContext(const nlohmann::json &nntr_cfg) {
+  if (nntr_cfg.is_object() && nntr_cfg.contains("chat_template_context") &&
+      nntr_cfg["chat_template_context"].is_object())
+    return nntr_cfg["chat_template_context"];
+
+  return nlohmann::json::object();
+}
+
+nlohmann::json makeUserRequest(const std::string &user_text,
+                               const nlohmann::json &render_context) {
+  nlohmann::json request = nlohmann::json::object();
+  if (render_context.is_object())
+    request = render_context;
+
+  // The message list is ours to define; a render context may only supply
+  // sibling render keys (a thinking-channel flag, for instance), never the
+  // conversation itself.
+  request["messages"] =
+    nlohmann::json::array({{{"role", "user"}, {"content", user_text}}});
+  return request;
+}
+
+std::string buildPrompt(const ChatTemplate *tmpl, const nlohmann::json &request,
+                        PromptTemplateMode mode,
+                        const nlohmann::json &render_context) {
+  if (tmpl == nullptr || mode == PromptTemplateMode::Never)
+    return std::string();
+
+  // Package-supplied defaults fill only the keys the request left undefined:
+  // an explicit request is authoritative about its own render context.
+  if (render_context.is_object() && !render_context.empty() &&
+      request.is_object()) {
+    nlohmann::json merged = request;
+    for (auto it = render_context.begin(); it != render_context.end(); ++it) {
+      if (!merged.contains(it.key()))
+        merged[it.key()] = it.value();
+    }
+    return tmpl->apply(merged);
+  }
+
+  return tmpl->apply(request);
+}
+
+std::string buildUserPrompt(const ChatTemplate *tmpl,
+                            const std::string &user_text,
+                            PromptTemplateMode mode,
+                            const nlohmann::json &render_context) {
+  if (tmpl == nullptr || mode == PromptTemplateMode::Never)
+    return user_text;
+
+  return buildPrompt(tmpl, makeUserRequest(user_text, render_context), mode);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/chat_template.h
+++ b/Applications/CausalLM/chat_template.h
@@ -70,6 +70,81 @@ private:
   std::unique_ptr<Impl> impl_;
 };
 
+/**
+ * @brief Whether a caller's prompt should be run through the model's template.
+ */
+enum class PromptTemplateMode {
+  Auto,  /**< apply the model package's template when it has one */
+  Never, /**< feed the prompt exactly as given (already-templated input) */
+};
+
+/**
+ * @brief The model package's default chat render context.
+ *
+ * Read from the optional "chat_template_context" object in nntr_config.json.
+ * Some templates branch on a sibling render key rather than on the messages --
+ * a thinking-channel switch is the common case -- and the right owner of that
+ * value is the model package, not a table in the code and not every caller.
+ *
+ * @param nntr_cfg parsed nntr_config.json
+ * @return the context object, or an empty object when the key is absent
+ */
+nlohmann::json chatTemplateContext(const nlohmann::json &nntr_cfg);
+
+/**
+ * @brief Wrap one user turn into the chat request a template expects.
+ * @param user_text      the caller's prompt (UTF-8)
+ * @param render_context extra top-level render keys merged into the request
+ *                       (ignored when not an object); explicit request keys
+ *                       always win, so this only supplies defaults
+ */
+nlohmann::json makeUserRequest(
+  const std::string &user_text,
+  const nlohmann::json &render_context = nlohmann::json::object());
+
+/**
+ * @brief Turn a chat request into the exact text handed to run().
+ *
+ * This is the single prompt-preparation seam. Every front end -- the CLI and
+ * the SDK entry points alike -- goes through it, so one prompt plus one model
+ * package yields one prompt string regardless of which front end the caller
+ * used. There is deliberately no per-architecture template table anywhere: a
+ * chat template is a property of the model package, not of the code.
+ *
+ * @param tmpl  template loaded from the model package, or nullptr when the
+ *              package carries none
+ * @param request chat request (messages array, or object with "messages")
+ * @param mode  Auto = render when @a tmpl is present; Never = not rendered
+ * @param render_context default render keys (see makeUserRequest)
+ * @return the rendered prompt, or "" when nothing was rendered (mode Never or
+ *         no template) -- callers in that case must feed their own raw text
+ * @throw std::exception propagated from the renderer: a template that cannot
+ *        render is reported, never silently downgraded to a raw prompt (a
+ *        silently raw prompt makes an instruction model drift, which reads as
+ *        a model bug rather than a configuration one)
+ */
+std::string
+buildPrompt(const ChatTemplate *tmpl, const nlohmann::json &request,
+            PromptTemplateMode mode = PromptTemplateMode::Auto,
+            const nlohmann::json &render_context = nlohmann::json::object());
+
+/**
+ * @brief Seam for a single user turn -- the SDK convenience path.
+ *
+ * Deliberately a different name rather than an overload of buildPrompt(): a
+ * string literal converts to nlohmann::json just as readily as to std::string,
+ * so an overload pair would make every `buildPrompt(t, "text")` call site
+ * ambiguous.
+ *
+ * @return the rendered prompt, or @a user_text unchanged when no template was
+ *         applied (mode Never, or the package has none)
+ * @see buildPrompt
+ */
+std::string buildUserPrompt(
+  const ChatTemplate *tmpl, const std::string &user_text,
+  PromptTemplateMode mode = PromptTemplateMode::Auto,
+  const nlohmann::json &render_context = nlohmann::json::object());
+
 } // namespace causallm
 
 #endif // __CHAT_TEMPLATE_H__

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -399,7 +399,19 @@ int main(int argc, char *argv[]) {
     } else {
       if (nntr_cfg.contains("chat_input")) {
         if (chat_template.has_value()) {
-          input_text = chat_template->apply(nntr_cfg["chat_input"]);
+          // The render goes through causallm::buildPrompt(), the one seam the
+          // SDK entry points use as well: a prompt rendered here and the same
+          // prompt rendered through the API cannot drift apart, because there
+          // is only one implementation to drift. A literal argv[2] prompt
+          // stays untouched -- callers that template their own input rely on
+          // those bytes arriving verbatim.
+          //
+          // Clearing the system prompts is part of the contract of using a
+          // chat template: the template carries its own system turn.
+          input_text = causallm::buildPrompt(
+            &chat_template.value(), nntr_cfg["chat_input"],
+            causallm::PromptTemplateMode::Auto,
+            causallm::chatTemplateContext(nntr_cfg));
           system_head_prompt.clear();
           system_tail_prompt.clear();
         } else {

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -284,6 +284,27 @@ if get_option('enable-test')
     suite: 'unittests'
   )
 
+  # Prompt-preparation seam: no model, no backend, no tokenizer -- the shared
+  # chat-template source plus gtest, so it runs anywhere the app builds.
+  unittest_chat_template = executable(
+    'unittest_chat_template',
+    [
+      meson.current_source_dir() / 'unittest_chat_template.cpp',
+      meson.current_source_dir() / 'chat_template.cpp',
+    ],
+    dependencies: [gtest_main_dep],
+    include_directories: [causallm_inc, causallm_inc_minja_inc,
+                          causallm_inc_nlohmann_inc],
+    build_by_default: true,
+    install: false,
+  )
+
+  test('unittest_chat_template', unittest_chat_template,
+    args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_chat_template'),
+    timeout: 60,
+    suite: 'unittests'
+  )
+
   unittest_cancel_api = executable(
     'unittest_cancel_api',
     [

--- a/Applications/CausalLM/unittest_chat_template.cpp
+++ b/Applications/CausalLM/unittest_chat_template.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    unittest_chat_template.cpp
+ * @date    30 Jul 2026
+ * @brief   Unit tests for the shared prompt-preparation seam.
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug     No known bugs except for NYI items
+ *
+ * These pin the contract every front end depends on: one prompt plus one model
+ * package yields one prompt string, an opt-out passes bytes through untouched,
+ * and a template that cannot render raises instead of quietly handing the model
+ * an unmarked prompt. No model weights, tokenizer or backend are involved.
+ */
+
+#include "chat_template.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+/** @brief A throwaway model-package directory holding just a template. */
+class TemplateDir {
+public:
+  explicit TemplateDir(const std::string &jinja, const std::string &name) {
+    path_ = fs::temp_directory_path() / ("nntr_chat_template_test_" + name +
+                                         "_" + std::to_string(::getpid()));
+    fs::create_directories(path_);
+
+    std::ofstream(path_ / "chat_template.jinja") << jinja;
+    std::ofstream(path_ / "tokenizer_config.json")
+      << R"({"bos_token": "<s>", "eos_token": "</s>"})";
+  }
+
+  ~TemplateDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  std::string str() const { return path_.string(); }
+
+private:
+  fs::path path_;
+};
+
+/**
+ * @brief A template that marks turns and reacts to a sibling render key.
+ *
+ * Newline-free on purpose: jinja's whitespace-trimming markers would otherwise
+ * make the expected strings below a puzzle about trimming rather than about the
+ * seam under test.
+ */
+constexpr const char *kTurnTemplate =
+  "{%- for m in messages -%}"
+  "[{{ m['role'] }}:{{ m['content'] }}]"
+  "{%- endfor -%}"
+  "{%- if add_generation_prompt -%}"
+  "[model{% if not (thinking | default(false)) %}:nothink{% endif %}]"
+  "{%- endif -%}";
+
+TEST(ChatTemplateSeam, PackageContextIsReadFromConfig) {
+  EXPECT_TRUE(causallm::chatTemplateContext(nlohmann::json::object()).empty());
+
+  nlohmann::json cfg = {{"chat_template_context", {{"thinking", false}}}};
+  const auto context = causallm::chatTemplateContext(cfg);
+  ASSERT_TRUE(context.is_object());
+  EXPECT_EQ(context.at("thinking"), false);
+
+  // A non-object value is ignored rather than propagated as junk.
+  nlohmann::json bad = {{"chat_template_context", "yes please"}};
+  EXPECT_TRUE(causallm::chatTemplateContext(bad).empty());
+}
+
+TEST(ChatTemplateSeam, UserRequestCarriesContextButOwnsMessages) {
+  const auto request =
+    causallm::makeUserRequest("hello", {{"thinking", true}, {"messages", 42}});
+
+  ASSERT_TRUE(request.contains("messages"));
+  ASSERT_TRUE(request["messages"].is_array());
+  ASSERT_EQ(request["messages"].size(), 1u);
+  EXPECT_EQ(request["messages"][0]["role"], "user");
+  EXPECT_EQ(request["messages"][0]["content"], "hello");
+  // The context supplied a "messages" key; the conversation still wins.
+  EXPECT_EQ(request["thinking"], true);
+}
+
+TEST(ChatTemplateSeam, NoTemplateFeedsThePromptUnchanged) {
+  const std::string prompt = "The capital of France is";
+  EXPECT_EQ(causallm::buildUserPrompt(nullptr, prompt), prompt);
+  EXPECT_TRUE(causallm::buildPrompt(nullptr, nlohmann::json::array()).empty());
+}
+
+TEST(ChatTemplateSeam, OptOutIsByteIdentical) {
+  TemplateDir dir(kTurnTemplate, "optout");
+  ASSERT_TRUE(causallm::ChatTemplate::Exists(dir.str()));
+  auto tmpl = causallm::ChatTemplate::Load(dir.str());
+
+  const std::string pre_templated = "<|turn>user\nalready wrapped<turn|>\n";
+  EXPECT_EQ(causallm::buildUserPrompt(&tmpl, pre_templated,
+                                      causallm::PromptTemplateMode::Never),
+            pre_templated);
+}
+
+TEST(ChatTemplateSeam, TemplateIsAppliedAndIsDeterministic) {
+  TemplateDir dir(kTurnTemplate, "apply");
+  auto tmpl = causallm::ChatTemplate::Load(dir.str());
+
+  const std::string first = causallm::buildUserPrompt(&tmpl, "hi");
+  const std::string second = causallm::buildUserPrompt(&tmpl, "hi");
+  EXPECT_EQ(first, second);
+  EXPECT_EQ(first, "[user:hi][model:nothink]");
+}
+
+TEST(ChatTemplateSeam, PackageContextReachesTheTemplate) {
+  TemplateDir dir(kTurnTemplate, "context");
+  auto tmpl = causallm::ChatTemplate::Load(dir.str());
+
+  // The package asks for the thinking channel: the empty-thought marker goes.
+  const std::string with_context = causallm::buildUserPrompt(
+    &tmpl, "hi", causallm::PromptTemplateMode::Auto, {{"thinking", true}});
+  EXPECT_EQ(with_context, "[user:hi][model]");
+}
+
+TEST(ChatTemplateSeam, RequestKeysWinOverPackageContext) {
+  TemplateDir dir(kTurnTemplate, "override");
+  auto tmpl = causallm::ChatTemplate::Load(dir.str());
+
+  nlohmann::json request = causallm::makeUserRequest("hi");
+  request["thinking"] = false; // explicit request value
+  const std::string rendered =
+    causallm::buildPrompt(&tmpl, request, causallm::PromptTemplateMode::Auto,
+                          {{"thinking", true}}); // package default loses
+  EXPECT_EQ(rendered, "[user:hi][model:nothink]");
+}
+
+TEST(ChatTemplateSeam, BrokenTemplateRaisesInsteadOfGoingRaw) {
+  TemplateDir dir("{%- for m in messages -%}{{ m['role'] }}", "broken");
+
+  // Whether the parse fails at Load or at the first render, the caller learns
+  // about it: what must never happen is a silent fallback to the raw prompt.
+  EXPECT_ANY_THROW({
+    auto tmpl = causallm::ChatTemplate::Load(dir.str());
+    (void)causallm::buildUserPrompt(&tmpl, "hi");
+  });
+}
+
+} // namespace


### PR DESCRIPTION
Both front ends of `Applications/CausalLM` have to turn a user prompt into model input, and each was about to grow its own way of doing it. This adds one prompt-preparation seam next to the existing renderer, points the CLI at it, and pins its contract with a unit test. **No behaviour change** — the CLI's one existing render call site becomes a `buildPrompt()` call, and the literal `argv[2]` prompt path is left byte-for-byte alone.

The consumer that makes this worth having is the SDK path (`Applications/CausalLM/api`), which today cannot template a prompt the way the runner does. That is a separate PR so this one can be reviewed on its own terms; see the bottom of this description.

## The seam

`Applications/CausalLM/chat_template.h` gains four free functions beside `causallm::ChatTemplate` — no new renderer, no second template source:

| symbol | role |
|---|---|
| `enum class PromptTemplateMode { Auto, Never }` | apply-when-available vs feed-raw |
| `chatTemplateContext(nntr_cfg)` | the package's optional `chat_template_context` object from `nntr_config.json` (empty object when absent) |
| `makeUserRequest(user_text, render_context)` | wrap one user turn into a request |
| `buildPrompt(tmpl, request, mode, render_context)` | the single application point: merges the package context *under* the request (request keys win), then calls `ChatTemplate::apply` |
| `buildUserPrompt(tmpl, user_text, mode, render_context)` | single-turn convenience; returns `user_text` unchanged when nothing is applied |

Three design points, each of which cost something to learn:

1. **One renderer, not two.** The seam consumes the in-tree minja machinery (`third_party/minja`) that `ChatTemplate` already wraps. A chat template is a property of the **model package** (`chat_template.jinja`, else `tokenizer_config.chat_template`), never of a table in the code keyed on an architecture string — two packages of the same architecture legitimately carry different templates.
2. **Render failures propagate.** A template that cannot render is reported, never silently downgraded to a raw prompt. An instruction model fed an unmarked prompt drifts, and that failure reads as a model bug rather than a configuration one; it has cost real debugging time.
3. **`buildUserPrompt` is not an overload of `buildPrompt`.** A string literal converts to `nlohmann::json` as readily as to `std::string`, so an overload pair made every `buildPrompt(t, "text")` call site ambiguous. The new unit test caught that before any caller could.

### Why a package-level render context

Some templates branch on a *sibling* render key rather than on the messages. `ChatTemplate::apply` already forwards any extra top-level request key into the renderer, so the plumbing exists; what was missing was an owner for the value. The model package is that owner, via an optional `"chat_template_context"` object in `nntr_config.json`.

Concretely: one in-tree model's template emits `…<|im_start|>assistant\n` and **stops** unless the request carries `enable_thinking: false`, in which case it emits the `<think>\n\n</think>\n\n` form its validated prompt uses (85 B vs 104 B rendered). This is not a renderer defect — the template branches on `enable_thinking` and the upstream default is `True`, which here would open a think block nothing closes. Proven end-to-end that a package-level `"chat_template_context": {"enable_thinking": false}` produces **byte-identical** output to passing the key per call, so it is fixable in package data with no caller code. Flagged for the model-package owners below rather than worked around in code.

## CLI: refactor only

`main.cpp`'s single `chat_template->apply(nntr_cfg["chat_input"])` becomes a `causallm::buildPrompt(...)` call carrying the package context. Everything else about prompt selection is untouched:

- **`argv[2]` still bypasses the template entirely.** Callers that template their own input rely on those bytes arriving verbatim; that path is not touched by this PR.
- the `chat_input` → render → clear system head/tail sequence keeps its exact order and semantics;
- packages with no template keep falling through to `sample_input` raw.

## `unittest_chat_template` — new, 8/8

No model, no tokenizer, no backend: the shared `chat_template.cpp` plus gtest, so it runs anywhere the app builds. It pins package-context plumbing, opt-out byte-identity, request-keys-win precedence, render determinism, and raise-instead-of-raw.

```
[----------] 8 tests from ChatTemplateSeam
[  PASSED  ] 8 tests.
```

## Verification

Beyond the unit test, the seam was exercised through both front ends on four model packages, CPU lane, fp16 — reported in full on the SDK PR because that is where the equivalence claim lives. The two results that belong here:

| gate | result |
|---|---|
| four CLI goldens, baseline binary vs post-change binary, same command | **IDENTICAL 4/4** (160 / 49 / 161 / 145 generated bytes) |
| rendered prompt, cold renderer construction (18 KB jinja) / warm | 180–195 ms / **0.09–0.19 ms** |

The cold construction is a property of the renderer this PR does not change; it is measured here only to justify keeping the render where a model-load window can hide it, which is what the CLI already does and what the SDK PR preserves.

**Lane note:** the gates ran on the CPU lane (fp16). The seam is upstream of every backend — it produces prompt *bytes* before any engine is touched — so a GPU-lane repeat is confirmation, not discovery. This PR does not claim GPU-lane coverage.

## For the model-package owners (data, not code)

Two findings surfaced while rendering the in-tree packages. Both are packaging decisions, deliberately **not** patched in code here:

1. One public package's `chat_template.jinja` is a byte-identical copy of another (internal) package's template. Rendering it emits a thought-channel opening that the package's own validated `sample_input` does not contain, so the model answers in a "thought" style instead of the direct answer its golden records. Template and golden prompt disagree *inside the package*. Both front ends now do the same thing with it — equivalence holds either way — but the package needs either its real template or a `chat_template_context`.
2. The `enable_thinking` case described above.

## Depends-on / relation to other PRs

- No dependency. Applies directly to `main`.
- **Follow-up:** `[causallm/api] Apply the model package's chat template in the SDK path` consumes this seam, deletes the API's hardcoded per-architecture template table, and carries the SDK ≡ CLI byte-identity gate. It also depends on #4115 for the shared model registry.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
