### PR TITLE
[CausalLM] Avoid weight shallow copy

### DIFF
--- a/Applications/CausalLM/layers/lm_head.cpp
+++ b/Applications/CausalLM/layers/lm_head.cpp
@@ -126,7 +126,7 @@ void LmHeadLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   if (skip_prefill && is_prefill)
     return;
 
-  nntrainer::Tensor weight =
+  nntrainer::Tensor &weight =
     context.getWeight(weight_idx[LmHeadParams::weight]);
 
   nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -304,7 +304,7 @@ void TieWordEmbedding::incremental_forwarding_lmhead(
   if (skip_prefill && is_prefill)
     return;
 
-  nntrainer::Tensor weight =
+  nntrainer::Tensor &weight =
     context.getWeight(weight_idx[TieWordEmbeddingParams::weight]);
 
   nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
@@ -476,7 +476,7 @@ void GptOssMoELayer::incremental_forwarding(nntrainer::RunLayerContext &context,
     // routing
     nntrainer::Tensor &gate_weights = context.getWeight(gate_idx);
     input.dot(gate_weights, router_logits);
-    nntrainer::Tensor gate_bias = context.getWeight(gate_bias_idx);
+    nntrainer::Tensor &gate_bias = context.getWeight(gate_bias_idx);
     router_logits.add_i(gate_bias);
 
     router_logits.apply(nntrainer::ActiFunc::softmax<float>, router_logits);


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Avoid weight shallow copy</summary><br />

getWeight() returns a reference, but it was bound to a value, shallow copying
the weight tensor on every incremental forward. Bind it
to a reference instead to avoid the copy.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
Let's remove redundant copy of weight tensor.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>